### PR TITLE
Fix dependency conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ galaxy_pulp_requirements = [
 
 requirements = galaxy_pulp_requirements + [
     "Django~=2.2.3",
-    "pulpcore>=3.1.1",
-    "pulp-ansible>=0.2.0b8",
+    "pulpcore>=3.0,<3.3",
+    "pulp-ansible>=0.2.0b11",
     "django-prometheus>=2.0.0",
     "django-storages[boto3]",
 ]


### PR DESCRIPTION
* Add pulpcore maximum version restriction to fix conflict with
  pulp-ansible.
* Update minimal pulp-ansible required version to 0.2.0b11.