### PR TITLE
Add a pinned version of galaxy-importer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ galaxy_pulp_requirements = [
 requirements = galaxy_pulp_requirements + [
     "pulpcore>=3.1.1",
     "pulp-ansible>=0.2.0b8",
-    "django-prometheus>=2.0.0"
+    "django-prometheus>=2.0.0",
+    "galaxy-importer==0.2.0",
 ]
-
 
 
 setup(


### PR DESCRIPTION
`galaxy_ng` uses `pulp_ansible` which requires `galaxy-importer` unpinned

This change uses a specific version of `galaxy-importer` for `galaxy_ng`

Supports #64 