### PR TITLE
Configure prometheus metrics for django app

### DIFF
--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -1,3 +1,18 @@
+MIDDLEWARE = [
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
+    # BEGIN: Pulp standard middleware
+    'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # END: Pulp standard middleware
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
+]
+
 
 AUTH_USER_MODEL = 'galaxy.User'
 

--- a/galaxy_ng/app/urls.py
+++ b/galaxy_ng/app/urls.py
@@ -8,4 +8,5 @@ API_PATH_PREFIX = settings.GALAXY_API_PATH_PREFIX.strip('/')
 app_name = "galaxy"
 urlpatterns = [
     path(f"{API_PATH_PREFIX}/", include(api_urls)),
+    path('', include('django_prometheus.urls')),
 ]


### PR DESCRIPTION
* Enable django_prometheus middlewares.
* Add `/metrics` URL.

Issue: #10 