### PR TITLE
Support query by repo for _ui CollectionVersionViewSet

### DIFF
--- a/CHANGES/118.misc
+++ b/CHANGES/118.misc
@@ -1,0 +1,1 @@
+Support query by repo for _ui CollectionVersionViewSet

--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -57,12 +57,15 @@ class CollectionMetadataSerializer(Serializer):
     license = serializers.ListField(serializers.CharField())
     tags = serializers.SerializerMethodField()
 
-    def get_tags(self, metadata):
-        return [tag['name'] for tag in metadata['tags']]
+    def get_tags(self, collection_version):
+        # TODO(awcrosby): remove when galaxy_pulp no longer used in _ui
+        if isinstance(collection_version, dict):
+            return [tag['name'] for tag in collection_version['tags']]
+
+        return [tag.name for tag in collection_version.tags.all()]
 
 
 class CollectionVersionBaseSerializer(Serializer):
-    id = serializers.UUIDField()
     namespace = serializers.CharField()
     name = serializers.CharField()
     version = serializers.CharField()

--- a/galaxy_ng/tests/unit/api/test_api_ui_collectionversion_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_collectionversion_viewsets.py
@@ -1,0 +1,80 @@
+import urllib
+
+from django.test import override_settings
+from django.urls import reverse
+from pulp_ansible.app.models import AnsibleDistribution, AnsibleRepository, Collection, CollectionVersion
+
+from galaxy_ng.app import models
+from galaxy_ng.app.constants import DeploymentMode
+from .base import BaseTestCase
+
+
+@override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value)
+class TestUiCollectionVersionViewSet(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.versions_url = reverse('galaxy:api:v3:ui:collection-versions-list')
+        self.namespace = models.Namespace.objects.create(name='my_namespace')
+        self.collection = Collection.objects.create(namespace=self.namespace, name='my_collection')
+        self._create_version_in_repo('1.1.1', self._create_repo(name='repo1'))
+        self._create_version_in_repo('1.1.2', self._create_repo(name='repo2'))
+
+    @staticmethod
+    def _create_repo(name):
+        repo = AnsibleRepository.objects.create(name=name)
+        AnsibleDistribution.objects.create(name=name, base_path=name, repository=repo)
+        return repo
+
+    def _create_version_in_repo(self, version, repo):
+        collection_version = CollectionVersion.objects.create(
+            namespace=self.namespace,
+            collection=self.collection,
+            version=version,
+        )
+        qs = CollectionVersion.objects.filter(pk=collection_version.pk)
+        with repo.new_version() as new_version:
+            new_version.add_content(qs)
+
+    def _versions_url_with_params(self, query_params):
+        return self.versions_url + '?' + urllib.parse.urlencode(query_params)
+
+    def test_no_filters(self):
+        response = self.client.get(self.versions_url)
+        self.assertEqual(response.data['meta']['count'], 2)
+
+    def test_repo_filter(self):
+        url = self._versions_url_with_params({'repository': 'repo_dne'})
+        response = self.client.get(url)
+        self.assertEqual(response.data['meta']['count'], 0)
+
+        url = self._versions_url_with_params({'repository': 'repo1'})
+        response = self.client.get(url)
+        self.assertEqual(response.data['meta']['count'], 1)
+        self.assertEqual(response.data['data'][0]['version'], '1.1.1')
+
+    def test_multiple_filters(self):
+        url = self._versions_url_with_params({
+            'namespace': 'namespace_dne',
+            'version': '1.1.2',
+            'repository': 'repo2',
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.data['meta']['count'], 0)
+
+        url = self._versions_url_with_params({
+            'namespace': 'my_namespace',
+            'version': '1.1.2',
+            'repository': 'repo2',
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.data['meta']['count'], 1)
+        self.assertEqual(response.data['data'][0]['version'], '1.1.2')
+
+    def test_sort(self):
+        url = self._versions_url_with_params({'sort': 'pulp_created'})
+        response = self.client.get(url)
+        self.assertEqual(response.data['data'][0]['version'], '1.1.1')
+
+        url = self._versions_url_with_params({'sort': '-pulp_created'})
+        response = self.client.get(url)
+        self.assertEqual(response.data['data'][0]['version'], '1.1.2')


### PR DESCRIPTION
Closes-Issue: #118
* Adds query by repo
* Removes the use of galaxy_pulp for list() and retrieve()

With this, the UI can make these changes to the Certification Dashboard (#119):
* Change query parameter used from `certification` to `repository`
* Change approval collection version api call from `certification/` to `move/` (#140)

This leaves the certification/ endpoint working until the UI stops using it
