### PR TITLE
Add sort last_name for User

### DIFF
--- a/galaxy_ng/app/api/ui/viewsets/user.py
+++ b/galaxy_ng/app/api/ui/viewsets/user.py
@@ -17,13 +17,14 @@ class UserFilter(filterset.FilterSet):
             ('username', 'username'),
             ('email', 'email'),
             ('first_name', 'first_name'),
+            ('last_name', 'last_name'),
             ('date_joined', 'date_joined')
         )
     )
 
     class Meta:
         model = auth_models.User
-        fields = ('username', 'email', 'first_name', 'date_joined')
+        fields = ('username', 'email', 'first_name', 'last_name', 'date_joined')
 
 
 class UserViewSet(


### PR DESCRIPTION
##### SUMMARY
Cannot sort Users by `last_name` via API

##### STEPS TO REPRODUCE
Call `http://0.0.0.0:8002/api/automation-hub/v3/_ui/users/?sort=-last_name&offset=0&limit=10`

##### Before
Returns `400` with
```
{"errors":[{"status":"400","code":"invalid_choice","title":"Invalid input.","detail":"Select a valid choice. -last_name is not one of the available choices.","source":{"parameter":"sort"}}]}
```

##### After
Returns `200` and sorted data like it does for `first_name, username, email`


@newswangerd Please have a look, thanks :)