### PR TITLE
Add repository_list to data returned in _ui collection-version endpoint

### DIFF
--- a/CHANGES/288.misc
+++ b/CHANGES/288.misc
@@ -1,0 +1,1 @@
+Add repository_list to ui collection version endpoint

--- a/galaxy_ng/tests/unit/api/test_api_ui_collectionversion_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_collectionversion_viewsets.py
@@ -70,11 +70,13 @@ class TestUiCollectionVersionViewSet(BaseTestCase):
         self.assertEqual(response.data['meta']['count'], 1)
         self.assertEqual(response.data['data'][0]['version'], '1.1.2')
 
-    def test_sort(self):
+    def test_sort_and_repo_list(self):
         url = self._versions_url_with_params({'sort': 'pulp_created'})
         response = self.client.get(url)
         self.assertEqual(response.data['data'][0]['version'], '1.1.1')
+        self.assertEqual(response.data['data'][0]['repository_list'], ['repo1'])
 
         url = self._versions_url_with_params({'sort': '-pulp_created'})
         response = self.client.get(url)
         self.assertEqual(response.data['data'][0]['version'], '1.1.2')
+        self.assertEqual(response.data['data'][0]['repository_list'], ['repo2'])


### PR DESCRIPTION
For the certification dashboard, add a `repository_list` field to the _ui collection-version endpoint.

This field includes a `Repository` if the `CollectionVersion` is included in the latest `RepositoryVersion`


An example:
```
"repository_list": [
    "automation-hub",
    "org-my_org"
]
```