### PR TITLE
Improvements to the Token API

### DIFF
--- a/CHANGES/187.feature
+++ b/CHANGES/187.feature
@@ -1,0 +1,3 @@
+Token API is moved from UI to v3 and now is served at ``<prefix>/v3/auth/token/``.
+Token API does not support ``GET`` method anymore, token is returned to client only once after creation.
+Add support of HTTP Basic authentication method to the Token API.

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -20,9 +20,8 @@ router.register(
 router.register('tags', viewsets.TagsViewSet, basename='tags')
 
 auth_views = [
-    path('login/', views.LoginView.as_view(), name='auth-login'),
-    path('logout/', views.LogoutView.as_view(), name='auth-logout'),
-    path('token/', views.TokenView.as_view(), name='auth-token'),
+    path("login/", views.LoginView.as_view(), name="auth-login"),
+    path("logout/", views.LogoutView.as_view(), name="auth-logout"),
 ]
 
 app_name = "ui"

--- a/galaxy_ng/app/api/ui/views/__init__.py
+++ b/galaxy_ng/app/api/ui/views/__init__.py
@@ -1,13 +1,11 @@
 from .auth import (
     LoginView,
     LogoutView,
-    TokenView,
 )
 
 
 __all__ = (
     # auth
-    'LoginView',
-    'LogoutView',
-    'TokenView'
+    "LoginView",
+    "LogoutView",
 )

--- a/galaxy_ng/app/api/ui/views/auth.py
+++ b/galaxy_ng/app/api/ui/views/auth.py
@@ -1,13 +1,9 @@
 from django.contrib import auth as django_auth
-from django.db import transaction
-from django.http import Http404
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from rest_framework.authentication import SessionAuthentication
 
-from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
 from rest_framework import status as http_code
 
 from galaxy_ng.app.api import base as api_base
@@ -16,9 +12,8 @@ from galaxy_ng.app.api.ui.serializers import LoginSerializer
 
 
 __all__ = (
-    'LoginView',
-    'LogoutView',
-    'TokenView',
+    "LoginView",
+    "LogoutView",
 )
 
 
@@ -60,27 +55,4 @@ class LogoutView(api_base.APIView):
 
     def post(self, request, *args, **kwargs):
         django_auth.logout(request)
-        return Response(status=http_code.HTTP_204_NO_CONTENT)
-
-
-class TokenView(api_base.APIView):
-    permission_classes = (IsAuthenticated, RestrictOnCloudDeployments)
-
-    def get(self, request, *args, **kwargs):
-        try:
-            token = Token.objects.get(user=self.request.user)
-        except Token.DoesNotExist:
-            raise Http404()
-        return Response({'token': token.key})
-
-    @transaction.atomic
-    def post(self, request, *args, **kwargs):
-        """Create or refresh user token."""
-        Token.objects.filter(user=self.request.user).delete()
-        token = Token.objects.create(user=self.request.user)
-        return Response({'token': token.key})
-
-    def delete(self, request, *args, **kwargs):
-        """Invalidate user token."""
-        Token.objects.filter(user=self.request.user).delete()
         return Response(status=http_code.HTTP_204_NO_CONTENT)

--- a/galaxy_ng/app/api/urls.py
+++ b/galaxy_ng/app/api/urls.py
@@ -11,6 +11,7 @@ app_name = "api"
 
 v3_urlpatterns = [
     path("_ui/", include(ui_urls)),
+    path("", include(v3_urls.auth_urls)),
 
     # Set an instance of the v3 urls/viewsets at the same
     # url path as the former galaxy_api.api.v3.viewsets

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -1,6 +1,13 @@
 from django.urls import path
 
+from . import views
 from . import viewsets
+
+
+auth_urls = [
+    path("auth/token/", views.TokenView.as_view(), name="auth-token"),
+]
+
 
 urlpatterns = [
     path(

--- a/galaxy_ng/app/api/v3/views/__init__.py
+++ b/galaxy_ng/app/api/v3/views/__init__.py
@@ -1,0 +1,4 @@
+from .auth import TokenView
+
+
+__all__ = ("TokenView",)

--- a/galaxy_ng/app/api/v3/views/auth.py
+++ b/galaxy_ng/app/api/v3/views/auth.py
@@ -1,0 +1,27 @@
+from django.db import transaction
+from rest_framework.authentication import BasicAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.authtoken.models import Token
+from rest_framework.response import Response
+from rest_framework import status as http_code
+
+from galaxy_ng.app.api import base as api_base
+from galaxy_ng.app.api.permissions import RestrictOnCloudDeployments
+
+
+class TokenView(api_base.APIView):
+    authentication_classes = (BasicAuthentication, *api_base.GALAXY_AUTHENTICATION_CLASSES)
+    permission_classes = (IsAuthenticated, RestrictOnCloudDeployments)
+
+    @transaction.atomic
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        """Create or refresh user token."""
+        Token.objects.filter(user=self.request.user).delete()
+        token = Token.objects.create(user=self.request.user)
+        return Response({"token": token.key})
+
+    def delete(self, request, *args, **kwargs):
+        """Invalidate user token."""
+        Token.objects.filter(user=self.request.user).delete()
+        return Response(status=http_code.HTTP_204_NO_CONTENT)

--- a/galaxy_ng/tests/unit/api/test_api_v3_auth_views.py
+++ b/galaxy_ng/tests/unit/api/test_api_v3_auth_views.py
@@ -1,0 +1,121 @@
+import base64
+
+from django.test import override_settings
+from django.urls import reverse
+
+from rest_framework import status as http_code
+from rest_framework.authtoken import models as token_models
+from rest_framework.response import Response
+from rest_framework.test import APIClient, APITestCase
+
+from galaxy_ng.app.constants import DeploymentMode
+from galaxy_ng.app.models import auth as auth_models
+
+
+@override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value)
+class TestTokenViewStandalone(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.token_url = reverse("galaxy:api:v3:auth-token")
+        self.me_url = reverse("galaxy:api:v3:ui:me")
+
+        self.user = auth_models.User.objects.create_user(username="test", password="test-secret")
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _issue_token(self):
+        response: Response = self.client.post(self.token_url)
+        self.assertEqual(response.status_code, http_code.HTTP_200_OK)
+        self.assertTrue("token" in response.data)
+
+        return response.data["token"]
+
+    def test_issue_token(self):
+        response: Response = self.client.post(self.token_url)
+        self.assertEqual(response.status_code, http_code.HTTP_200_OK)
+        self.assertTrue("token" in response.data)
+        self.assertEqual(response.data["token"], self._get_token(self.user).key)
+
+    def test_issue_token_basic_auth(self):
+        client = APIClient()
+        http_authorization = "Basic {}".format(base64.b64encode(b"test:test-secret").decode())
+        client.credentials(HTTP_AUTHORIZATION=http_authorization)
+        response: Response = client.post(self.token_url)
+        self.assertEqual(response.status_code, http_code.HTTP_200_OK)
+        self.assertTrue("token" in response.data)
+
+    def test_refresh_token(self):
+        token_1 = self._issue_token()
+        self.assertTrue(self._token_exists(self.user, token_1))
+
+        token_2 = self._issue_token()
+
+        self.assertNotEqual(token_1, token_2)
+
+        self.assertFalse(self._token_exists(self.user, token_1))
+        self.assertTrue(self._token_exists(self.user, token_2))
+
+    def test_token_auth(self):
+        token = token_models.Token.objects.create(user=self.user)
+
+        new_client = APIClient()
+        new_client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+
+        response: Response = new_client.get(self.me_url)
+        self.assertEqual(response.status_code, http_code.HTTP_200_OK)
+
+    def test_token_auth_missing_token(self):
+        new_client = APIClient()
+
+        response: Response = new_client.get(self.me_url)
+        self.assertEqual(response.status_code, http_code.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.data,
+            {
+                "errors": [
+                    {
+                        "code": "not_authenticated",
+                        "status": "403",
+                        "title": "Authentication credentials were not provided.",
+                    }
+                ]
+            },
+        )
+
+    def test_token_auth_invalid_token(self):
+        new_client = APIClient()
+        new_client.credentials(HTTP_AUTHORIZATION="Token c451947e96372bc215c1a9e9e9d01eca910cd144")
+
+        response: Response = new_client.get(self.me_url)
+        self.assertEqual(response.status_code, http_code.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.data,
+            {
+                "errors": [
+                    {
+                        "detail": "Invalid token.",
+                        "code": "authentication_failed",
+                        "status": "403",
+                        "title": "Incorrect authentication credentials.",
+                    }
+                ]
+            },
+        )
+
+    def test_revoke_token(self):
+        token_models.Token.objects.create(user=self.user)
+
+        response: Response = self.client.delete(self.token_url)
+        self.assertEqual(response.status_code, http_code.HTTP_204_NO_CONTENT)
+
+        token_exists = token_models.Token.objects.filter(user=self.user).exists()
+        self.assertFalse(token_exists)
+
+    @staticmethod
+    def _get_token(user):
+        return token_models.Token.objects.get(user=user)
+
+    @staticmethod
+    def _token_exists(user, token):
+        return token_models.Token.objects.filter(user=user, key=token).exists()

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -80,6 +80,41 @@ info:
 paths:
 
   # -------------------------------------
+  # Authentication
+  # -------------------------------------
+
+  /auth/token/:
+    post:
+      summary: "Issue Auth Token"
+      operationId: createAuthToken
+      description: "Create a new authentication token. Any existing token is revoked."
+      tags:
+        - 'Authentication'
+      security:
+        - TokenAuth: []
+        - BasicAuth: []
+      responses:
+        '200':
+          $ref: '#/components/responses/Token'
+        'default':
+          $ref: '#/components/responses/Errors'
+
+    delete:
+      summary: "Revoke Auth Token"
+      operationId: deleteAuthToken
+      description: "Revoke authentication token if it exists."
+      security:
+        - TokenAuth: []
+        - BasicAuth: []
+      tags:
+        - 'Authentication'
+      responses:
+        '204':
+          description: "Token has been revoked."
+        'default':
+          $ref: '#/components/responses/Errors'
+
+  # -------------------------------------
   # Collections
   # -------------------------------------
 
@@ -234,6 +269,20 @@ paths:
           $ref: '#/components/responses/Errors'
 
 components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+
+    TokenAuth:
+      type: apiKey
+      name: Authorization
+      in: header
+      description: |
+        Django Rest Framework (DRF) token authentication.
+        Passed in HTTP header as:
+          Authorization: Token <token>
+
   schemas:
     Author:
       description: 'Author of a collection or role'
@@ -841,6 +890,19 @@ components:
       type: string
       # TODO: This could in theory be an enum
 
+    # -------------------------------------
+    # Schemas: Authentication
+    # -------------------------------------
+
+    Token:
+      title: "Token"
+      description: "Authentication token"
+      type: object
+      properties:
+        token:
+          description: "Token string"
+          type: string
+
   parameters:
 
     CollectionNamespaceName:
@@ -1076,3 +1138,10 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Errors'
+
+    Token:
+      description: 'Response containing a Token'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Token'

--- a/openapi/ui_openapi.yaml
+++ b/openapi/ui_openapi.yaml
@@ -346,44 +346,6 @@ paths:
         '204':
           description: "User signed out successfully."
 
-  /_ui/auth/token/:
-    get:
-      summary: "Get Auth Token (UI)"
-      operationId: getAuthTokenUi
-      tags:
-        - 'UI: Authhentication'
-      responses:
-        '200':
-          $ref: '#/components/responses/Token'
-        '404':
-          description: "User does not have a token."
-        'default':
-          $ref: '#/components/responses/Errors'
-
-    post:
-      summary: "Issue Auth Token (UI)"
-      operationId: issueAuthTokenUi
-      description: "Create a new authentication token. Any existing token is revoked."
-      tags:
-        - 'UI: Authhentication'
-      responses:
-        '200':
-          $ref: '#/components/responses/Token'
-        'default':
-          $ref: '#/components/responses/Errors'
-
-    delete:
-      summary: "Revoke Auth Token (UI)"
-      operationId: revokeAuthTokenUi
-      description: "Revoke authentication token if it exists."
-      tags:
-        - 'UI: Authhentication'
-      responses:
-        '204':
-          description: "Token has been revoked."
-        'default':
-          $ref: '#/components/responses/Errors'
-
   #
   # Sync lists
   #
@@ -1266,15 +1228,6 @@ components:
           description: "User password"
           type: string
 
-    Token:
-      title: "Token"
-      description: "Authentication token"
-      type: object
-      properties:
-        token:
-          description: "Token string"
-          type: string
-
   parameters:
 
     CollectionNamespaceName:
@@ -1501,10 +1454,3 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/UsersPage'
-
-    Token:
-      description: 'Response containing a Token'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Token'


### PR DESCRIPTION
* Token API is moved from UI to v3 and now is served at ``<prefix>/v3/auth/token/``.
* Token API does not support ``GET`` method anymore,
  token is returned to client only once after creation.
* Add support of HTTP Basic authentication method to the Token API.

Issue: #187