### PR TITLE
Handle the multipart/form bodies sent from ansible2.9

### DIFF
--- a/galaxy_ng/app/api/v3/viewsets.py
+++ b/galaxy_ng/app/api/v3/viewsets.py
@@ -19,6 +19,7 @@ from galaxy_ng.app.api.ui import serializers
 from galaxy_ng.app.api.v3.serializers import CollectionSerializer, CollectionUploadSerializer
 from galaxy_ng.app.common import pulp
 from galaxy_ng.app.common import metrics
+from galaxy_ng.app.common.parsers import AnsibleGalaxy29MultiPartParser
 from galaxy_ng.app.api import permissions
 from galaxy_ng.app import models
 from galaxy_ng.app import constants
@@ -191,6 +192,8 @@ class CollectionArtifactUploadView(api_base.APIView):
     permission_classes = api_base.GALAXY_PERMISSION_CLASSES + [
         permissions.IsNamespaceOwner
     ]
+
+    parser_classes = [AnsibleGalaxy29MultiPartParser]
 
     def post(self, request, *args, **kwargs):
         metrics.collection_import_attempts.inc()

--- a/galaxy_ng/app/common/parsers.py
+++ b/galaxy_ng/app/common/parsers.py
@@ -1,0 +1,34 @@
+import io
+import logging
+
+from rest_framework.parsers import MultiPartParser
+
+log = logging.getLogger(__name__)
+
+
+class AnsibleGalaxy29MultiPartParser(MultiPartParser):
+    def parse(self, stream, media_type=None, parser_context=None):
+        # Add in a crlf newline if the body is missing it between the Content-Disposition line
+        # and the value
+
+        b_data = stream.read()
+        body_parts = b_data.partition(b'Content-Disposition: form-data; name="sha256"\r\n')
+
+        new_stream = io.BytesIO()
+        new_stream.write(body_parts[0])
+        new_stream.write(body_parts[1])
+
+        if not body_parts[2].startswith(b'\r\n'):
+            log.warning('Malformed multipart body user-agent: %s',
+                        parser_context['request'].META.get('HTTP_USER_AGENT'))
+
+            # add the crlf to the new stream so the base parser does the right thing
+            new_stream.write(b'\r\n')
+
+        new_stream.write(body_parts[2])
+
+        new_stream.seek(0)
+
+        return super(AnsibleGalaxy29MultiPartParser, self).parse(new_stream,
+                                                                 media_type=media_type,
+                                                                 parser_context=parser_context)


### PR DESCRIPTION
(port of fix for galaxy-api)

In ansible-galaxy versions 2.9, the body of the multipart/form
POST'ed as part of the 'publish' command causes the default
django/drf multipart/form parsers to ignore the 'sha256' content.

When the parser ignores it, the sha256 value is None, which
the galaxy-api publish code considers an optional value.
So when the publish / import is passed to pulp api via
galaxy_pulp, the pulp side doesn't check that the artifacts
sha256sum matches the 'sha256' value (since it is None).

This adds a custom parser that subclasses the drf 'MultiPartParser'
but does some pre-processing on the request body stream to
correct it before it is sent to the base MultiPartParser.

Fixes ansible/galaxy-dev#246