### PR TITLE
Multiple development projects

### DIFF
--- a/compose
+++ b/compose
@@ -3,6 +3,7 @@
 set -o nounset
 set -o errexit
 
+declare -xr DEV_SOURCE_PATH=${DEV_SOURCE_PATH:-galaxy_ng}
 
 declare -xr COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-galaxy_ng}"
 declare -xr COMPOSE_FILE="${COMPOSE_FILE:-dev/docker-compose.yml}"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -10,13 +10,14 @@ services:
     ports:
       - "5001:8000"
     environment:
-      - 'WITH_DEV_INSTALL=1'
+      - "WITH_DEV_INSTALL=1"
+      - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
     env_file:
       - './common/galaxy_ng.env'
       - './automation-hub/galaxy_ng.env'
     volumes:
       - "./common/settings.py:/etc/pulp/settings.py:z"
-      - "${COMPOSE_CONTEXT}:/app:z"
+      - "${COMPOSE_CONTEXT}/..:/src:z"
       - "pulp_artifact:/var/lib/pulp/artifact"
     depends_on:
       - postgres
@@ -26,13 +27,13 @@ services:
     image: "localhost/${COMPOSE_PROJECT_NAME}/galaxy_ng:latest"
     command: ['run', 'resource-manager']
     environment:
-      - 'WITH_DEV_INSTALL=1'
+      - "WITH_DEV_INSTALL=1"
     env_file:
       - './common/galaxy_ng.env'
       - './automation-hub/galaxy_ng.env'
     volumes:
       - "./common/settings.py:/etc/pulp/settings.py:z"
-      - "${COMPOSE_CONTEXT}:/app:z"
+      - "${COMPOSE_CONTEXT}/..:/src:z"
       - "pulp_artifact:/var/lib/pulp/artifact"
     depends_on:
       - postgres
@@ -42,13 +43,13 @@ services:
     image: "localhost/${COMPOSE_PROJECT_NAME}/galaxy_ng:latest"
     command: ['run', 'worker']
     environment:
-      - 'WITH_DEV_INSTALL=1'
+      - "WITH_DEV_INSTALL=1"
     env_file:
       - './common/galaxy_ng.env'
       - './automation-hub/galaxy_ng.env'
     volumes:
       - "./common/settings.py:/etc/pulp/settings.py:z"
-      - "${COMPOSE_CONTEXT}:/app:z"
+      - "${COMPOSE_CONTEXT}/..:/src:z"
       - "pulp_artifact:/var/lib/pulp/artifact"
     depends_on:
       - postgres
@@ -60,13 +61,13 @@ services:
     ports:
       - "24816:24816"
     environment:
-      - 'WITH_DEV_INSTALL=1'
+      - "WITH_DEV_INSTALL=1"
     env_file:
       - './common/galaxy_ng.env'
       - './automation-hub/galaxy_ng.env'
     volumes:
       - "./common/settings.py:/etc/pulp/settings.py:z"
-      - "${COMPOSE_CONTEXT}:/app:z"
+      - "${COMPOSE_CONTEXT}/..:/src:z"
       - "pulp_artifact:/var/lib/pulp/artifact"
     depends_on:
       - postgres

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,9 +4,9 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-
 readonly WITH_MIGRATIONS="${WITH_MIGRATIONS:-0}"
 readonly WITH_DEV_INSTALL="${WITH_DEV_INSTALL:-0}"
+readonly DEV_SOURCE_PATH="${DEV_SOURCE_PATH:-}"
 
 
 log_message() {
@@ -14,8 +14,20 @@ log_message() {
 }
 
 
+# TODO(cutwater): This function should be moved to entrypoint hooks.
 install_local_deps() {
-    pip install --no-cache --no-deps --editable "/app" >/dev/null
+    local src_path_list
+    IFS=':' read -ra src_path_list <<< "$DEV_SOURCE_PATH"
+
+    for item in "${src_path_list[@]}"; do
+        src_path="/src/${item}"
+        if [[ -d "$src_path" ]]; then
+            log_message "Installing path ${item} in editable mode."
+            pip install --no-cache-dir --no-deps --editable "$src_path" >/dev/null
+        else
+            log_message "WARNING: Source path ${item} is not a directory."
+        fi
+    done
 }
 
 


### PR DESCRIPTION
Adds possibility to run project dependencies from local
filesystem in editable mode. This patch changes directory being
mounted to containers from project directory to its parent directory.
    
By setting `DEV_SOURCE_PATH` environment variable it is possible to
include additional projects to be installed in editable mode.
Project directory path is relative to galaxy_ng parent directory and
separated by colon `:`. Default `DEV_SOURCE_PATH=galaxy_ng`
    
Example:
   
    $ export DEV_SOURCE_PATH='galaxy_ng:galaxy-importer'
    $ ./compose up
