### PR TITLE
fix: Malformed content app URL

### DIFF
--- a/dev/automation-hub/galaxy_ng.env
+++ b/dev/automation-hub/galaxy_ng.env
@@ -1,4 +1,3 @@
-PULP_API_PATH_PREFIX=
 PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
 
 PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/

--- a/dev/common/galaxy_ng.env
+++ b/dev/common/galaxy_ng.env
@@ -8,3 +8,5 @@ PULP_DB_NAME=galaxy_ng
 PULP_REDIS_HOST=redis
 
 PULP_CONTENT_ORIGIN="http://localhost:5001"
+
+PULP_X_PULP_CONTENT_HOST=content-app

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -51,6 +51,8 @@ services:
   content-app:
     image: "localhost/${COMPOSE_PROJECT_NAME}/galaxy_ng:latest"
     command: ['run', 'content-app']
+    ports:
+      - "24816:24816"
     env_file:
       - './common/galaxy_ng.env'
       - './automation-hub/galaxy_ng.env'

--- a/galaxy_ng/app/api/v3/viewsets.py
+++ b/galaxy_ng/app/api/v3/viewsets.py
@@ -282,7 +282,7 @@ class CollectionArtifactDownloadView(api_base.APIView):
         url = 'http://{host}:{port}/{prefix}/automation-hub/{filename}'.format(
             host=settings.X_PULP_CONTENT_HOST,
             port=settings.X_PULP_CONTENT_PORT,
-            prefix=settings.X_PULP_CONTENT_PATH_PREFIX.strip('/'),
+            prefix=settings.CONTENT_PATH_PREFIX.strip('/'),
             filename=self.kwargs['filename'],
         )
         response = requests.get(url, stream=True, allow_redirects=False)

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -32,6 +32,5 @@ X_PULP_API_USER = "admin"
 X_PULP_API_PASSWORD = "admin"
 X_PULP_API_PREFIX = "pulp_ansible/galaxy/automation-hub/api"
 
-X_PULP_CONTENT_HOST = "pulp-content"
+X_PULP_CONTENT_HOST = "localhost"
 X_PULP_CONTENT_PORT = 24816
-X_PULP_CONTENT_PATH_PREFIX = f"/{GALAXY_API_PATH_PREFIX}/v3/artifacts/collections/"


### PR DESCRIPTION
* Use CONTENT_PATH_PREFIX setting from pulpcore to
  build content app URL.
* Fix missing X_PULP_CONTENT_HOST setting for development
  environment.