### PR TITLE
build: Add parameter to start-api container script

### DIFF
--- a/docker/bin/start-api
+++ b/docker/bin/start-api
@@ -5,15 +5,22 @@ set -o nounset
 
 
 readonly GUNICORN='/venv/bin/gunicorn'
-readonly GUNICORN_WORKERS=${GUNICORN_WORKERS:-4}
+readonly GUNICORN_FORWARDED_ALLOW_IPS="${GUNICORN_FORWARDED_ALLOW_IPS:-}"
+readonly GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
 
 readonly BIND_HOST='0.0.0.0'
 readonly BIND_PORT=${GUNICORN_PORT:-8000}
 readonly APP_MODULE='pulpcore.app.wsgi:application'
 
 
-exec "${GUNICORN}" \
-  --bind "${BIND_HOST}:${BIND_PORT}" \
-  --workers "${GUNICORN_WORKERS}" \
-  --access-logfile - \
-  "${APP_MODULE}"
+GUNICORN_OPTIONS=(
+  --bind "${BIND_HOST}:${BIND_PORT}"
+  --workers "${GUNICORN_WORKERS}"
+  --access-logfile -
+)
+
+if [[ -n "$GUNICORN_FORWARDED_ALLOW_IPS" ]]; then
+    GUNICORN_OPTIONS+=(--forwarded-allow-ips "${GUNICORN_FORWARDED_ALLOW_IPS}")
+fi
+
+exec "${GUNICORN}" "${GUNICORN_OPTIONS[@]}" "${APP_MODULE}"

--- a/docker/bin/start-api
+++ b/docker/bin/start-api
@@ -19,7 +19,7 @@ GUNICORN_OPTIONS=(
   --access-logfile -
 )
 
-if [[ -n "$GUNICORN_FORWARDED_ALLOW_IPS" ]]; then
+if [[ -n "${GUNICORN_FORWARDED_ALLOW_IPS}" ]]; then
     GUNICORN_OPTIONS+=(--forwarded-allow-ips "${GUNICORN_FORWARDED_ALLOW_IPS}")
 fi
 


### PR DESCRIPTION
Add `GUNICORN_FORWARDED_ALLOW_IPS` parameter to `docker/bin/start-api`
script to add configurable option `--forwarded-allow-ips` for gunicorn.

By default gunicorn strips all `X-Forwarded-*` headers unless this
options is specified. It is useful whenever gunicorn is run
behind a reverse proxy not on the same host.
This is typical for OpenShift deployment environment.