### PR TITLE
Increase timeout for migrations

### DIFF
--- a/docker/bin/wait-for-migrations
+++ b/docker/bin/wait-for-migrations
@@ -8,7 +8,7 @@ readonly CMDNAME=$(basename "$0")
 readonly MIN_SLEEP=0.5
 readonly MAX_SLEEP=30
 readonly ATTEMPTS=10
-readonly TIMEOUT=10
+readonly TIMEOUT=60
 
 log_message() { echo "[${CMDNAME}]" "$@" >&2; }
 log_error() { echo "[${CMDNAME}] ERROR:" "$@" >&2; }


### PR DESCRIPTION
Increase timeout in `wait-for-migrations` script from 10 to 60 seconds
to prevent possible failure doe to timeout on low CPU limits.