### PR TITLE
Fix dependency resolution when installing project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ galaxy_pulp_requirements = [
 ]
 
 requirements = galaxy_pulp_requirements + [
+    "Django~=2.2.3",
     "pulpcore>=3.1.1",
     "pulp-ansible>=0.2.0b8",
     "django-prometheus>=2.0.0",


### PR DESCRIPTION
Change introduced in #78 causes failure during installation
due to insonsistent dependency resolution. Adding explicit
django dependency with a version restriction.