### PR TITLE
Content Sync: On content change in the golden repo, replicate in all org repos

### DIFF
--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -285,7 +285,13 @@ class CollectionVersionMoveViewSet(ViewSet):
             settings.GALAXY_DEPLOYMENT_MODE == DeploymentMode.INSIGHTS.value and
             dest_repo == AnsibleRepository.objects.get(name='automation-hub')  # use constant or param
         ):
-            dispatch_copy_to_org_repos(collection_version)
+            dispatch_tasks_to_org_repos(collection_version, action='add')
+
+        if (
+            settings.GALAXY_DEPLOYMENT_MODE == DeploymentMode.INSIGHTS.value and
+            src_repo == AnsibleRepository.objects.get(name='automation-hub')  # use constant or param
+        ):
+            dispatch_tasks_to_org_repos(collection_version, action='remove')
 
         return Response(
             data={

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -281,6 +281,12 @@ class CollectionVersionMoveViewSet(ViewSet):
         add_task = self._add_content(collection_version, dest_repo)
         remove_task = self._remove_content(collection_version, src_repo)
 
+        if (
+            settings.GALAXY_DEPLOYMENT_MODE == DeploymentMode.INSIGHTS.value and
+            dest_repo == AnsibleRepository.objects.get(name='automation-hub')  # use constant or param
+        ):
+            dispatch_copy_to_org_repos(collection_version)
+
         return Response(
             data={
                 'add_task_id': add_task.id,

--- a/galaxy_ng/app/tasks/promotion.py
+++ b/galaxy_ng/app/tasks/promotion.py
@@ -28,8 +28,8 @@ def remove_content_from_repository(collection_version_pk, repository_pk):
         new_version.remove_content(qs)
 
 
-def dispatch_copy_to_org_repos(collection_version_pk):
-    """Starts tasks to copy CollectionVersion to org repos.
+def dispatch_tasks_to_org_repos(collection_version_pk, action):
+    """Starts tasks to add/remove CollectionVersion to/from org repos.
     Method to start tasks, not a task itself."""
 
     # get all org distros
@@ -44,11 +44,17 @@ def dispatch_copy_to_org_repos(collection_version_pk):
     except KeyError:
         pass
 
-    # filter out repos with this Collection in their denylist
-    # TODO ^
+    if action == 'remove':
+        for repo in org_repos:
+            locks = [repo]
+            task_args = (collection_version_pk, repo.pk)
+            enqueue_with_reservation(remove_content_from_repository, locks, args=task_args)
+    elif action == 'add':
+        # filter out repos with this Collection in their denylist
+        # TODO ^
 
-    # dispatch copy tasks
-    for repo in org_repos:
-        locks = [repo]
-        task_args = (collection_version_pk, repo.pk)
-        enqueue_with_reservation(add_content_to_repository, locks, args=task_args)
+        # dispatch copy tasks
+        for repo in org_repos:
+            locks = [repo]
+            task_args = (collection_version_pk, repo.pk)
+            enqueue_with_reservation(add_content_to_repository, locks, args=task_args)

--- a/galaxy_ng/app/tasks/promotion.py
+++ b/galaxy_ng/app/tasks/promotion.py
@@ -1,4 +1,5 @@
-from pulp_ansible.app.models import AnsibleRepository, CollectionVersion
+from pulpcore.plugin.tasking import enqueue_with_reservation
+from pulp_ansible.app.models import AnsibleRepository, AnsibleDistribution, CollectionVersion
 
 
 def add_content_to_repository(collection_version_pk, repository_pk):
@@ -25,3 +26,29 @@ def remove_content_from_repository(collection_version_pk, repository_pk):
     qs = CollectionVersion.objects.filter(pk=collection_version_pk)
     with repository.new_version() as new_version:
         new_version.remove_content(qs)
+
+
+def dispatch_copy_to_org_repos(collection_version_pk):
+    """Starts tasks to copy CollectionVersion to org repos.
+    Method to start tasks, not a task itself."""
+
+    # get all org distros
+    # TODO: replace with correct convention, regex in constants?
+    org_distros = AnsibleDistribution.objects.filter(name__startswith='org-')
+
+    # filter out distros which point to golden repo
+    golden = AnsibleRepository.objects.get(name='automation-hub')  # use constant or param
+    org_repos = set([d.repository for d in org_distros])
+    try:
+        org_repos.remove(golden)
+    except KeyError:
+        pass
+
+    # filter out repos with this Collection in their denylist
+    # TODO ^
+
+    # dispatch copy tasks
+    for repo in org_repos:
+        locks = [repo]
+        task_args = (collection_version_pk, repo.pk)
+        enqueue_with_reservation(add_content_to_repository, locks, args=task_args)


### PR DESCRIPTION
Works #285 

In Insights mode, when a `CollectionVersion` is added to or removed from the golden repo, the same action should be replicated in the appropriate org repos.

A `CollectionVersion` promoted to the golden repo via the `CollectionVersion` `move/` endpoint will kick off N tasks to add the `CollectionVersion` to N org repos. Where N is the number of org repos where the parent `Collection` is not on the org's denylist.

A `CollectionVersion` removed from the golden repo via the `CollectionVersion` `move/` endpoint will kick off N tasks to remove the `CollectionVersion` from N org repos. Where N is the total number of org repos.

The Certification Dashboard uses the CollectionVersion `move/` endpoint