### PR TITLE
Auto-approve collection version on import

### DIFF
--- a/CHANGES/170.feature
+++ b/CHANGES/170.feature
@@ -1,0 +1,1 @@
+Support config to auto-approve collection versions on import

--- a/dev/standalone/galaxy_ng.env
+++ b/dev/standalone/galaxy_ng.env
@@ -4,6 +4,7 @@ PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
 PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication']
 PULP_GALAXY_PERMISSION_CLASSES=['rest_framework.permissions.IsAuthenticated']
 PULP_GALAXY_DEPLOYMENT_MODE=standalone
+PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=False
 PULP_RH_ENTITLEMENT_REQUIRED=insights
 
 PULP_ANSIBLE_API_HOSTNAME=http://localhost:5001

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -83,7 +83,7 @@ class CollectionUploadViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionU
             locks.append(repository)
             kwargs["repository_pk"] = repository.pk
 
-        if settings.GALAXY_REQUIRE_CONTENT_APPROVAL:
+        if settings.GALAXY_REQUIRE_CONTENT_APPROVAL == 'True':
             return enqueue_with_reservation(import_collection, locks, kwargs=kwargs)
         return enqueue_with_reservation(import_and_auto_approve, locks, kwargs=kwargs)
 

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -13,6 +13,8 @@ from rest_framework.response import Response
 from rest_framework.exceptions import APIException, NotFound
 
 from pulpcore.plugin.models import ContentArtifact, Task
