### PR TITLE
Fix unit tests failing when run in non-standalone mode

### DIFF
--- a/galaxy_ng/app/api/base.py
+++ b/galaxy_ng/app/api/base.py
@@ -1,36 +1,39 @@
-from django.conf import settings
+from django.test.signals import setting_changed
 
 from rest_framework import generics
 from rest_framework import views
 from rest_framework import viewsets
-from rest_framework.settings import perform_import
+from rest_framework.settings import APISettings
 
 
-GALAXY_EXCEPTION_HANDLER = perform_import(
-    settings.GALAXY_EXCEPTION_HANDLER,
-    'GALAXY_EXCEPTION_HANDLER'
-)
-GALAXY_AUTHENTICATION_CLASSES = perform_import(
-    settings.GALAXY_AUTHENTICATION_CLASSES,
-    'GALAXY_AUTHENTICATION_CLASSES'
-)
-GALAXY_PERMISSION_CLASSES = perform_import(
-    settings.GALAXY_PERMISSION_CLASSES,
-    'GALAXY_PERMISSION_CLASSES',
-)
-GALAXY_PAGINATION_CLASS = perform_import(
-    settings.GALAXY_PAGINATION_CLASS,
-    'GALAXY_PAGINATION_CLASS'
-)
+# NOTE: This code uses undocumented and internal class rest_framework.settings.APISettings.
+#       It must be eventually refactored.
+DEFAULT_SETTINGS = {
+    "GALAXY_EXCEPTION_HANDLER": "galaxy_ng.app.api.exceptions.exception_handler",
+    "GALAXY_PAGINATION_CLASS": "galaxy_ng.app.api.pagination.LimitOffsetPagination",
+    "GALAXY_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
+    ],
+    "GALAXY_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
+}
+IMPORT_STRINGS = [
+    "GALAXY_EXCEPTION_HANDLER",
+    "GALAXY_AUTHENTICATION_CLASSES",
+    "GALAXY_PERMISSION_CLASSES",
+    "GALAXY_PAGINATION_CLASS",
+]
+
+local_settings = APISettings(defaults=DEFAULT_SETTINGS, import_strings=IMPORT_STRINGS)
 
 
 class LocalSettingsMixin:
-    authentication_classes = GALAXY_AUTHENTICATION_CLASSES
-    permission_classes = GALAXY_PERMISSION_CLASSES
-    pagination_class = GALAXY_PAGINATION_CLASS
+    authentication_classes = local_settings.GALAXY_AUTHENTICATION_CLASSES
+    permission_classes = local_settings.GALAXY_PERMISSION_CLASSES
+    pagination_class = local_settings.GALAXY_PAGINATION_CLASS
 
     def get_exception_handler(self):
-        return GALAXY_EXCEPTION_HANDLER
+        return local_settings.GALAXY_EXCEPTION_HANDLER
 
 
 class APIView(LocalSettingsMixin, views.APIView):
@@ -47,3 +50,11 @@ class GenericAPIView(LocalSettingsMixin, generics.GenericAPIView):
 
 class GenericViewSet(LocalSettingsMixin, viewsets.GenericViewSet):
     pass
+
+
+def _reload_local_settings(**kwargs):
+    if kwargs["setting"] in DEFAULT_SETTINGS:
+        local_settings.reload()
+
+
+setting_changed.connect(_reload_local_settings)

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -164,10 +164,9 @@ class CollectionVersionViewSet(api_base.GenericViewSet):
         methods=["PUT"],
         detail=True,
         url_path="certified",
