### PR TITLE
Make password change clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ The following is a simple quickstart for installing a local Galaxy server. It re
 
 3. Create a playbook called `install.yml` that contains the following:
 
-    * **Warning**: please change the `pulp_default_admin_password`  (Initial password for the Pulp admin).
+    * **Warning**: please change the value of `pulp_default_admin_password` (initial password for the Pulp admin user). Note the
+      example playbook below requires setting the value in each play, so there are 2 spots where it will need to be changed.
 
     ```
     - hosts: all
       vars:
+        pulp_default_admin_password: password
         pulp_settings:
           secret_key: secret
           content_origin: "http://{{ ansible_fqdn }}"
@@ -52,7 +54,6 @@ The following is a simple quickstart for installing a local Galaxy server. It re
           x_pulp_api_prefix: "pulp_ansible/galaxy/automation-hub/api"
           galaxy_require_content_approval: "False"
           pulp_token_auth_disabled: "True"
-        pulp_default_admin_password: password
         pulp_install_plugins:
           pulp-ansible: {}
           galaxy-ng: {}


### PR DESCRIPTION
- Move password var to the top
- Updates the note, pointing out that there are 2 places where the var must be set.