### PR TITLE
Fix openapi so 'sha256' field for is not required.

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -184,7 +184,6 @@ paths:
                   format: binary
               required:
                 - file
-                - sha256
       responses:
         '202':
           $ref: '#/components/responses/CollectionImportAccepted'


### PR DESCRIPTION
Actual implementation of 'POST
/api/automation-hub/artifacts/collections'
doesn't enforce it, so update spec.

Fixes: ansible/galaxy-dev#290