### PR TITLE
Fix pulp content url in dev env

### DIFF
--- a/dev/automation-hub/galaxy_ng.env
+++ b/dev/automation-hub/galaxy_ng.env
@@ -4,3 +4,6 @@ PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
 PULP_GALAXY_AUTHENTICATION_CLASSES=['galaxy_ng.app.auth.auth.RHIdentityAuthentication']
 PULP_GALAXY_PERMISSION_CLASSES=['rest_framework.permissions.IsAuthenticated', 'galaxy_ng.app.auth.auth.RHEntitlementRequired']
 PULP_RH_ENTITLEMENT_REQUIRED=insights
+
+PULP_ANSIBLE_API_HOSTNAME=http://localhost:5001
+PULP_ANSIBLE_CONTENT_HOSTNAME=http://localhost:24816/api/automation-hub/v3/artifacts/collections


### PR DESCRIPTION
When following along with https://pulp-ansible.readthedocs.io/en/latest/workflows/collections.html, I hit a few bugs that required these variables to be set.