### PR TITLE
Fix wrong href's in results from collection viewsets

### DIFF
--- a/CHANGES/247.bugfix
+++ b/CHANGES/247.bugfix
@@ -1,0 +1,1 @@
+Fix wrong href's in results from collection viewsets

--- a/galaxy_ng/app/api/v3/serializers/__init__.py
+++ b/galaxy_ng/app/api/v3/serializers/__init__.py
@@ -1,5 +1,7 @@
 from .collection import (
+    CollectionSerializer,
     CollectionVersionSerializer,
+    CollectionVersionListSerializer,
     CollectionUploadSerializer,
 )
 
@@ -13,7 +15,9 @@ from .group import (
 )
 
 __all__ = (
+    'CollectionSerializer',
     'CollectionVersionSerializer',
+    'CollectionVersionListSerializer',
     'CollectionUploadSerializer',
     'GroupSummarySerializer',
     'NamespaceSerializer',

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -21,22 +21,22 @@ urlpatterns = [
     path(
         'collections/',
         viewsets.CollectionViewSet.as_view({'get': 'list'}),
-        name='collection-list'
+        name='collections-list'
     ),
     path(
         'collections/<str:namespace>/<str:name>/',
         viewsets.CollectionViewSet.as_view({'get': 'retrieve', 'put': 'update'}),
-        name='collection'
+        name='collections-detail'
     ),
     path(
         'collections/<str:namespace>/<str:name>/versions/',
         viewsets.CollectionVersionViewSet.as_view({'get': 'list'}),
-        name='collection-version-list',
+        name='collection-versions-list',
     ),
     path(
         'collections/<str:namespace>/<str:name>/versions/<str:version>/',
         viewsets.CollectionVersionViewSet.as_view({'get': 'retrieve'}),
-        name='collection-version',
+        name='collection-versions-detail',
     ),
     path(
         'imports/collections/<str:pk>/',


### PR DESCRIPTION
The pulp_ansible viewsets build hrefs by reverse() on the
pulp_ansible url name. But the galaxy_ng names are different
and include url namespaces ('galaxy:api:v3:collection' for ex).

Makes collection api endpoints serialize correctly, with the various
href's pointing to the right places. That includes:

  1. Not pointing to the pulp hrefs
  1. pointing to either the default-content endpoint or the per-repo
endpoints

Update the collection url 'names' so that suffix matches the
upstream pulp names exactly (sanes url namespace)

Add custom collection Serializer's that uses view_namespace for url reverse.

Add a serializers.collections.HrefNamespaceMixin to use
with the galaxy_ng subclasses of collection related
pulp_ansible.app.galaxy Serializers.

Update the collection related viewsets to use the new
viewsets.

Add a ViewNamespaceSerializerContextMixin to mixin
with the collection viewset. This provides a
get_serializer_context that adds 'view_namespace'
and 'view_route' info to the context, so the various
href serializer methods will generate the correct urls.

Issue: #247