### PR TITLE
Fix import record url returned from publish

### DIFF
--- a/galaxy_ng/app/api/v3/viewsets.py
+++ b/galaxy_ng/app/api/v3/viewsets.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.core.exceptions import ValidationError
+from django.urls import reverse
 
 from rest_framework.response import Response
 
@@ -92,4 +93,15 @@ class CollectionUploadViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionU
             version=data['filename'].version,
         )
 
-        return response
+        # TODO: CollectionImport.get_absolute_url() should be able to generate this, but
+        #       it needs the  repo/distro base_path for the <path> part of url
+        import_obj_url = reverse("galaxy:api:content:v3:collection-import",
+                                 kwargs={'pk': str(task_detail.pulp_id),
+                                         'path': path})
+
+        log.debug('import_obj_url: %s', import_obj_url)
+
+        return Response(
+            data={'task': import_obj_url},
+            status=response.status_code
+        )


### PR DESCRIPTION
First pass at returning the CollectionImport url
include the repo <path> in the response to
a POST to:
        /api/automation-hub/content/automation-hub/v3/artifacts/collections/

Better fix will be either add method to CollectionImport to build
url with pass in <path>.

Or Better, to add a field to CollectionImport that references the
Repository the collection was imported to, so it can fill out the
<path> in the url pattern itself in get_absolute_url()

Issue: #167