### PR TITLE
Update development pulp data fixture with staging and rejected repos

### DIFF
--- a/dev/automation-hub/initial_data.json
+++ b/dev/automation-hub/initial_data.json
@@ -33,7 +33,7 @@
       "pulp_last_updated": "2020-03-12T15:56:19.072Z",
       "pulp_type": "ansible.ansible",
       "name": "automation-hub",
-      "description": null,
+      "description": "Default repository, the source of downloads",
       "next_version": 1
     }
   },
@@ -72,6 +72,106 @@
     "pk": "64bbf7a5-841a-4b0b-a17b-70cc1e6eea16",
     "fields": {
       "repository": "20ab43ad-24ee-4868-8127-88a9ab590317",
+      "repository_version": null
+    }
+  },
+  {
+    "model": "core.repository",
+    "pk": "f35b9f02-30cd-4b44-8977-ddc7edab074c",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:19.071Z",
+      "pulp_last_updated": "2020-03-12T15:56:19.072Z",
+      "pulp_type": "ansible.ansible",
+      "name": "staging",
+      "description": "Repository where newly imported content lands",
+      "next_version": 1
+    }
+  },
+  {
+    "model": "core.repositoryversion",
+    "pk": "e5c504e0-d9b3-40d2-9904-023a01464f50",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:19.075Z",
+      "pulp_last_updated": "2020-03-12T15:56:19.075Z",
+      "repository": "f35b9f02-30cd-4b44-8977-ddc7edab074c",
+      "number": 0,
+      "complete": true,
+      "base_version": null
+    }
+  },
+  {
+    "model": "core.basedistribution",
+    "pk": "37d96e76-c99e-4797-abe3-3a4894a9a5d3",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:23.436Z",
+      "pulp_last_updated": "2020-03-12T15:56:23.436Z",
+      "pulp_type": "ansible.ansible",
+      "name": "staging",
+      "base_path": "staging",
+      "content_guard": null,
+      "remote": null
+    }
+  },
+  {
+    "model": "ansible.ansiblerepository",
+    "pk": "f35b9f02-30cd-4b44-8977-ddc7edab074c",
+    "fields": {}
+  },
+  {
+    "model": "ansible.ansibledistribution",
+    "pk": "37d96e76-c99e-4797-abe3-3a4894a9a5d3",
+    "fields": {
+      "repository": "f35b9f02-30cd-4b44-8977-ddc7edab074c",
+      "repository_version": null
+    }
+  },
+  {
+    "model": "core.repository",
+    "pk": "787d4137-c9cf-4b26-b66a-aea0e3b6b433",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:19.071Z",
+      "pulp_last_updated": "2020-03-12T15:56:19.072Z",
+      "pulp_type": "ansible.ansible",
+      "name": "rejected",
+      "description": "Repository with content rejected via certifiaction dashboard",
+      "next_version": 1
+    }
+  },
+  {
+    "model": "core.repositoryversion",
+    "pk": "4cee928d-0bc3-4ab4-9260-746c39e0bb69",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:19.075Z",
+      "pulp_last_updated": "2020-03-12T15:56:19.075Z",
+      "repository": "787d4137-c9cf-4b26-b66a-aea0e3b6b433",
+      "number": 0,
+      "complete": true,
+      "base_version": null
+    }
+  },
+  {
+    "model": "core.basedistribution",
+    "pk": "d6469579-c8ea-42b9-8c4c-477861a940ed",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:23.436Z",
+      "pulp_last_updated": "2020-03-12T15:56:23.436Z",
+      "pulp_type": "ansible.ansible",
+      "name": "rejected",
+      "base_path": "rejected",
+      "content_guard": null,
+      "remote": null
+    }
+  },
+  {
+    "model": "ansible.ansiblerepository",
+    "pk": "787d4137-c9cf-4b26-b66a-aea0e3b6b433",
+    "fields": {}
+  },
+  {
+    "model": "ansible.ansibledistribution",
+    "pk": "d6469579-c8ea-42b9-8c4c-477861a940ed",
+    "fields": {
+      "repository": "787d4137-c9cf-4b26-b66a-aea0e3b6b433",
       "repository_version": null
     }
   }


### PR DESCRIPTION
Have development fixtures automatically create a `staging` and `rejected` repo, in addition to the `automation-hub` repo. After this, wiki manual steps will need to be updated.

Related-Issue: #117