### PR TITLE
Fix CollectionVersionViewSet showing uncertified content

### DIFF
--- a/CHANGES/214.bugfix
+++ b/CHANGES/214.bugfix
@@ -1,0 +1,1 @@
+Fix CollectionVersionViewSet so it filters based on "certification" status.

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -47,6 +47,13 @@ class CollectionViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionViewSet
 class CollectionVersionViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionVersionViewSet):
     serializer_class = CollectionVersionSerializer
 
+    # FIXME(akl): This can be removed when we move to multiple repos for managing "certifiaction"
+    def get_queryset(self):
+        """
+        Returns a CollectionVersions queryset for specified distribution filtering on certification.
+        """
+        return super().get_queryset().filter(certification="certified")
+
     # Custom retrive so we can use the class serializer_class
     # galaxy_ng.app.api.v3.serializers.CollectionVersionSerializer
     # which is responsible for building the 'download_url'. The default pulp one doesn't


### PR DESCRIPTION
Add a certification="certified" filter to the default queryset

Issue: #214