### PR TITLE
Bump version for pypi

### DIFF
--- a/galaxy_ng/__init__.py
+++ b/galaxy_ng/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.2.0a4"
+__version__ = "4.2.0a5"
 
 default_app_config = "galaxy_ng.app.PulpGalaxyPluginAppConfig"


### PR DESCRIPTION
4.2.0a4 was missing some UI updates, so I'm pushing a new release to include https://github.com/ansible/ansible-hub-ui/releases/tag/4.2.0a3