### PR TITLE
README: Make call to pulp_redis explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following is a simple quickstart for installing a local Galaxy server. It re
         pulp_api_workers: 4
       roles:
         - pulp_database
+        - pulp_redis
         - pulp_workers
         - pulp_resource_manager
         - pulp_webserver


### PR DESCRIPTION
Earlier today in `pulp/pulp_installer`
https://github.com/pulp/pulp_installer/pull/332 got merged. This leads
to one having to specify the pulp_redis role explicitly.

It has a WIKI Impact