### PR TITLE
Use pulp viewsets for 'v3' and add per repo/distro v3 style endpoints

### DIFF
--- a/galaxy_ng/app/api/urls.py
+++ b/galaxy_ng/app/api/urls.py
@@ -38,19 +38,26 @@ content_urlpatterns = [
          include((content_v3_urlpatterns, app_name), namespace="v3")),
 
     path("content/<str:path>/",
-         v3_viewsets.ApiRootView.as_view()),
+         views.ApiRootView.as_view(),
+         name="root"),
 
     # This can be removed when ansible-galaxy stops appending '/api' to the
     # urls.
     path("content/<str:path>/api/",
-         v3_viewsets.SlashApiRedirectPerDistroView.as_view(),
-         name="api-redirect"),
+         views.ApiRedirectView.as_view(),
+         name="api-redirect",
+         kwargs={"reverse_url_name": "galaxy:api:content:root"}),
 ]
 
 urlpatterns = [
     path("v3/", include((v3_urlpatterns, app_name), namespace="v3")),
 
     path("", include((content_urlpatterns, app_name), namespace='content')),
+
+    path("",
+         views.ApiRootView.as_view(),
+         name="root",
+         ),
 
     # This path is to redirect requests to /api/automation-hub/api/
     # to /api/automation-hub/
@@ -60,14 +67,10 @@ urlpatterns = [
     # galaxy server urls to try to find the API root. So add a redirect from
     # "/api" to actual API root at "/".
 
-    path("",
-         views.ApiRootView.as_view(),
-         name="root"
-         ),
-
     # This can be removed when ansible-galaxy stops appending '/api' to the
     # urls.
     path("api/",
-         views.SlashApiRedirectView.as_view(),
-         name="api-redirect"),
+         views.ApiRedirectView.as_view(),
+         name="api-redirect",
+         kwargs={"reverse_url_name": "galaxy:api:root"}),
 ]

--- a/galaxy_ng/app/api/urls.py
+++ b/galaxy_ng/app/api/urls.py
@@ -9,24 +9,9 @@ from .v3 import viewsets as v3_viewsets
 DEFAULT_DISTRIBUTION_BASE_PATH = settings.GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH.strip('/')
 
 app_name = "api"
