### PR TITLE
Add task view for certification dashboard, update move permission

### DIFF
--- a/CHANGES/295.feature
+++ b/CHANGES/295.feature
@@ -1,0 +1,1 @@
+Add endpoint to get status of pulp tasks

--- a/galaxy_ng/app/api/v3/serializers/__init__.py
+++ b/galaxy_ng/app/api/v3/serializers/__init__.py
@@ -14,6 +14,11 @@ from .group import (
     GroupSummarySerializer,
 )
 
+from .task import (
+    TaskSerializer,
+)
+
+
 __all__ = (
     'CollectionSerializer',
     'CollectionVersionSerializer',
@@ -22,4 +27,5 @@ __all__ = (
     'GroupSummarySerializer',
     'NamespaceSerializer',
     'NamespaceSummarySerializer',
+    'TaskSerializer',
 )

--- a/galaxy_ng/app/api/v3/serializers/task.py
+++ b/galaxy_ng/app/api/v3/serializers/task.py
@@ -1,0 +1,15 @@
+import logging
+
+from rest_framework import serializers
+
+from galaxy_ng.app.api.ui.serializers.base import Serializer
+
+log = logging.getLogger(__name__)
+
+
+class TaskSerializer(Serializer):
+    pulp_id = serializers.UUIDField(source='pk')
+    name = serializers.CharField()
+    state = serializers.CharField()
+    started_at = serializers.DateTimeField()
+    finished_at = serializers.DateTimeField()

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -59,4 +59,14 @@ urlpatterns = [
         viewsets.CollectionVersionMoveViewSet.as_view({'post': 'move_content'}),
         name='collection-version-move',
     ),
+    path(
+        'tasks/',
+        viewsets.TaskViewSet.as_view({'get': 'list'}),
+        name='tasks-list'
+    ),
+    path(
+        'tasks/<str:pk>/',
+        viewsets.TaskViewSet.as_view({'get': 'retrieve'}),
+        name='tasks-detail'
+    ),
 ]

--- a/galaxy_ng/app/api/v3/viewsets/__init__.py
+++ b/galaxy_ng/app/api/v3/viewsets/__init__.py
@@ -11,6 +11,10 @@ from .namespace import (
     NamespaceViewSet,
 )
 
+from .task import (
+    TaskViewSet,
+)
+
 
 __all__ = (
     'CollectionArtifactDownloadView',
@@ -20,4 +24,5 @@ __all__ = (
     'CollectionVersionViewSet',
     'CollectionVersionMoveViewSet',
     'NamespaceViewSet',
+    'TaskViewSet',
 )

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -242,7 +242,7 @@ class CollectionArtifactDownloadView(APIView):
 
 class CollectionVersionMoveViewSet(ViewSet):
     permission_classes = GALAXY_PERMISSION_CLASSES + [
-        permissions.IsNamespaceOwner
+        permissions.IsPartnerEngineer
     ]
 
     def move_content(self, request, *args, **kwargs):

--- a/galaxy_ng/app/api/v3/viewsets/task.py
+++ b/galaxy_ng/app/api/v3/viewsets/task.py
@@ -1,0 +1,14 @@
+import logging
+
+from pulpcore.plugin import viewsets as pulp_core_viewsets
+
+from galaxy_ng.app.api.base import GALAXY_PERMISSION_CLASSES, LocalSettingsMixin
+from galaxy_ng.app.api.v3.serializers import TaskSerializer
+
+
+log = logging.getLogger(__name__)
+
+
+class TaskViewSet(LocalSettingsMixin, pulp_core_viewsets.TaskViewSet):
+    permission_classes = GALAXY_PERMISSION_CLASSES
+    serializer_class = TaskSerializer


### PR DESCRIPTION
Closes-Issue: #295

Add task view for certification dashboard to get status of pulp tasks
on CollectionVersion move. Also useful for other pulp tasks such as
importing, moving repos on import, and sync

Update CollectionVersion move endpoint permission to be same as
certification dashboard

Example endpoints:
```
http://localhost:5001/api/automation-hub/v3/tasks/
http://localhost:5001/api/automation-hub/v3/tasks/acc6fea7-12c2-48fb-b6c5-85f1a3237404/
```