### PR TITLE
Promotion collection version move/ endpoint

### DIFF
--- a/CHANGES/41.feature
+++ b/CHANGES/41.feature
@@ -1,0 +1,1 @@
+Add collection version move/ endpoint to move to and from repository

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -53,4 +53,10 @@ urlpatterns = [
         viewsets.CollectionArtifactDownloadView.as_view(),
         name='collection-artifact-download'
     ),
+    path(
+        'collections/<str:namespace>/<str:name>/versions/<str:version>/move/'
+        '<str:source_path>/<str:dest_path>/',
+        viewsets.CollectionVersionMoveViewSet.as_view({'post': 'move_content'}),
+        name='collection-version-move',
+    ),
 ]

--- a/galaxy_ng/app/api/v3/viewsets/__init__.py
+++ b/galaxy_ng/app/api/v3/viewsets/__init__.py
@@ -4,6 +4,7 @@ from .collection import (
     CollectionUploadViewSet,
     CollectionViewSet,
     CollectionVersionViewSet,
+    CollectionVersionMoveViewSet,
 )
 
 from .namespace import (
@@ -13,9 +14,10 @@ from .namespace import (
 
 __all__ = (
     'CollectionArtifactDownloadView',
+    'CollectionImportViewSet',
     'CollectionUploadViewSet',
     'CollectionViewSet',
     'CollectionVersionViewSet',
-    'CollectionImportViewSet',
+    'CollectionVersionMoveViewSet',
     'NamespaceViewSet',
 )

--- a/galaxy_ng/app/tasks/__init__.py
+++ b/galaxy_ng/app/tasks/__init__.py
@@ -1,2 +1,3 @@
 from .publishing import import_and_auto_approve  # noqa: F401
+from .promotion import add_content_to_repository, remove_content_from_repository  # noqa: F401
 # from .synchronizing import synchronize  # noqa

--- a/galaxy_ng/app/tasks/promotion.py
+++ b/galaxy_ng/app/tasks/promotion.py
@@ -1,0 +1,27 @@
+from pulp_ansible.app.models import AnsibleRepository, CollectionVersion
+
+
+def add_content_to_repository(collection_version_pk, repository_pk):
+    """
+    Add a CollectionVersion to repository.
+    Args:
+        collection_version_pk: The pk of the CollectionVersion to add to repository.
+        repository_pk: The pk of the AnsibleRepository to add the CollectionVersion to.
+    """
+    repository = AnsibleRepository.objects.get(pk=repository_pk)
+    qs = CollectionVersion.objects.filter(pk=collection_version_pk)
+    with repository.new_version() as new_version:
+        new_version.add_content(qs)
+
+
+def remove_content_from_repository(collection_version_pk, repository_pk):
+    """
+    Remove a CollectionVersion from a repository.
+    Args:
+        collection_version_pk: The pk of the CollectionVersion to remove from repository.
+        repository_pk: The pk of the AnsibleRepository to remove the CollectionVersion from.
+    """
+    repository = AnsibleRepository.objects.get(pk=repository_pk)
+    qs = CollectionVersion.objects.filter(pk=collection_version_pk)
+    with repository.new_version() as new_version:
+        new_version.remove_content(qs)

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -191,6 +191,28 @@ paths:
         'default':
           $ref: '#/components/responses/Errors'
 
+  '/v3/collections/{namespace}/{name}/versions/{version}/move/{source_path}/{destination_path}':
+    parameters: #tag
+      - $ref: '#/components/parameters/CollectionNamespaceName'
+      - $ref: '#/components/parameters/CollectionName'
+      - $ref: '#/components/parameters/SemanticVersion'
+      - $ref: '#/components/parameters/DistributionBasePath'
+      - $ref: '#/components/parameters/DistributionBasePath'
+    post:
+      summary: >
+        Queues tasks to move CollectionVersion
+        from source Repository to destination Repository
+        using the Repository DistributionBasePath.
+      operationId: moveCollectionVersion
+      tags:
+        - Collections
+      parameters: []
+      responses:
+        '202':
+          $ref: '#/components/responses/CollectionVersionMove'
+        'default':
+          $ref: '#/components/responses/Errors'
+
   # -------------------------------------
   # Artifacts
   # -------------------------------------
@@ -732,6 +754,19 @@ components:
           required:
             - data
 
+    CollectionVersionMoveResult: #tag
+      description: 'Task ids for moving a CollectionVersion'
+      type: object
+      properties:
+        add_task_id:
+          description: 'Task id for task to add CollectionVersion to Repository'
+          type: string
+        remove_task_id:
+          description: 'Task id for task to remove CollectionVersion from Repository'
+          type: string
+        version:
+          $ref: '#/components/schemas/SemanticVersion'
+
     # -------------------------------------
     # Schemas: Errors
     # -------------------------------------
@@ -1180,6 +1215,16 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CollectionVersionArtifact'
+
+    CollectionVersionMove: #tag
+      description: >
+        Response containing task ids for
+        adding the CollectionVersion to a destination Repository
+        and removing the CollectionVersion from a source Repository.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CollectionVersionMoveResult'
 
     CollectionImportAccepted:
       description: >


### PR DESCRIPTION
`move/` endpoint on a CollectionVersion that starts 2 pulp tasks... 1 to make a new RepositoryVerison of source repo without CollectionVersion, and 1 to make a new RepositoryVersion of destination repo with CollectionVersion. Works #41, #117

Example:
`api/automation-hub/content/automation-hub/v3/collections/<str:namespace>/<str:name>/versions/<str:version>/move/<str:source_path>/<str:dest_path>/`

Testing:
1. Confirm a version (i.e. `1.0.74`) in list http://localhost:5001/api/automation-hub/content/staging/v3/collections/awcrosby/collection_test/versions/
2. POST to http://localhost:5001/api/automation-hub/v3/collections/awcrosby/collection_test/versions/1.0.74/move/staging/automation-hub/ and see task ids returned
3. Confirm version no longer in source_repo list: http://localhost:5001/api/automation-hub/content/staging/v3/collections/awcrosby/collection_test/versions/
4. Confirm version now in destination_repo list: http://localhost:5001/api/automation-hub/content/automation-hub/v3/collections/awcrosby/collection_test/versions/