### PR TITLE
Bump pulp-container to 2.0.0b2

### DIFF
--- a/CHANGES/131.misc
+++ b/CHANGES/131.misc
@@ -1,0 +1,1 @@
+Bump pulp-container version to 2.0.0b2

--- a/requirements/requirements.standalone.in
+++ b/requirements/requirements.standalone.in
@@ -1,1 +1,1 @@
-pulp-container==2.0.0b1
+pulp-container==2.0.0b2

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -14,7 +14,7 @@ attrs==19.3.0             # via aiohttp, galaxy-importer
 backoff==1.10.0           # via pulpcore
 bleach-whitelist==0.0.10  # via galaxy-importer
 bleach==3.1.5             # via galaxy-importer
-certifi==2020.4.5.1       # via galaxy-ng (setup.py), requests
+certifi==2020.4.5.2       # via galaxy-ng (setup.py), requests
 cffi==1.14.0              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via dynaconf, rq
@@ -34,14 +34,13 @@ drf-yasg==1.17.1          # via pulpcore
 dynaconf==2.2.3           # via pulpcore
 ecdsa==0.13.3             # via pulp-container
 et-xmlfile==1.0.1         # via openpyxl
-flake8==3.8.2             # via galaxy-importer
+flake8==3.8.3             # via galaxy-importer
 future==0.18.2            # via pyjwkest
 galaxy-importer==0.2.4    # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.9                 # via idna-ssl, requests, yarl
-importlib-metadata==1.6.0  # via flake8, markdown
-inflection==0.4.0         # via drf-yasg
+idna==2.9                 # via requests, yarl
+importlib-metadata==1.6.1  # via flake8, markdown
+inflection==0.5.0         # via drf-yasg
 itypes==1.2.0             # via coreapi
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via ansible, coreschema
@@ -56,7 +55,7 @@ packaging==20.4           # via bleach, drf-yasg, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
 psycopg2==2.8.5           # via pulpcore
 pulp-ansible==0.2.0b13    # via galaxy-ng (setup.py)
-pulp-container==2.0.0b1   # via -r requirements/requirements.standalone.in
+pulp-container==2.0.0b2   # via -r requirements/requirements.standalone.in
 pulpcore==3.4.1           # via galaxy-ng (setup.py), pulp-ansible, pulp-container
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
@@ -83,8 +82,6 @@ six==1.15.0               # via ansible-lint, bleach, cryptography, drf-yasg, ga
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
 toml==0.10.1              # via dynaconf
-typing-extensions==3.7.4.2  # via aiohttp
-typing==3.7.4.1           # via aiodns
 uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.25.9           # via galaxy-ng (setup.py), requests
 webencodings==0.5.1       # via bleach


### PR DESCRIPTION
Bump pulp-container version to pulp-container==2.0.0b2.  `docker push` and `docker pull` functionality tested successfully.