### PR TITLE
Add repo name params and task to move from inbound to staging repo

### DIFF
--- a/CHANGES/117.feature
+++ b/CHANGES/117.feature
@@ -1,0 +1,1 @@
+After successful import move collection version from incoming repo to staging repo

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -16,7 +16,6 @@ from rest_framework.exceptions import APIException, NotFound
 
 from pulpcore.plugin.models import ContentArtifact, Task
 from pulpcore.plugin.tasking import enqueue_with_reservation
-from pulp_ansible.app.tasks.collections import import_collection
 from pulp_ansible.app.galaxy.v3 import views as pulp_ansible_views
 from pulp_ansible.app.models import CollectionVersion, AnsibleDistribution
 
@@ -39,6 +38,7 @@ from galaxy_ng.app.api.v3.serializers import (
 
 from galaxy_ng.app.common import metrics
 from galaxy_ng.app.tasks import (
+    import_and_move_to_staging,
     import_and_auto_approve,
     add_content_to_repository,
     remove_content_from_repository,
@@ -149,7 +149,7 @@ class CollectionUploadViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionU
             kwargs["repository_pk"] = repository.pk
 
         if settings.GALAXY_REQUIRE_CONTENT_APPROVAL == 'True':
-            return enqueue_with_reservation(import_collection, locks, kwargs=kwargs)
+            return enqueue_with_reservation(import_and_move_to_staging, locks, kwargs=kwargs)
         return enqueue_with_reservation(import_and_auto_approve, locks, kwargs=kwargs)
 
     # Wrap super().create() so we can create a galaxy_ng.app.models.CollectionImport based on the

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -30,6 +30,9 @@ STATIC_URL = "/static/"
 # created by the initial-data.json data fixture
 GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH = "automation-hub"
 
+GALAXY_API_STAGING_DISTRIBUTION_BASE_PATH = "staging"
+GALAXY_API_REJECTED_DISTRIBUTION_BASE_PATH = "rejected"
+
 # Require approval for incoming content,
 # currently using a certification flag,
 # later using a staging repository

--- a/galaxy_ng/app/tasks/__init__.py
+++ b/galaxy_ng/app/tasks/__init__.py
@@ -1,3 +1,3 @@
-from .publishing import import_and_auto_approve  # noqa: F401
+from .publishing import import_and_move_to_staging, import_and_auto_approve  # noqa: F401
 from .promotion import add_content_to_repository, remove_content_from_repository  # noqa: F401
 # from .synchronizing import synchronize  # noqa

--- a/galaxy_ng/app/tasks/publishing.py
+++ b/galaxy_ng/app/tasks/publishing.py
@@ -1,11 +1,49 @@
 import logging
 
-from pulp_ansible.app.tasks.collections import import_collection
+from django.conf import settings
 from pulpcore.plugin.models import ContentArtifact
+from pulpcore.plugin.tasking import enqueue_with_reservation
+from pulp_ansible.app.models import AnsibleRepository
+from pulp_ansible.app.tasks.collections import import_collection
+
+from .promotion import add_content_to_repository, remove_content_from_repository
 
 log = logging.getLogger(__name__)
 
 VERSION_CERTIFIED = "certified"
+
+golden_name = settings.GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH
+staging_name = settings.GALAXY_API_STAGING_DISTRIBUTION_BASE_PATH
+
+
+def import_and_move_to_staging(artifact_pk, **kwargs):
+    """Import collection version and move to staging repository.
+
+    Custom task to call pulp_ansible's import_collection() task then
+    enqueue two tasks to add to staging repo and remove from inbound repo.
+
+    This task will not wait for the enqueued tasks to finish.
+    """
+    inbound_repository_pk = kwargs.get('repository_pk')
+    import_collection(artifact_pk=artifact_pk, repository_pk=inbound_repository_pk)
+
+    content_artifact = ContentArtifact.objects.get(artifact_id=artifact_pk)
+    collection_version = content_artifact.content.ansible_collectionversion
+
+    # enqueue task to add collection_version to staging repo
+    try:
+        staging_repo = AnsibleRepository.objects.get(name=staging_name)
+    except AnsibleRepository.DoesNotExist:
+        raise RuntimeError(f'Could not find staging repository: "{staging_name}"')
+    locks = [staging_repo]
+    task_args = (collection_version.pk, staging_repo.pk)
+    enqueue_with_reservation(add_content_to_repository, locks, args=task_args)
+
+    # enqueue task to remove collection_verion from inbound repo
+    inbound_repo = AnsibleRepository.objects.get(pk=inbound_repository_pk)
+    locks = [inbound_repo]
+    task_args = (collection_version.pk, inbound_repository_pk)
+    enqueue_with_reservation(remove_content_from_repository, locks, args=task_args)
 
 
 def import_and_auto_approve(artifact_pk, **kwargs):


### PR DESCRIPTION
Closes-Issue: #117

Adds custom task to call pulp_ansible import_collection, then
enqueues tasks to move CollectionVersion from whichever repository
it is coming into, to the staging repository.

Adds names for staging repo and rejected repo to settings.