### PR TITLE
Fix auto certification parameter check

### DIFF
--- a/CHANGES/318.bugfix
+++ b/CHANGES/318.bugfix
@@ -1,0 +1,1 @@
+Fixed bug in auto certification parameter check, that caused all submitted content being automatically approved.

--- a/dev/standalone/galaxy_ng.env
+++ b/dev/standalone/galaxy_ng.env
@@ -4,7 +4,7 @@ PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
 PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication']
 PULP_GALAXY_PERMISSION_CLASSES=['rest_framework.permissions.IsAuthenticated']
 PULP_GALAXY_DEPLOYMENT_MODE=standalone
-PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=False
+PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false
 PULP_RH_ENTITLEMENT_REQUIRED=insights
 
 PULP_ANSIBLE_API_HOSTNAME=http://localhost:5001

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -148,7 +148,7 @@ class CollectionUploadViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionU
             locks.append(repository)
             kwargs["repository_pk"] = repository.pk
 
-        if settings.GALAXY_REQUIRE_CONTENT_APPROVAL == 'True':
+        if settings.GALAXY_REQUIRE_CONTENT_APPROVAL:
             return enqueue_with_reservation(import_and_move_to_staging, locks, kwargs=kwargs)
         return enqueue_with_reservation(import_and_auto_approve, locks, kwargs=kwargs)
 


### PR DESCRIPTION
Fix usage of parameter `settings.GALAXY_REQUIRE_CONTENT_APPROVAL`
that disables content auto approval.

Closes-Issue: #318