### PR TITLE
Install dependencies for running ansible-test via Pulp Container

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -41,6 +41,11 @@ services:
   worker:
     image: "localhost/${COMPOSE_PROJECT_NAME}/galaxy_ng:latest"
     command: ['run', 'worker']
+    devices: 
+      - "/dev/fuse:/dev/fuse"
+    ports:
+      - "8080:8080"
+      - "8081:8081"
     environment:
       - "WITH_DEV_INSTALL=1"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"


### PR DESCRIPTION
Installs and configures dependencies for running Podman and Buildah.

- [ ] Fix `cannot clone: Operation not permitted` error when running Podman

Issue: https://github.com/ansible/galaxy_ng/issues/81
Replaces https://github.com/ansible/galaxy-dev/pull/260