### PR TITLE
Update import_and_auto_approve task to use pulp repos

### DIFF
--- a/CHANGES/316.feature
+++ b/CHANGES/316.feature
@@ -1,0 +1,1 @@
+Use pulp repos to denote approved content on auto-approval

--- a/galaxy_ng/app/tasks/publishing.py
+++ b/galaxy_ng/app/tasks/publishing.py
@@ -12,8 +12,8 @@ log = logging.getLogger(__name__)
 
 VERSION_CERTIFIED = "certified"
 
-golden_name = settings.GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH
-staging_name = settings.GALAXY_API_STAGING_DISTRIBUTION_BASE_PATH
+GOLDEN_NAME = settings.GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH
+STAGING_NAME = settings.GALAXY_API_STAGING_DISTRIBUTION_BASE_PATH
 
 
 def import_and_move_to_staging(artifact_pk, **kwargs):
@@ -32,9 +32,9 @@ def import_and_move_to_staging(artifact_pk, **kwargs):
 
     # enqueue task to add collection_version to staging repo
     try:
-        staging_repo = AnsibleRepository.objects.get(name=staging_name)
+        staging_repo = AnsibleRepository.objects.get(name=STAGING_NAME)
     except AnsibleRepository.DoesNotExist:
-        raise RuntimeError(f'Could not find staging repository: "{staging_name}"')
+        raise RuntimeError(f'Could not find staging repository: "{STAGING_NAME}"')
     locks = [staging_repo]
     task_args = (collection_version.pk, staging_repo.pk)
     enqueue_with_reservation(add_content_to_repository, locks, args=task_args)
@@ -52,12 +52,27 @@ def import_and_auto_approve(artifact_pk, **kwargs):
     Custom task to call pulp_ansible's import_collection() task
     then automatically approve collection version so no
     manual approval action needs to occur.
-
-    Approval currently is a collection version certification flag
-    Approval later will be moving from a staging to an approved repo
     """
-    import_collection(artifact_pk=artifact_pk, repository_pk=kwargs.get('repository_pk', None))
+    inbound_repository_pk = kwargs.get('repository_pk')
+    import_collection(artifact_pk=artifact_pk, repository_pk=inbound_repository_pk)
     content_artifact = ContentArtifact.objects.get(artifact_id=artifact_pk)
     collection_version = content_artifact.content.ansible_collectionversion
+
+    # FIXME: remove when no longer using certification flag
     collection_version.certification = VERSION_CERTIFIED
     collection_version.save()
+
+    # enqueue task to add collection_version to golden repo
+    try:
+        golden_repo = AnsibleRepository.objects.get(name=GOLDEN_NAME)
+    except AnsibleRepository.DoesNotExist:
+        raise RuntimeError(f'Could not find golden repository: "{GOLDEN_NAME}"')
+    locks = [golden_repo]
+    task_args = (collection_version.pk, golden_repo.pk)
+    enqueue_with_reservation(add_content_to_repository, locks, args=task_args)
+
+    # enqueue task to remove collection_verion from inbound repo
+    inbound_repo = AnsibleRepository.objects.get(pk=inbound_repository_pk)
+    locks = [inbound_repo]
+    task_args = (collection_version.pk, inbound_repository_pk)
+    enqueue_with_reservation(remove_content_from_repository, locks, args=task_args)


### PR DESCRIPTION
Closes-Issue: #316

* On GALAXY_REQUIRE_CONTENT_APPROVAL=False edit the auto approve task to
  use pulp repos to automatically promote content to golden repo