### PR TITLE
Updating and fixing the CI

### DIFF
--- a/.travis/Containerfile.j2
+++ b/.travis/Containerfile.j2
@@ -1,4 +1,4 @@
-FROM pulp/pulp-ci:latest
+FROM {{ ci_base | default("pulp/pulp-ci:latest") }}
 
 {% if s3_test | default(false) %}
 # Hacking botocore (https://github.com/boto/botocore/pull/1990)

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -9,6 +9,9 @@
 
 set -mveuo pipefail
 
+mkdir .travis/vars || true
+echo "---" > .travis/vars/main.yaml
+
 export PRE_BEFORE_INSTALL=$TRAVIS_BUILD_DIR/.travis/pre_before_install.sh
 export POST_BEFORE_INSTALL=$TRAVIS_BUILD_DIR/.travis/post_before_install.sh
 
@@ -30,11 +33,13 @@ then
   export PULP_SMASH_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-smash\/pull\/(\d+)' | awk -F'/' '{print $7}')
   export PULP_OPENAPI_GENERATOR_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
   export PULP_ANSIBLE_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp_ansible\/pull\/(\d+)' | awk -F'/' '{print $7}')
+  echo $COMMIT_MSG | sed -n -e 's/.*CI Base Image:\s*\([-_/[:alnum:]]*:[-_[:alnum:]]*\).*/ci_base: "\1"/p' >> .travis/vars/main.yaml
 else
   export PULPCORE_PR_NUMBER=
   export PULP_SMASH_PR_NUMBER=
   export PULP_OPENAPI_GENERATOR_PR_NUMBER=
   export PULP_ANSIBLE_PR_NUMBER=
+  export CI_BASE_IMAGE=
 fi
 
 # dev_requirements contains tools needed for flake8, etc.

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -18,6 +18,10 @@ if [[ -f $PRE_BEFORE_SCRIPT ]]; then
   source $PRE_BEFORE_SCRIPT
 fi
 
+# Developers should be able to reproduce the containers with this config
+echo "CI vars:"
+tail -v -n +1 .travis/vars/main.yaml
+
 # Developers often want to know the final pulp config
 echo "PULP CONFIG:"
 tail -v -n +1 .travis/settings/settings.* ~/.config/pulp_smash/settings.json

--- a/.travis/build_container.yaml
+++ b/.travis/build_container.yaml
@@ -11,7 +11,6 @@
         dest: Containerfile
 
     - name: "Build pulp image"
-      docker_image:
       # We build from the ../.. (parent dir of pulpcore git repo) Docker build
       # "context" so that repos like pulp-smash are accessible to Docker
       # build. So that PR branches can be used via relative paths.
@@ -20,15 +19,7 @@
       # 1-off-builds and Travis CI purposes (which has no cache across CI runs.)
       # Run build.yaml with -e cache=false if your builds are using outdated
       # layers.
-        name: "{{ image.name }}"
-        tag: "{{ image.tag }}"
-        build:
-          path: "../.."
-          dockerfile: "{{ playbook_dir }}/Containerfile"
-          nocache: "{{ not cache | default(true) | bool }}"
-          pull: false
-        state: present
-        source: build
+      command: "docker build --network host --no-cache={{ not cache | default(true) | bool }} -t {{ image.name }}:{{ image.tag }} -f {{ playbook_dir }}/Containerfile ../.."
 
     - name: "Clean image cache"
       docker_prune:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -50,13 +50,10 @@ if [ -e $TRAVIS_BUILD_DIR/../pulp_ansible ]; then
 else
   PULP_ANSIBLE=git+https://github.com/pulp/pulp_ansible.git@master
 fi
-
-mkdir vars
 if [ -n "$TRAVIS_TAG" ]; then
   # Install the plugin only and use published PyPI packages for the rest
   # Quoting ${TAG} ensures Ansible casts the tag as a string.
-  cat > vars/main.yaml << VARSYAML
----
+  cat >> vars/main.yaml << VARSYAML
 image:
   name: pulp
   tag: "${TAG}"
@@ -74,8 +71,7 @@ services:
       - ./settings:/etc/pulp
 VARSYAML
 else
-  cat > vars/main.yaml << VARSYAML
----
+  cat >> vars/main.yaml << VARSYAML
 image:
   name: pulp
   tag: "${TAG}"

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -24,7 +24,7 @@ export PULP_SETTINGS=$TRAVIS_BUILD_DIR/.travis/settings/settings.py
 
 if [ "$TEST" = "docs" ]; then
   cd docs
