### PR TITLE
Get download_url to point at pulp content app

### DIFF
--- a/dev/common/galaxy_ng.env
+++ b/dev/common/galaxy_ng.env
@@ -7,6 +7,6 @@ PULP_DB_NAME=galaxy_ng
 
 PULP_REDIS_HOST=redis
 
-PULP_CONTENT_ORIGIN="http://localhost:5001"
+PULP_CONTENT_ORIGIN="http://localhost:24816"
 
 PULP_X_PULP_CONTENT_HOST=content-app

--- a/dev/insights/galaxy_ng.env
+++ b/dev/insights/galaxy_ng.env
@@ -1,9 +1,7 @@
-PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
-
 PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
 PULP_GALAXY_AUTHENTICATION_CLASSES=['galaxy_ng.app.auth.auth.RHIdentityAuthentication']
 PULP_GALAXY_PERMISSION_CLASSES=['rest_framework.permissions.IsAuthenticated', 'galaxy_ng.app.auth.auth.RHEntitlementRequired']
 PULP_RH_ENTITLEMENT_REQUIRED=insights
 
 PULP_ANSIBLE_API_HOSTNAME=http://localhost:5001
-PULP_ANSIBLE_CONTENT_HOSTNAME=http://localhost:24816/api/automation-hub/v3/artifacts/collections
+PULP_ANSIBLE_CONTENT_ORIGIN=http://localhost:24816


### PR DESCRIPTION
Let pulp_ansible / galaxy_ng point to the default pulp content urls for
'download_url' in CollectionVersion. This lets ansible-galaxy download
directly from the pulp content-app.

This avoids galaxy_ng having to provide a viewset that provides the 
'GET /v3​/artifacts​/collections​/{filename}' endpoint. That is the endpoint
that was previously provided by galaxy_ng's CollectionArtifactDownloadView.

Since there isn't a pulp_ansible equivalent to that viewset, there is nothing
to expose in the per-repo urls.

For the standalone cases, using the pulp content app urls provided in
'download_url' for ansible-galaxy downloads makes sense.

For hosted/c.r.c scenario, we may need a custom download endpoint, depending
on what it needs to do. (For ex, download metrics).

This is related to https://github.com/ansible/galaxy_ng/pull/84
