### PR TITLE
Fix for bad multipart posts workaround got rm, readd

### DIFF
--- a/CHANGES/256.bugfix
+++ b/CHANGES/256.bugfix
@@ -1,0 +1,1 @@
+Add back workaround for multipart forms from ansible-galaxy.

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -44,8 +44,7 @@ from galaxy_ng.app.tasks import (
     remove_content_from_repository,
 )
 
-# hmm, not sure what to do with this
-# from galaxy_ng.app.common.parsers import AnsibleGalaxy29MultiPartParser
+from galaxy_ng.app.common.parsers import AnsibleGalaxy29MultiPartParser
 
 
 log = logging.getLogger(__name__)
@@ -139,6 +138,7 @@ class CollectionUploadViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionU
     permission_classes = GALAXY_PERMISSION_CLASSES + [
         permissions.IsNamespaceOwner
     ]
+    parser_classes = [AnsibleGalaxy29MultiPartParser]
 
     def _dispatch_import_collection_task(self, artifact_pk, repository=None, **kwargs):
         """Dispatch a pulp task started on upload of collection version."""


### PR DESCRIPTION
In the move to use the pulp viewsets, the previous
workaround for ansible/galaxy-dev#246 didn't
get added back. That was added in 035371f819a168b
but got removed in 1245d37bf5.

So, add it back.

This manifests itself with older versions of ansible-galaxy
on 'publish'. If the server doesn't workaround the multipart
parser, the sha256 value in the body will be ignored, and
cause 400 errors about the sha256sum mismatch.