-  make html
+  make PULP_URL="http://pulp" html
   cd ..
 
   if [ -f $POST_DOCS_TEST ]; then
@@ -72,6 +72,10 @@ fi
 
 cat unittest_requirements.txt | cmd_stdin_prefix bash -c "cat > /tmp/unittest_requirements.txt"
 cmd_prefix pip3 install -r /tmp/unittest_requirements.txt
+
+# check for any uncommitted migrations
+echo "Checking for uncommitted migrations..."
+cmd_prefix bash -c "django-admin makemigrations --check --dry-run"
 
 # Run unit tests.
 cmd_prefix bash -c "PULP_DATABASES__default__USER=postgres django-admin test --noinput /usr/local/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/galaxy_ng/tests/unit/"

--- a/.travis/start_container.yaml
+++ b/.travis/start_container.yaml
@@ -67,14 +67,19 @@
         state: present
       when: s3_test | default(false)
 
-    - name: "Wait for Pulp"
-      uri:
-        url: "http://pulp/pulp/api/v3/status/"
-        follow_redirects: none
-      register: result
-      until: result.status == 200
-      retries: 6
-      delay: 5
+    - block:
+        - name: "Wait for Pulp"
+          uri:
+            url: "http://pulp/pulp/api/v3/status/"
+            follow_redirects: none
+          register: result
+          until: result.status == 200
+          retries: 6
+          delay: 5
+      rescue:
+        - name: "Output pulp container log"
+          command: "docker logs pulp"
+          failed_when: true
 
 - hosts: pulp
   gather_facts: false

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend, OrderingFilter
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework.decorators import action as drf_action
 from pulp_ansible.app.models import AnsibleDistribution, CollectionVersion, Collection
 from rest_framework.exceptions import NotFound
@@ -161,8 +161,8 @@ class CollectionVersionViewSet(api_base.GenericViewSet):
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 
-    @swagger_auto_schema(operation_summary="Retrieve collection version",
-                         responses={200: serializers.CollectionVersionDetailSerializer})
+    @extend_schema(summary="Retrieve collection version",
+                   responses={200: serializers.CollectionVersionDetailSerializer})
     def retrieve(self, request, *args, **kwargs):
         namespace, name, version = self.kwargs['version'].split('/')
         try:
@@ -244,8 +244,8 @@ class CollectionImportViewSet(api_base.GenericViewSet):
             results.append(data)
         return self.get_paginated_response(results)
 
-    @swagger_auto_schema(operation_summary="Retrieve collection import",
-                         responses={200: serializers.ImportTaskDetailSerializer})
+    @extend_schema(summary="Retrieve collection import",
+                   responses={200: serializers.ImportTaskDetailSerializer})
     def retrieve(self, request, *args, **kwargs):
         api = galaxy_pulp.GalaxyImportsApi(pulp.get_client())
         task = self.get_object()

--- a/galaxy_ng/app/api/v3/viewsets/namespace.py
+++ b/galaxy_ng/app/api/v3/viewsets/namespace.py
@@ -50,9 +50,9 @@ class NamespaceViewSet(api_base.ModelViewSet):
 
     def get_permissions(self):
         permission_list = super().get_permissions()
-        if self.request.method == 'POST':
+        if self.request and self.request.method == 'POST':
             permission_list.append(permissions.IsPartnerEngineer())
-        elif self.request.method == 'PUT':
+        elif self.request and self.request.method == 'PUT':
             permission_list.append(permissions.IsNamespaceOwnerOrPartnerEngineer())
 
         return permission_list

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ galaxy_pulp_requirements = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python
 
 requirements = galaxy_pulp_requirements + [
     "Django~=2.2.3",
-    "pulpcore>=3.4,<3.5",
+    "pulpcore>=3.4",
     "pulp-ansible>=0.2.0b13",
     "django-prometheus>=2.0.0",
 ]


### PR DESCRIPTION
- Making build errors easier to see
- Removing pulpcore upper bound
- OpenAPI v3 with drf-spectacular

Problem:
```
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/usr/local/lib/python3.7/site-packages/pulp_ansible/app/viewsets.py", line 18, in <module>
        from pulpcore.plugin.models import PulpTemporaryFile
    ImportError: cannot import name 'PulpTemporaryFile' from 'pulpcore.plugin.models' (/usr/local/lib/python3.7/site-packages/pulpcore/plugin/models/__init__.py)
```

Solution:
Removing pulpcore upper bound

Alternative: https://github.com/ansible/galaxy_ng/pull/321