### PR TITLE
Allow all pulp containers to get dev installs

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     command: ['run', 'resource-manager']
     environment:
       - "WITH_DEV_INSTALL=1"
+      - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
     env_file:
       - './common/galaxy_ng.env'
     volumes:
@@ -42,6 +43,7 @@ services:
     command: ['run', 'worker']
     environment:
       - "WITH_DEV_INSTALL=1"
+      - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
     env_file:
       - './common/galaxy_ng.env'
     volumes:
@@ -59,6 +61,7 @@ services:
       - "24816:24816"
     environment:
       - "WITH_DEV_INSTALL=1"
+      - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
     env_file:
       - './common/galaxy_ng.env'
     volumes:


### PR DESCRIPTION
`"DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"` is needed in the worker container for galaxy-importer to work per the wiki [additional-development-dependencies](https://github.com/ansible/galaxy_ng/wiki/Automation-Hub-SaaS-Development/_edit#additional-development-dependencies) instructions, this PR adds to the other pulp containers as I assume they would be needed for pulp-ansible