-        permission_classes=api_base.GALAXY_PERMISSION_CLASSES + [
-            permissions.IsPartnerEngineer
-        ],
-        serializer_class=serializers.CertificationSerializer
+        permission_classes=api_base.local_settings.GALAXY_PERMISSION_CLASSES
+        + [permissions.IsPartnerEngineer],
+        serializer_class=serializers.CertificationSerializer,
     )
     def set_certified(self, request, *args, **kwargs):
         namespace, name, version = self.kwargs['version'].split('/')

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -16,7 +16,7 @@ from pulpcore.plugin.models import ContentArtifact, Task
 from pulp_ansible.app.galaxy.v3 import views as pulp_ansible_views
 
 from galaxy_ng.app.api.base import (
-    GALAXY_PERMISSION_CLASSES,
+    local_settings,
     APIView,
     LocalSettingsMixin,
 )
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 
 
 class CollectionViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionViewSet):
-    permission_classes = GALAXY_PERMISSION_CLASSES + [
+    permission_classes = local_settings.GALAXY_PERMISSION_CLASSES + [
         permissions.IsNamespaceOwnerOrPartnerEngineer,
     ]
 
@@ -68,7 +68,7 @@ class CollectionImportViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionI
 
 
 class CollectionUploadViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionUploadViewSet):
-    permission_classes = GALAXY_PERMISSION_CLASSES + [
+    permission_classes = local_settings.GALAXY_PERMISSION_CLASSES + [
         permissions.IsNamespaceOwner
     ]
 

--- a/galaxy_ng/tests/unit/api/test_api_ui_auth_views.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_auth_views.py
@@ -9,12 +9,18 @@ from rest_framework.test import APIClient, APITestCase
 from galaxy_ng.app.constants import DeploymentMode
 from galaxy_ng.app.models import auth as auth_models
 
-import logging
 
-LOG = logging.getLogger(__name__)
+STANDALONE_AUTH_SETTINGS = dict(
+    GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value,
+    GALAXY_PERMISSION_CLASSES=["rest_framework.permissions.IsAuthenticated"],
+    GALAXY_AUTHENTICATION_CLASSES=[
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
+    ],
+)
 
 
-@override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value)
+@override_settings(**STANDALONE_AUTH_SETTINGS)
 class TestLoginViewsStandalone(APITestCase):
     def setUp(self):
         super().setUp()
@@ -56,7 +62,7 @@ class TestLoginViewsStandalone(APITestCase):
 
     def test_login_invalid_password(self):
         response: Response = self.client.post(
-            self.login_url, data={"username": "test1", "password": "invalid", }
+            self.login_url, data={"username": "test1", "password": "invalid"}
         )
         self.assertEqual(response.status_code, http_code.HTTP_403_FORBIDDEN)
 
@@ -65,7 +71,7 @@ class TestLoginViewsStandalone(APITestCase):
 
     def test_login_wrong_password(self):
         response: Response = self.client.post(
-            self.login_url, data={"username": "test2", "password": "test1-secret", }
+            self.login_url, data={"username": "test2", "password": "test1-secret"}
         )
         self.assertEqual(response.status_code, http_code.HTTP_403_FORBIDDEN)
 
@@ -165,7 +171,7 @@ class TestLoginViewsStandalone(APITestCase):
         self.assertDictEqual(response.data, expected_response_data)
 
 
-@override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value)
+@override_settings(**STANDALONE_AUTH_SETTINGS)
 class TestTokenViewStandalone(APITestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Authentication unit tests were failing if being executed with
`GALAXY_DEPLOYMENT_MODE` setting value other than 'standalone'.
This was caused by several factors:

1. When other `GALAXY_DEPLOYMENT_MODE` is used, usually
   authentication and permission classes are different.

   For these unit tests to pass it is required that.
   `SessionAuthentication` and `TokenAuthentication` authentication
   classes are used.

   This is fixed by overriding `GALAXY_AUTHENTICATION_CLASSES`
   and `GALAXY_PERMISSION_CLASSES` settings variables for related
   unit tests.

2. Settings that were overridden in unit tests were not applied
   properly, because settings values were read at module import time
   and settings were not reloaded if set later by `@override_settings`
   decorator.

   This is fixed by refactoring local settings from global variables
   read at the import time and using ApiSettings object instead
   which is reloaded by Django's `settings_changed` signal.