-urlpatterns = [
-    path("v3/_ui/", include(ui_urls)),
 
-    # A set of galaxy v3 API urls per Distribution.base_path
-    # which is essentially per Repository
-    path("content/<str:path>/v3/",
-         include(v3_urls, namespace='content')),
-
-    path("content/<str:path>/",
-         v3_viewsets.ApiRootView.as_view(),
-         name="content"),
-
-    # This can be removed when ansible-galaxy stops appending '/api' to the
-    # urls.
-    path("content/<str:path>/api/",
-         v3_viewsets.SlashApiRedirectPerDistroView.as_view(),
-         name="content-redirect"),
-
+v3_urlpatterns = [
+    path("_ui/", include(ui_urls)),
 
     # Set an instance of the v3 urls/viewsets at the same
     # url path as the former galaxy_api.api.v3.viewsets
@@ -34,9 +19,38 @@ urlpatterns = [
     # and pass in path param 'path' that actually means
     # the base_path of the Distribution. For the default case,
     # use the hard coded 'default' distro (ie, 'automation-hub')
-    path("v3/",
-         include(v3_urls, namespace='default-content'),
+    path("",
+         # include((v3_urls, app_name), namespace='default-content'),
+         include((v3_urls, app_name), namespace='default-content'),
          {'path': DEFAULT_DISTRIBUTION_BASE_PATH}),
+]
+
+content_v3_urlpatterns = [
+    # A set of galaxy v3 API urls per Distribution.base_path
+    # which is essentially per Repository
+    path("<str:path>/v3/",
+         # include((v3_urls, app_name))),
+         include(v3_urls)),
+]
+
+content_urlpatterns = [
+    path("content/",
+         include((content_v3_urlpatterns, app_name), namespace="v3")),
+
+    path("content/<str:path>/",
+         v3_viewsets.ApiRootView.as_view()),
+
+    # This can be removed when ansible-galaxy stops appending '/api' to the
+    # urls.
+    path("content/<str:path>/api/",
+         v3_viewsets.SlashApiRedirectPerDistroView.as_view(),
+         name="api-redirect"),
+]
+
+urlpatterns = [
+    path("v3/", include((v3_urlpatterns, app_name), namespace="v3")),
+
+    path("", include((content_urlpatterns, app_name), namespace='content')),
 
     # This path is to redirect requests to /api/automation-hub/api/
     # to /api/automation-hub/

--- a/galaxy_ng/app/api/urls.py
+++ b/galaxy_ng/app/api/urls.py
@@ -3,13 +3,37 @@ from django.urls import include, path
 from . import views
 from .ui import urls as ui_urls
 from .v3 import urls as v3_urls
-
+from .v3 import viewsets as v3_viewsets
 
 app_name = "api"
 urlpatterns = [
-    path("", views.ApiRootView.as_view(), name="root"),
-    path("v3/", include(v3_urls)),
     path("v3/_ui/", include(ui_urls)),
+
+    # A set of galaxy v3 API urls per Distribution.base_path
+    # which is essentially per Repository
+    path("content/<str:path>/v3/",
+         include(v3_urls, namespace='per_distribution')),
+
+    path("content/<str:path>/",
+         v3_viewsets.ApiRootView.as_view(),
+         name="root-per-distro"),
+
+    # This can be removed when ansible-galaxy stops appending '/api' to the
+    # urls.
+    path("content/<str:path>/api/",
+         v3_viewsets.SlashApiRedirectPerDistroView.as_view(),
+         name="api-redirect"),
+
+
+    # Set an instance of the v3 urls/viewsets at the same
+    # url path as the former galaxy_api.api.v3.viewsets
+    # ie (/api/automation-hub/v3/collections etc
+    # and pass in path param 'path' that actually means
+    # the base_path of the Distribution. For the default case,
+    # use the hard coded 'default' distro (ie, 'automation-hub')
+    path("v3/",
+         include(v3_urls, namespace='default_distribution'),
+         {'path': 'golden-distro-base-path'}),
 
     # This path is to redirect requests to /api/automation-hub/api/
     # to /api/automation-hub/
@@ -19,7 +43,13 @@ urlpatterns = [
     # galaxy server urls to try to find the API root. So add a redirect from
     # "/api" to actual API root at "/".
 
+    path("",
+         views.ApiRootView.as_view(),
+         name="root-api"),
+
     # This can be removed when ansible-galaxy stops appending '/api' to the
     # urls.
-    path("api/", views.SlashApiRedirectView.as_view()),
+    path("api/",
+         views.SlashApiRedirectView.as_view(),
+         name="api-redirect"),
 ]

--- a/galaxy_ng/app/api/urls.py
+++ b/galaxy_ng/app/api/urls.py
@@ -1,9 +1,12 @@
+from django.conf import settings
 from django.urls import include, path
 
 from . import views
 from .ui import urls as ui_urls
 from .v3 import urls as v3_urls
 from .v3 import viewsets as v3_viewsets
+
+DEFAULT_DISTRIBUTION_BASE_PATH = settings.GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH.strip('/')
 
 app_name = "api"
 urlpatterns = [
@@ -33,7 +36,7 @@ urlpatterns = [
     # use the hard coded 'default' distro (ie, 'automation-hub')
     path("v3/",
          include(v3_urls, namespace='default_distribution'),
-         {'path': 'golden-distro-base-path'}),
+         {'path': DEFAULT_DISTRIBUTION_BASE_PATH}),
 
     # This path is to redirect requests to /api/automation-hub/api/
     # to /api/automation-hub/

--- a/galaxy_ng/app/api/urls.py
+++ b/galaxy_ng/app/api/urls.py
@@ -15,17 +15,17 @@ urlpatterns = [
     # A set of galaxy v3 API urls per Distribution.base_path
     # which is essentially per Repository
     path("content/<str:path>/v3/",
-         include(v3_urls, namespace='per-distribution')),
+         include(v3_urls, namespace='content')),
 
     path("content/<str:path>/",
          v3_viewsets.ApiRootView.as_view(),
-         name="root-per-distro"),
+         name="content"),
 
     # This can be removed when ansible-galaxy stops appending '/api' to the
     # urls.
     path("content/<str:path>/api/",
          v3_viewsets.SlashApiRedirectPerDistroView.as_view(),
-         name="api-redirect"),
+         name="content-redirect"),
 
 
     # Set an instance of the v3 urls/viewsets at the same
@@ -35,7 +35,7 @@ urlpatterns = [
     # the base_path of the Distribution. For the default case,
     # use the hard coded 'default' distro (ie, 'automation-hub')
     path("v3/",
-         include(v3_urls, namespace='default-distribution'),
+         include(v3_urls, namespace='default-content'),
          {'path': DEFAULT_DISTRIBUTION_BASE_PATH}),
 
     # This path is to redirect requests to /api/automation-hub/api/
@@ -48,7 +48,8 @@ urlpatterns = [
 
     path("",
          views.ApiRootView.as_view(),
-         name="root-api"),
+         name="root"
+         ),
 
     # This can be removed when ansible-galaxy stops appending '/api' to the
     # urls.

--- a/galaxy_ng/app/api/urls.py
+++ b/galaxy_ng/app/api/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
     # A set of galaxy v3 API urls per Distribution.base_path
     # which is essentially per Repository
     path("content/<str:path>/v3/",
-         include(v3_urls, namespace='per_distribution')),
+         include(v3_urls, namespace='per-distribution')),
 
     path("content/<str:path>/",
          v3_viewsets.ApiRootView.as_view(),
@@ -35,7 +35,7 @@ urlpatterns = [
     # the base_path of the Distribution. For the default case,
     # use the hard coded 'default' distro (ie, 'automation-hub')
     path("v3/",
-         include(v3_urls, namespace='default_distribution'),
+         include(v3_urls, namespace='default-distribution'),
          {'path': DEFAULT_DISTRIBUTION_BASE_PATH}),
 
     # This path is to redirect requests to /api/automation-hub/api/

--- a/galaxy_ng/app/api/v3/serializers.py
+++ b/galaxy_ng/app/api/v3/serializers.py
@@ -1,6 +1,13 @@
 import logging
+import mimetypes
 
 from django.conf import settings
+
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError, _get_error_details
+
+from galaxy_ng.app.api.ui.serializers.base import Serializer
+from galaxy_ng.app.api.utils import parse_collection_filename
 
 from pulp_ansible.app.galaxy.v3.serializers import (
     CollectionVersionSerializer as _CollectionVersionSerializer
@@ -23,3 +30,35 @@ class CollectionVersionSerializer(_CollectionVersionSerializer):
         download_url = f"{host}/{prefix}/{distro_base_path}/{filename_path}"
 
         return download_url
+
+
+class CollectionUploadSerializer(Serializer):
+    """
+    A serializer for the Collection One Shot Upload API.
+    """
+
+    file = serializers.FileField(required=True)
+
+    sha256 = serializers.CharField(required=False, default=None)
+
+    def to_internal_value(self, data):
+        """Parse and validate collection filename."""
+        data = super().to_internal_value(data)
+
+        errors = {}
+
+        filename = data["file"].name
+
+        try:
+            filename_tuple = parse_collection_filename(filename)
+        except ValueError as exc:
+            errors['filename'] = _get_error_details(exc)
+            log.error('CollectionUploadSerializer validation of filename failed: %s',
+                      errors['filename'])
+            raise ValidationError(errors)
+
+        data.update({
+            "filename": filename_tuple,
+            "mimetype": (mimetypes.guess_type(filename)[0] or 'application/octet-stream')
+        })
+        return data

--- a/galaxy_ng/app/api/v3/serializers.py
+++ b/galaxy_ng/app/api/v3/serializers.py
@@ -1,48 +1,23 @@
 import logging
-import mimetypes
 
-from rest_framework import serializers
-from rest_framework.exceptions import ValidationError, _get_error_details
+from django.conf import settings
 
-from galaxy_ng.app.api.ui.serializers.base import Serializer
-from galaxy_ng.app.api.utils import parse_collection_filename
+from pulp_ansible.app.galaxy.v3.serializers import CollectionVersionSerializer
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
-class CollectionSerializer(Serializer):
-    name = serializers.CharField(required=True)
-    namespace = serializers.CharField(required=True)
-    deprecated = serializers.BooleanField(required=False)
+class GalaxyNGCollectionVersionSerializer(CollectionVersionSerializer):
+    def get_download_url(self, obj):
+        """
+        Get artifact download URL.
+        """
 
+        host = settings.CONTENT_ORIGIN.strip("/")
+        prefix = settings.CONTENT_PATH_PREFIX.strip("/")
+        distro_base_path = self.context["path"]
+        filename_path = self.context["content_artifact"].relative_path.lstrip("/")
 
-class CollectionUploadSerializer(Serializer):
-    """
-    A serializer for the Collection One Shot Upload API.
-    """
+        download_url = f"{host}/{prefix}/{distro_base_path}/{filename_path}"
 
-    file = serializers.FileField(required=True)
-
-    sha256 = serializers.CharField(required=False, default=None)
-
-    def to_internal_value(self, data):
-        """Parse and validate collection filename."""
-        data = super().to_internal_value(data)
-
-        errors = {}
-
-        filename = data["file"].name
-
-        try:
-            filename_tuple = parse_collection_filename(filename)
-        except ValueError as exc:
-            errors['filename'] = _get_error_details(exc)
-            logger.error('CollectionUploadSerializer validation of filename failed: %s',
-                         errors['filename'])
-            raise ValidationError(errors)
-
-        data.update({
-            "filename": filename_tuple,
-            "mimetype": (mimetypes.guess_type(filename)[0] or 'application/octet-stream')
-        })
-        return data
+        return download_url

--- a/galaxy_ng/app/api/v3/serializers.py
+++ b/galaxy_ng/app/api/v3/serializers.py
@@ -2,12 +2,14 @@ import logging
 
 from django.conf import settings
 
-from pulp_ansible.app.galaxy.v3.serializers import CollectionVersionSerializer
+from pulp_ansible.app.galaxy.v3.serializers import (
+    CollectionVersionSerializer as _CollectionVersionSerializer
+)
 
 log = logging.getLogger(__name__)
 
 
-class GalaxyNGCollectionVersionSerializer(CollectionVersionSerializer):
+class CollectionVersionSerializer(_CollectionVersionSerializer):
     def get_download_url(self, obj):
         """
         Get artifact download URL.

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from . import viewsets
 
-# app_name = "v3"
 urlpatterns = [
     path(
         'collections/',
@@ -33,10 +32,5 @@ urlpatterns = [
         'artifacts/collections/',
         viewsets.CollectionUploadViewSet.as_view({'post': 'create'}),
         name='collection-artifact-upload'
-    ),
-    path(
-        '',
-        viewsets.ApiRootView.as_view(),
-        # name='root-v3',
     ),
 ]

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -1,9 +1,7 @@
-"""API v3 URLs Configuration."""
 
 from django.urls import path
 
 from . import viewsets
-
 
 app_name = "v3"
 urlpatterns = [
@@ -34,12 +32,12 @@ urlpatterns = [
     ),
     path(
         'artifacts/collections/',
-        viewsets.CollectionArtifactUploadView.as_view(),
+        viewsets.CollectionUploadViewSet.as_view({'post': 'create'}),
         name='collection-artifact-upload'
     ),
     path(
-        'artifacts/collections/<str:filename>',
-        viewsets.CollectionArtifactDownloadView.as_view(),
-        name='collection-artifact-download'
+        '',
+        viewsets.ApiRootView.as_view(),
+        name='root-v3',
     ),
 ]

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -38,6 +38,6 @@ urlpatterns = [
     path(
         '',
         viewsets.ApiRootView.as_view(),
-        name='root-v3',
+        # name='root-v3',
     ),
 ]

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -1,9 +1,8 @@
-
 from django.urls import path
 
 from . import viewsets
 
-app_name = "v3"
+# app_name = "v3"
 urlpatterns = [
     path(
         'collections/',

--- a/galaxy_ng/app/api/v3/viewsets.py
+++ b/galaxy_ng/app/api/v3/viewsets.py
@@ -52,22 +52,3 @@ class CollectionImportViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionI
 
 class CollectionUploadViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionUploadViewSet):
     pass
-
-
-class ApiRootView(APIView):
-    def get(self, request, *args, **kwargs):
-        data = {
-            "location": "v3",
-            "viewset": self.__class__.__name__,
-            "distro_base_path": kwargs.get('path'),
-            "available_versions": {"v3": "v3/"},
-        }
-
-        return Response(data)
-
-
-class SlashApiRedirectPerDistroView(APIView):
-    reverse_url = 'galaxy:api:content'
-
-    def get(self, request, *args, **kwargs):
-        return HttpResponseRedirect(reverse(self.reverse_url), status=307)

--- a/galaxy_ng/app/api/v3/viewsets.py
+++ b/galaxy_ng/app/api/v3/viewsets.py
@@ -10,7 +10,7 @@ from pulpcore.plugin.models import ContentArtifact
 from pulp_ansible.app.galaxy.v3 import views as pulp_ansible_views
 
 from galaxy_ng.app.api.base import LocalSettingsMixin, APIView
-from .serializers import GalaxyNGCollectionVersionSerializer
+from .serializers import CollectionVersionSerializer
 # from galaxy_ng.app.common import metrics
 
 # hmm, not sure what to do with this
@@ -27,7 +27,8 @@ class CollectionViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionViewSet
 class CollectionVersionViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionVersionViewSet):
     serializer_class = CollectionVersionSerializer
 
-    # Custom retrive so we can use the class serializer_class GalaxyNGCollectionVersionSerializer
+    # Custom retrive so we can use the class serializer_class
+    # galaxy_ng.app.api.v3.serializers.CollectionVersionSerializer
     # which is responsible for building the 'download_url'. The default pulp one doesn't
     # include the distro base_path which we need (https://pulp.plan.io/issues/6510)
     # so override this so we can use a different serializer

--- a/galaxy_ng/app/api/v3/viewsets.py
+++ b/galaxy_ng/app/api/v3/viewsets.py
@@ -1,310 +1,72 @@
-import json
 import logging
-from urllib import parse as urlparse
 
-from django.conf import settings
-from django.core.exceptions import ValidationError
-from django.http import StreamingHttpResponse, HttpResponseRedirect
 from django.urls import reverse
 
-from rest_framework.exceptions import APIException, NotFound
-from rest_framework.generics import get_object_or_404
+from django.http import HttpResponseRedirect
+
 from rest_framework.response import Response
 
-import galaxy_pulp
-import requests
+from pulpcore.plugin.models import ContentArtifact
+from pulp_ansible.app.galaxy.v3 import views as pulp_ansible_views
 
-from galaxy_ng.app.api import base as api_base
-from galaxy_ng.app.api.ui import serializers
-from galaxy_ng.app.api.v3.serializers import CollectionSerializer, CollectionUploadSerializer
-from galaxy_ng.app.common import pulp
-from galaxy_ng.app.common import metrics
-from galaxy_ng.app.common.parsers import AnsibleGalaxy29MultiPartParser
-from galaxy_ng.app.api import permissions
-from galaxy_ng.app import models
-from galaxy_ng.app import constants
+from galaxy_ng.app.api.base import LocalSettingsMixin, APIView
+from .serializers import GalaxyNGCollectionVersionSerializer
+# from galaxy_ng.app.common import metrics
+
+# hmm, not sure what to do with this
+# from galaxy_ng.app.common.parsers import AnsibleGalaxy29MultiPartParser
 
 
 log = logging.getLogger(__name__)
 
 
-class CollectionViewSet(api_base.GenericViewSet):
-    permission_classes = api_base.GALAXY_PERMISSION_CLASSES + [
-        permissions.IsNamespaceOwnerOrPartnerEngineer,
-    ]
-    serializer_class = CollectionSerializer
+class CollectionViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionViewSet):
+    pass
 
-    def list(self, request, *args, **kwargs):
-        self.paginator.init_from_request(request)
 
-        params = self.request.query_params.dict()
-        params.update({
-            'offset': self.paginator.offset,
-            'limit': self.paginator.limit,
-        })
+class CollectionVersionViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionVersionViewSet):
+    serializer_class = GalaxyNGCollectionVersionSerializer
 
-        api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
-        response = api.list(prefix=settings.X_PULP_API_PREFIX, **params)
-        data = list(map(self._fix_item_urls, response.results))
-        return self.paginator.paginate_proxy_response(data, response.count)
-
+    # Custom retrive so we can use the class serializer_class GalaxyNGCollectionVersionSerializer
+    # which is responsible for building the 'download_url'. The default pulp one doesn't
+    # include the distro base_path which we need (https://pulp.plan.io/issues/6510)
+    # so override this so we can use a different serializer
     def retrieve(self, request, *args, **kwargs):
-        api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
+        """
+        Returns a CollectionVersion object.
+        """
+        instance = self.get_object()
+        artifact = ContentArtifact.objects.get(content=instance)
 
-        response = api.get(
-            prefix=settings.X_PULP_API_PREFIX,
-            namespace=self.kwargs['namespace'],
-            name=self.kwargs['name']
-        )
-        response = self._fix_item_urls(response)
+        context = self.get_serializer_context()
+        context["content_artifact"] = artifact
 
-        return Response(response)
-
-    def update(self, request, *args, **kwargs):
-        namespace = self.kwargs['namespace']
-        name = self.kwargs['name']
-
-        namespace_obj = get_object_or_404(models.Namespace, name=namespace)
-        self.check_object_permissions(self.request, namespace_obj)
-
-        serializer = CollectionSerializer(data=request.data, context={'request': request})
-        serializer.is_valid(raise_exception=True)
-        data = serializer.validated_data
-
-        collection = galaxy_pulp.models.Collection(deprecated=data.get('deprecated', False))
-
-        api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
-
-        response = api.put(
-            prefix=settings.X_PULP_API_PREFIX,
-            namespace=namespace,
-            name=name,
-            collection=collection,
-        )
-
-        return Response(response.to_dict())
-
-    @staticmethod
-    def _fix_item_urls(data):
-        namespace = data['namespace']
-        name = data['name']
-        highest_version = data['highest_version']['version']
-
-        data['href'] = reverse(
-            'galaxy:api:v3:collection',
-            kwargs=dict(namespace=namespace, name=name)
-        )
-        data['versions_url'] = reverse(
-            'galaxy:api:v3:collection-version-list',
-            kwargs=dict(namespace=namespace, name=name)
-        )
-        data['highest_version']['href'] = reverse(
-            'galaxy:api:v3:collection-version',
-            kwargs=dict(namespace=namespace, name=name, version=highest_version)
-        )
-        return data
+        serializer = self.get_serializer_class()(instance, context=context)
+        return Response(serializer.data)
 
 
-class CollectionVersionViewSet(api_base.GenericViewSet):
-    serializer_class = serializers.CollectionVersionSerializer
-
-    def list(self, request, *args, **kwargs):
-        self.paginator.init_from_request(request)
-
-        params = self.request.query_params.dict()
-        params.update({
-            'offset': self.paginator.offset,
-            'limit': self.paginator.limit,
-            'certification': constants.CertificationStatus.CERTIFIED.value
-        })
-
-        api = galaxy_pulp.GalaxyCollectionVersionsApi(pulp.get_client())
-        response = api.list(
-            prefix=settings.X_PULP_API_PREFIX,
-            namespace=self.kwargs['namespace'],
-            name=self.kwargs['name'],
-            **params,
-        )
-
-        # Consider an empty list of versions as a 404 on the Collection
-        if not response.results:
-            raise NotFound()
-
-        self._fix_list_urls(response.results)
-        return self.paginator.paginate_proxy_response(response.results, response.count)
-
-    def retrieve(self, request, *args, **kwargs):
-        api = galaxy_pulp.GalaxyCollectionVersionsApi(pulp.get_client())
-        response = api.get(
-            prefix=settings.X_PULP_API_PREFIX,
-            namespace=self.kwargs['namespace'],
-            name=self.kwargs['name'],
-            version=self.kwargs['version'],
-        )
-        self._fix_retrieve_url(response)
-        response['download_url'] = self._transform_pulp_url(request, response['download_url'])
-        return Response(response)
-
-    @staticmethod
-    def _transform_pulp_url(request, pulp_url):
-        """Translate URL returned by Pulp."""
-        urlparts = urlparse.urlsplit(pulp_url)
-        # Build relative URL by stripping scheme and netloc
-        relative_url = urlparse.urlunsplit(('', '') + urlparts[2:])
-        return request.build_absolute_uri(relative_url)
-
-    def _fix_list_urls(self, data):
-        namespace = self.kwargs['namespace']
-        name = self.kwargs['name']
-
-        for item in data:
-            version = item['version']
-            item['href'] = reverse(
-                'galaxy:api:v3:collection-version',
-                kwargs=dict(namespace=namespace, name=name, version=version)
-            )
-
-    def _fix_retrieve_url(self, data):
-        namespace = self.kwargs['namespace']
-        name = self.kwargs['name']
-        version = self.kwargs['version']
-
-        data['href'] = reverse(
-            'galaxy:api:v3:collection-version',
-            kwargs=dict(namespace=namespace, name=name, version=version)
-        )
-        data['collection']['href'] = reverse(
-            'galaxy:api:v3:collection',
-            kwargs=dict(namespace=namespace, name=name)
-        )
+class CollectionImportViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionImportViewSet):
+    pass
 
 
-class CollectionImportViewSet(api_base.ViewSet):
-
-    def retrieve(self, request, pk):
-        api = galaxy_pulp.GalaxyImportsApi(pulp.get_client())
-        response = api.get(prefix=settings.X_PULP_API_PREFIX, id=pk)
-        return Response(response.to_dict())
+class CollectionUploadViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionUploadViewSet):
+    pass
 
 
-class CollectionArtifactUploadView(api_base.APIView):
-
-    permission_classes = api_base.GALAXY_PERMISSION_CLASSES + [
-        permissions.IsNamespaceOwner
-    ]
-
-    parser_classes = [AnsibleGalaxy29MultiPartParser]
-
-    def post(self, request, *args, **kwargs):
-        metrics.collection_import_attempts.inc()
-        serializer = CollectionUploadSerializer(data=request.data, context={'request': request})
-        serializer.is_valid(raise_exception=True)
-
-        data = serializer.validated_data
-        filename = data['filename']
-
-        try:
-            namespace = models.Namespace.objects.get(name=filename.namespace)
-        except models.Namespace.DoesNotExist:
-            raise ValidationError(
-                'Namespace "{0}" does not exist.'.format(filename.namespace)
-            )
-
-        self.check_object_permissions(request, namespace)
-        api = pulp.get_client()
-        url = '{host}/{prefix}/{path}'.format(
-            host=api.configuration.host,
-            path='v3/artifacts/collections/',
-            prefix=settings.X_PULP_API_PREFIX
-        )
-        headers = {}
-        headers.update(api.default_headers)
-        headers.update({'Content-Type': 'multipart/form-data'})
-
-        api.update_params_for_auth(headers, tuple(), api.configuration.auth_settings())
-
-        post_params = self._prepare_post_params(data)
-        try:
-            upload_response = api.request(
-                'POST',
-                url,
-                headers=headers,
-                post_params=post_params,
-            )
-        except galaxy_pulp.ApiException:
-            log.exception('Failed to publish artifact %s (namespace=%s, sha256=%s) to pulp at url=%s',  # noqa
-                          data['file'].name, namespace, data.get('sha256'), url)
-            raise
-
-        upload_response_data = json.loads(upload_response.data)
-
-        task_detail = api.call_api(
-            upload_response_data['task'],
-            'GET',
-            auth_settings=['BasicAuth'],
-            response_type='CollectionImport',
-            _return_http_data_only=True,
-        )
-
-        log.info('Publishing of artifact %s to namespace=%s by user=%s created pulp import task_id=%s', # noqa
-                 data['file'].name, namespace, request.user, task_detail.id)
-
-        import_obj = models.CollectionImport.objects.create(
-            task_id=task_detail.id,
-            created_at=task_detail.created_at,
-            namespace=namespace,
-            name=data['filename'].name,
-            version=data['filename'].version,
-        )
-
-        metrics.collection_import_successes.inc()
-        return Response(
-            data={'task': import_obj.get_absolute_url()},
-            status=upload_response.status
-        )
-
-    @staticmethod
-    def _prepare_post_params(data):
-        filename = data['filename']
-        post_params = [
-            ('file', (data['file'].name, data['file'].read(), data['mimetype'])),
-            ('expected_namespace', filename.namespace),
-            ('expected_name', filename.name),
-            ('expected_version', filename.version),
-        ]
-        if data['sha256']:
-            post_params.append(('sha256', data['sha256']))
-        return post_params
-
-
-class CollectionArtifactDownloadView(api_base.APIView):
+class ApiRootView(APIView):
     def get(self, request, *args, **kwargs):
-        metrics.collection_artifact_download_attempts.inc()
+        data = {
+            "location": "v3",
+            "viewset": self.__class__.__name__,
+            "distro_base_path": kwargs.get('path'),
+            "available_versions": {"v3": "v3/"},
+        }
 
-        # NOTE(cutwater): Using urllib3 because it's already a dependency of galaxy_ng
-        url = 'http://{host}:{port}/{prefix}/automation-hub/{filename}'.format(
-            host=settings.X_PULP_CONTENT_HOST,
-            port=settings.X_PULP_CONTENT_PORT,
-            prefix=settings.CONTENT_PATH_PREFIX.strip('/'),
-            filename=self.kwargs['filename'],
-        )
-        response = requests.get(url, stream=True, allow_redirects=False)
+        return Response(data)
 
-        if response.status_code == requests.codes.not_found:
-            metrics.collection_artifact_download_failures.labels(status=requests.codes.not_found).inc() # noqa
-            raise NotFound()
 
-        if response.status_code == requests.codes.found:
-            return HttpResponseRedirect(response.headers['Location'])
+class SlashApiRedirectPerDistroView(APIView):
+    reverse_url = 'galaxy:api:root-per-distro'
 
-        if response.status_code == requests.codes.ok:
-            metrics.collection_artifact_download_successes.inc()
-
-            return StreamingHttpResponse(
-                response.iter_content(chunk_size=4096),
-                content_type=response.headers['Content-Type']
-            )
-
-        metrics.collection_artifact_download_failures.labels(status=response.status_code).inc()
-        raise APIException('Unexpected response from content app. '
-                           f'Code: {response.status_code}.')
+    def get(self, request, *args, **kwargs):
+        return HttpResponseRedirect(reverse(self.reverse_url), status=307)

--- a/galaxy_ng/app/api/v3/viewsets.py
+++ b/galaxy_ng/app/api/v3/viewsets.py
@@ -67,7 +67,7 @@ class ApiRootView(APIView):
 
 
 class SlashApiRedirectPerDistroView(APIView):
-    reverse_url = 'galaxy:api:root-per-distro'
+    reverse_url = 'galaxy:api:content'
 
     def get(self, request, *args, **kwargs):
         return HttpResponseRedirect(reverse(self.reverse_url), status=307)

--- a/galaxy_ng/app/api/v3/viewsets.py
+++ b/galaxy_ng/app/api/v3/viewsets.py
@@ -25,7 +25,7 @@ class CollectionViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionViewSet
 
 
 class CollectionVersionViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionVersionViewSet):
-    serializer_class = GalaxyNGCollectionVersionSerializer
+    serializer_class = CollectionVersionSerializer
 
     # Custom retrive so we can use the class serializer_class GalaxyNGCollectionVersionSerializer
     # which is responsible for building the 'download_url'. The default pulp one doesn't

--- a/galaxy_ng/app/api/views.py
+++ b/galaxy_ng/app/api/views.py
@@ -7,17 +7,29 @@ from galaxy_ng.app.api import base as api_base
 
 
 class ApiRootView(api_base.APIView):
-    def get(self, request):
+    def get(self, request, *args, **kwargs):
         data = {
             "available_versions": {"v3": "v3/"},
         }
+
+        if kwargs.get("path"):
+            data["distro_base_path"] = kwargs["path"]
+
         return Response(data)
 
 
-class SlashApiRedirectView(api_base.APIView):
+class ApiRedirectView(api_base.APIView):
     """Redirect requests to /api/automation-hub/api/ to /api/automation-hub/
 
     This is a workaround for https://github.com/ansible/ansible/issues/62073.
     This can be removed when ansible-galaxy stops appending '/api' to the url."""
-    def get(self, request):
-        return HttpResponseRedirect(reverse('galaxy:api'), status=307)
+
+    def get(self, request, *args, **kwargs):
+        reverse_url_name = kwargs.get("reverse_url_name")
+
+        reverse_kwargs = {}
+        if "path" in kwargs:
+            reverse_kwargs["path"] = kwargs["path"]
+
+        return HttpResponseRedirect(reverse(reverse_url_name,
+                                            kwargs=reverse_kwargs), status=307)

--- a/galaxy_ng/app/api/views.py
+++ b/galaxy_ng/app/api/views.py
@@ -20,4 +20,4 @@ class SlashApiRedirectView(api_base.APIView):
     This is a workaround for https://github.com/ansible/ansible/issues/62073.
     This can be removed when ansible-galaxy stops appending '/api' to the url."""
     def get(self, request):
-        return HttpResponseRedirect(reverse('galaxy:api:root-api'), status=307)
+        return HttpResponseRedirect(reverse('galaxy:api'), status=307)

--- a/galaxy_ng/app/api/views.py
+++ b/galaxy_ng/app/api/views.py
@@ -20,4 +20,4 @@ class SlashApiRedirectView(api_base.APIView):
     This is a workaround for https://github.com/ansible/ansible/issues/62073.
     This can be removed when ansible-galaxy stops appending '/api' to the url."""
     def get(self, request):
-        return HttpResponseRedirect(reverse('galaxy:api:root'), status=307)
+        return HttpResponseRedirect(reverse('galaxy:api:root-api'), status=307)

--- a/galaxy_ng/app/models/collectionimport.py
+++ b/galaxy_ng/app/models/collectionimport.py
@@ -34,4 +34,4 @@ class CollectionImport(models.Model):
         ordering = ['-task_id']
 
     def get_absolute_url(self):
-        return reverse('galaxy:api:v3:collection-import', args=[str(self.task_id)])
+        return reverse('galaxy:api:content:collection-import', args=[str(self.task_id)])

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -26,6 +26,10 @@ AUTH_USER_MODEL = 'galaxy.User'
 GALAXY_API_PATH_PREFIX = "/api/galaxy"
 STATIC_URL = "/static/"
 
+# The default repo and distro is called 'automation-hub', as
+# created by the initial-data.json data fixture
+GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH = "automation-hub"
+
 # Local rest framework settings
 # -----------------------------
 


### PR DESCRIPTION
This replaces most of galaxy_ng/app/api/v3/ with viewsets based on the pulp_ansible v3 viewsets eliminating the use of galaxy_pulp for those views.

This also adds a new set of api endpoints that are exposed on urls based on each available
pulp Distribution's base_path. ie, there is an api endpoint for each pulp Repository

The new 'per Distribution' endpoints:

```
/api/automation-hub/content/<str:path>/v3/collections/	galaxy_ng.app.api.v3.viewsets.CollectionViewSet	galaxy:api:per_distribution:collection-list
/api/automation-hub/content/<str:path>/v3/collections/<str:namespace>/<str:name>/	galaxy_ng.app.api.v3.viewsets.CollectionViewSet	galaxy:api:per_distribution:collection
/api/automation-hub/content/<str:path>/v3/collections/<str:namespace>/<str:name>/versions/	galaxy_ng.app.api.v3.viewsets.CollectionVersionViewSet	galaxy:api:per_distribution:collection-version-list
/api/automation-hub/content/<str:path>/v3/collections/<str:namespace>/<str:name>/versions/<str:version>/	galaxy_ng.app.api.v3.viewsets.CollectionVersionViewSet	galaxy:api:per_distribution:collection-version
/api/automation-hub/content/<str:path>/v3/imports/collections/<str:pk>/	galaxy_ng.app.api.v3.viewsets.CollectionImportViewSet	galaxy:api:per_distribution:collection-import
/api/automation-hub/content/<str:path>/v3/artifacts/collections/	galaxy_ng.app.api.v3.viewsets.CollectionUploadViewSet	galaxy:api:per_distribution:collection-artifact-upload
/api/automation-hub/content/<str:path>/v3/	galaxy_ng.app.api.v3.viewsets.ApiRootView	galaxy:api:per_distribution:root-v3
/api/automation-hub/content/<str:path>/	galaxy_ng.app.api.v3.viewsets.ApiRootView	galaxy:api:root-per-distro
/api/automation-hub/content/<str:path>/api/	galaxy_ng.app.api.v3.viewsets.SlashApiRedirectPerDistroView	galaxy:api:api-redirect
```


The 'default distribution' endpoints are equivalent to the old 'v3/' endpoints (excluding '_ui' for now).
They both use the same viewset implementation, but the 'default distribution' sets a default
distribution base_path.

```
/api/automation-hub/v3/collections/	galaxy_ng.app.api.v3.viewsets.CollectionViewSet	galaxy:api:default_distribution:collection-list
/api/automation-hub/v3/collections/<str:namespace>/<str:name>/	galaxy_ng.app.api.v3.viewsets.CollectionViewSet	galaxy:api:default_distribution:collection
/api/automation-hub/v3/collections/<str:namespace>/<str:name>/versions/	galaxy_ng.app.api.v3.viewsets.CollectionVersionViewSet	galaxy:api:default_distribution:collection-version-list
/api/automation-hub/v3/collections/<str:namespace>/<str:name>/versions/<str:version>/	galaxy_ng.app.api.v3.viewsets.CollectionVersionViewSet	galaxy:api:default_distribution:collection-version
/api/automation-hub/v3/imports/collections/<str:pk>/	galaxy_ng.app.api.v3.viewsets.CollectionImportViewSet	galaxy:api:default_distribution:collection-import
/api/automation-hub/v3/artifacts/collections/	galaxy_ng.app.api.v3.viewsets.CollectionUploadViewSet	galaxy:api:default_distribution:collection-artifact-upload
/api/automation-hub/v3/	galaxy_ng.app.api.v3.viewsets.ApiRootView	galaxy:api:default_distribution:v3-root
```

How to Test

NOTE: At the moment, this is just for the 'client api' that ansible-galaxy uses and not any of the _ui API that the web ui uses, so not much should show up in the web ui.

NOTE: Also, at the moment, there isn't a ton in the way of permissions setup. It should be more or less be equivalent to using the existing endpoints for publish and read access. But there isn't any new perms or auth yet, so things might be on the loosey goosey end ACL/RBAC/perms wise.


If your local dev galaxy_ng only has the default 'automation-hub' repository and distribution,
you can test with the implicit default and by specifying that distro explicitly. ie the
'local_ng_implicit' and 'local_ng_explicit' server stanzas below.

A sample ansible.cfg with some example per-repo endpoints defined:

``` ini
[galaxy]
server_list = local_ng_implicit, local_ng_explicit, local_ng_autohub_stage, local_ng_myrepo, local_ng_myrepo_stage

[galaxy_server.automation_hub]
url=https://cloud.redhat.com/api/automation-hub

[galaxy_server.local_ng_implicit]
url=http://localhost:5001/api/automation-hub/
username=admin
password=admin

[galaxy_server.local_ng_explicit]
url=http://localhost:5001/api/automation-hub/content/automation-hub/
username=admin
password=admin

# To create a repo and dist ('automation-hub-stage' in this case)
# http --auth admin:admin POST 'http://localhost:5001/pulp/api/v3/repositories/ansible/ansible/' name="automation-hub-stage"
# Note the 'pulp_href' of the created repository, need it next
# http --auth admin:admin POST 'http://localhost:5001/pulp/api/v3/distributions/ansible/ansible/' name="automation-hub-stage-idistro" base_path="automation-hub-stage-distro-base-path" repository="${THAT_PULP_HREF_OF_THE_NEW_REPO}"

[galaxy_server.local_ng_autohub_stage]
url=http://localhost:5001/api/automation-hub/content/automation-hub-stage-distro-base-path/
username=admin
password=admin

[galaxy_server.local_ng_myrepo]
url=http://localhost:5001/api/automation-hub/content/myrepo-distro-base-path/
username=admin
password=admin

[galaxy_server.local_ng_myrepo_stage]
url=http://localhost:5001/api/automation-hub/content/myrepo-stage-distro-base-path/
username=admin
password=admin
```

Then using that config, something like:

To publish collection to the repo/dict:

`ansible-galaxy  collection publish --server local_ng_explicit  /home/adrian/src/testcollections/collection-releases/alikins-collection_inspect-0.0.183.tar.gz`

To install it:
`ansible-galaxy  collection install --server local_ng_explicit  alikins.collection_inspect`


To test custom repos, you will need to create the repo and dist. For example, to create 'automation-hub-staging':

``` 
$ http --auth admin:admin POST 'http://localhost:5001/pulp/api/v3/repositories/ansible/ansible/' name="automation-hub-stage"
# Note the 'pulp_href' of the created repository, need it next
$ http --auth admin:admin POST 'http://localhost:5001/pulp/api/v3/distributions/ansible/ansible/' name="automation-hub-stage-idistro" base_path="automation-hub-stage-distro-base-path" repository="${THAT_PULP_HREF_OF_THE_NEW_REPO}"
```

To publish collection to the custom automation-hub-stage repo/dict:

`ansible-galaxy  collection publish --server local_ng_autohub_stage  /home/adrian/src/testcollections/collection-releases/alikins-collection_inspect-0.0.183.tar.gz`

To install it:
`ansible-galaxy  collection install --server local_ng_autohub_stage  alikins.collection_inspect`

The results should be seen at
` http --auth admin:admin 'http://localhost:5001/api/automation-hub/content/automation-hub-stage-distro-base-path/v3/collections/`
