### PR TITLE
Add unit test command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,15 @@ DOCKER_IMAGE_NAME = localhost/galaxy_ng/galaxy_ng
 
 
 .PHONY: help
-help:
+help:             ## Show the help.
 	@echo "Usage: make <target>"
 	@echo ""
 	@echo "Targets:"
-	@echo "requirements                Update python dependencies lock files (i.e. requirements.txt)."
-	@echo ""
-	@echo "Docker targets:"
-	@echo "docker/build                Build all development images."
+	@fgrep "##" Makefile | fgrep -v fgrep
 
 
 .PHONY: requirements
-requirements:
+requirements:     ## Update python dependencies lock files (i.e. requirements.txt).
 	pip-compile -U -o requirements/requirements.common.txt \
 		setup.py
 	pip-compile -U -o requirements/requirements.standalone.txt \
@@ -23,5 +20,10 @@ requirements:
 
 
 .PHONY: docker/build
-docker/build:
+docker/build:     ## Build all development images.
 	./compose build
+
+
+.PHONY: docker/test
+docker/test:      ## Run unit tests.
+	./compose run api manage test galaxy_ng.tests.unit


### PR DESCRIPTION
No-Issue

```
galaxy_ng$ make help 
Usage: make <target>

Targets:
help:             ## Show the help.
requirements:     ## Update python dependencies lock files (i.e. requirements.txt).
docker/build:     ## Build all development images.
docker/test:      ## Run unit tests.
galaxy_ng$
```