+from pulpcore.plugin.tasking import enqueue_with_reservation
+from pulp_ansible.app.tasks.collections import import_collection
 from pulp_ansible.app.galaxy.v3 import views as pulp_ansible_views
 
 from galaxy_ng.app.api.base import (
@@ -27,6 +29,7 @@ from galaxy_ng.app.api import permissions
 from galaxy_ng.app.api.v3.serializers import CollectionVersionSerializer, CollectionUploadSerializer
 
 from galaxy_ng.app.common import metrics
+from galaxy_ng.app.tasks import import_and_auto_approve
 
 # hmm, not sure what to do with this
 # from galaxy_ng.app.common.parsers import AnsibleGalaxy29MultiPartParser
@@ -71,6 +74,18 @@ class CollectionUploadViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionU
     permission_classes = GALAXY_PERMISSION_CLASSES + [
         permissions.IsNamespaceOwner
     ]
+
+    def _dispatch_import_collection_task(self, artifact_pk, repository=None, **kwargs):
+        """Dispatch a pulp task started on upload of collection version."""
+        locks = [str(artifact_pk)]
+        kwargs["artifact_pk"] = artifact_pk
+        if repository:
+            locks.append(repository)
+            kwargs["repository_pk"] = repository.pk
+
+        if settings.GALAXY_REQUIRE_CONTENT_APPROVAL:
+            return enqueue_with_reservation(import_collection, locks, kwargs=kwargs)
+        return enqueue_with_reservation(import_and_auto_approve, locks, kwargs=kwargs)
 
     # Wrap super().create() so we can create a galaxy_ng.app.models.CollectionImport based on the
     # the import task and the collection artifact details

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -30,6 +30,11 @@ STATIC_URL = "/static/"
 # created by the initial-data.json data fixture
 GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH = "automation-hub"
 
+# Require approval for incoming content,
+# currently using a certification flag,
+# later using a staging repository
+GALAXY_REQUIRE_CONTENT_APPROVAL = True
+
 # Local rest framework settings
 # -----------------------------
 

--- a/galaxy_ng/app/tasks/__init__.py
+++ b/galaxy_ng/app/tasks/__init__.py
@@ -1,2 +1,2 @@
-from .publishing import publish  # noqa
-from .synchronizing import synchronize  # noqa
+from .publishing import import_and_auto_approve  # noqa: F401
+# from .synchronizing import synchronize  # noqa

--- a/galaxy_ng/app/tasks/publishing.py
+++ b/galaxy_ng/app/tasks/publishing.py
@@ -1,0 +1,25 @@
+import logging
+
+from pulp_ansible.app.tasks.collections import import_collection
+from pulpcore.plugin.models import ContentArtifact
+
+log = logging.getLogger(__name__)
+
+VERSION_CERTIFIED = "certified"
+
+
+def import_and_auto_approve(artifact_pk, **kwargs):
+    """Import collection version and automatically approve.
+
+    Custom task to call pulp_ansible's import_collection() task
+    then automatically approve collection version so no
+    manual approval action needs to occur.
+
+    Approval currently is a collection version certification flag
+    Approval later will be moving from a staging to an approved repo
+    """
+    import_collection(artifact_pk=artifact_pk, repository_pk=kwargs.get('repository_pk', None))
+    content_artifact = ContentArtifact.objects.get(artifact_id=artifact_pk)
+    collection_version = content_artifact.content.ansible_collectionversion
+    collection_version.certification = VERSION_CERTIFIED
+    collection_version.save()

--- a/galaxy_ng/tests/unit/app/test_tasks.py
+++ b/galaxy_ng/tests/unit/app/test_tasks.py
@@ -1,0 +1,39 @@
+import logging
+import os
+import tempfile
+from unittest import mock
+
+from django.test import TestCase
+from pulpcore.plugin.models import Artifact, Content, ContentArtifact
+from pulp_ansible.app.models import Collection, CollectionVersion
+
+from galaxy_ng.app.tasks import import_and_auto_approve
+
+log = logging.getLogger(__name__)
+
+
+class TestTaskImportAndAutoApprove(TestCase):
+    artifact_path = os.path.join(tempfile.gettempdir(), 'artifact-tmp')
+
+    def setUp(self):
+        with open(self.artifact_path, 'w') as f:
+            f.write('Temp Artifact File')
+        self.artifact = Artifact.init_and_validate(self.artifact_path)
+        self.artifact.save()
+
+        collection = Collection.objects.create(namespace='my_ns', name='my_name')
+        self.collection_version = CollectionVersion.objects.create(collection=collection)
+        self.collection_version.save()
+
+        content_artifact = ContentArtifact.objects.create(
+            artifact=self.artifact,
+            content=self.collection_version,
+        )
+        content_artifact.save()
+
+    @mock.patch('galaxy_ng.app.tasks.publishing.import_collection')
+    def test_import_and_auto_approve(self, mocked_import_collection):
+        self.assertTrue(self.collection_version.certification == 'needs_review')
+        import_and_auto_approve(self.artifact.pk)
+        self.collection_version.refresh_from_db()
+        self.assertTrue(self.collection_version.certification == 'certified')

--- a/release_requirements.txt
+++ b/release_requirements.txt
@@ -58,7 +58,7 @@ openpyxl==3.0.3           # via tablib
 packaging==20.4           # via bleach, drf-yasg, pulp-ansible
 prometheus-client==0.7.1  # via django-prometheus
 psycopg2==2.8.5           # via pulpcore
-pulp-ansible==0.2.0b12    # via galaxy-ng (setup.py)
+pulp-ansible==0.2.0b13    # via galaxy-ng (setup.py)
 pulpcore==3.3.1           # via galaxy-ng (setup.py), pulp-ansible
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ galaxy_pulp_requirements = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python
 requirements = galaxy_pulp_requirements + [
     "Django~=2.2.3",
     "pulpcore>=3.0,<3.4",
-    "pulp-ansible>=0.2.0b11",
+    "pulp-ansible>=0.2.0b13",
     "django-prometheus>=2.0.0",
     "django-storages[boto3]",
 ]


### PR DESCRIPTION
* Add config setting for when to require approval of a collection version
* Add galaxy_ng task to call pulp_ansible `import_collection` task then auto-approve collection version
* In CollectionUploadViewSet dispatch pulp task from pulp_ansible or galaxy_ng based on config

Works #170 