### PR TITLE
Update galaxy-importer dependency to 0.2.3

### DIFF
--- a/CHANGES/122.bugfix
+++ b/CHANGES/122.bugfix
@@ -1,0 +1,1 @@
+Fix importer job scheduling issues with importer resource params

--- a/CHANGES/159.bugfix
+++ b/CHANGES/159.bugfix
@@ -1,0 +1,1 @@
+Fix importer exception on unexpected docstring format

--- a/release_requirements.txt
+++ b/release_requirements.txt
@@ -35,7 +35,7 @@ drf-yasg==1.17.1          # via pulpcore
 dynaconf==2.2.3           # via pulpcore
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via galaxy-importer
-galaxy-importer==0.2.1    # via pulp-ansible
+galaxy-importer==0.2.3    # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via idna-ssl, requests, yarl


### PR DESCRIPTION
The galaxy-importer version 0.2.3 includes:
* fix for importer job scheduling issues with importer resource params
* fix for importer error on unexpected docstring format

Works #122, #159