### PR TITLE
Remove static naming for pulp worker

### DIFF
--- a/docker/bin/start-worker
+++ b/docker/bin/start-worker
@@ -4,9 +4,8 @@ set -o errexit
 set -o nounset
 
 
-readonly WORKER_NAME='worker'
 readonly WORKER_CLASS='pulpcore.tasking.worker.PulpWorker'
 readonly WORKER_CONFIG='pulpcore.rqconfig'
 
 
-exec rq worker -n "${WORKER_NAME}" -w "${WORKER_CLASS}" -c "${WORKER_CONFIG}"
+exec rq worker -w "${WORKER_CLASS}" -c "${WORKER_CONFIG}"


### PR DESCRIPTION
Pulp worker were deployed with pre-defined name to avoid
stalled tasks. However this issue is not reproducible
at current pulpcore version.

References:

[1] https://pulp.plan.io/issues/7119

No-Issue