### PR TITLE
Flake8 ignore doc errors for now

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,12 @@
 [flake8]
-exclude = ./docs/*,*/migrations/*
-ignore = W503,Q000,D100,D104,D106,D200,D401,D402,E203
+exclude = ./docs/*,*/migrations/*,./galaxy_ng/tests/*
+ignore = BLK,W503,Q000,D,D100,D101,D102,D103,D104,D105,D106,D107,D200,D401,D402,E203
 max-line-length = 100
+
+# Flake8 builtin codes
+# --------------------
+# W503: This enforces operators before line breaks which is not pep8 or black compatible.
+# E203: no whitespace around ':'. disabled until https://github.com/PyCQA/pycodestyle/issues/373 is fixed
 
 # Flake8-quotes extension codes
 # -----------------------------
@@ -9,11 +14,18 @@ max-line-length = 100
 
 # Flake8-docstring extension codes
 # --------------------------------
-# W503: This enforces operators before line breaks which is not pep8 or black compatible.
 # D100: missing docstring in public module
+# D101 Missing docstring in public class
+# D102 Missing docstring in public method
+# D103 Missing docstring in public function
 # D104: missing docstring in public package
+# D105 Missing docstring in magic method
 # D106: missing docstring in public nested class (complains about "class Meta:" and documenting those is silly)
+# D107 Missing docstring in __init__
 # D200: one-line docstring should fit on one line with quotes
 # D401: first line should be imperative (nitpicky)
 # D402: first line should not be the function’s “signature” (false positives)
-# E203: no whitespace around ':'. disabled until https://github.com/PyCQA/pycodestyle/issues/373 is fixed
+
+# Flake8-black
+# ------------
+# BLK


### PR DESCRIPTION
Ignore all the current flake8 errors
    
So that flake8 is somewhat useful for the time being.
This can be updated to stop ignoring the errors as
we fix them.

(Most of the errors could be easily fixed in other prs if we want to enforce them, but
for now try to get flake8 passing so it means something when it starts failing)