### PR TITLE
Pinning to latest pulpcore, pulp-ansible and pulp-container

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -101,7 +101,7 @@ if [ -z "$TRAVIS_TAG" ]; then
 fi
 
 
-git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch master
+git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.2.0 
 if [ -n "$PULP_ANSIBLE_PR_NUMBER" ]; then
   cd pulp_ansible
   git fetch --depth=1 origin pull/$PULP_ANSIBLE_PR_NUMBER/head:$PULP_ANSIBLE_PR_NUMBER

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -45,11 +45,6 @@ else
   TAG=$(git rev-parse --abbrev-ref HEAD | tr / _)
 fi
 
-if [ -e $TRAVIS_BUILD_DIR/../pulp_ansible ]; then
-  PULP_ANSIBLE=./pulp_ansible
-else
-  PULP_ANSIBLE=git+https://github.com/pulp/pulp_ansible.git@master
-fi
 if [ -n "$TRAVIS_TAG" ]; then
   # Install the plugin only and use published PyPI packages for the rest
   # Quoting ${TAG} ensures Ansible casts the tag as a string.
@@ -81,7 +76,7 @@ plugins:
   - name: galaxy_ng
     source: ./galaxy_ng
   - name: pulp_ansible
-    source: $PULP_ANSIBLE
+    source: ./pulp_ansible
 services:
   - name: pulp
     image: "pulp:${TAG}"

--- a/CHANGES/380.feature
+++ b/CHANGES/380.feature
@@ -1,0 +1,1 @@
+Pin to pulpcore 3.6.0, pulp-ansible 0.2.0 and pulp-container 2.0.0

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -7,36 +7,38 @@
 aiodns==2.0.0             # via pulpcore
 aiofiles==0.5.0           # via pulpcore
 aiohttp==3.6.2            # via pulpcore
-ansible-lint==4.2.0       # via galaxy-importer
-ansible==2.9.11           # via ansible-lint, galaxy-importer
+ansible-lint==4.3.0       # via galaxy-importer
+ansible==2.9.12           # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
 bleach-whitelist==0.0.11  # via galaxy-importer
 bleach==3.1.5             # via galaxy-importer
 certifi==2020.6.20        # via galaxy-ng (setup.py), requests
-cffi==1.14.1              # via cryptography, pycares
+cffi==1.14.2              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
 cryptography==3.0         # via ansible
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
+django-currentuser==0.5.1  # via pulpcore
 django-filter==2.3.0      # via pulpcore
+django-guardian==2.3.0    # via pulpcore
 django-import-export==2.3.0  # via pulpcore
+django-lifecycle==0.7.7   # via pulpcore
 django-prometheus==2.0.0  # via galaxy-ng (setup.py)
-django==2.2.15            # via django-filter, django-import-export, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django==2.2.15            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
 djangorestframework==3.10.3  # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.6.2  # via pulpcore
 drf-nested-routers==0.91  # via pulpcore
 drf-spectacular==0.9.12   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.0.0           # via pulpcore
+dynaconf==3.1.0           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.8rc10  # via pulp-ansible
+galaxy-importer==0.2.7    # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via flake8, jsonschema, markdown
+idna==2.10                # via requests, yarl
 inflection==0.5.0         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via ansible
@@ -51,6 +53,8 @@ openpyxl==3.0.4           # via tablib
 packaging==20.4           # via bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
 psycopg2==2.8.5           # via pulpcore
+pulp-ansible==0.2.0       # via galaxy-ng (setup.py)
+pulpcore==3.6.0           # via galaxy-ng (setup.py), pulp-ansible
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
@@ -68,19 +72,17 @@ rq==1.5.0                 # via pulpcore
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via ansible-lint
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via ansible-lint, bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyrsistent, python-dateutil
+six==1.15.0               # via bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyrsistent, python-dateutil
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.2  # via aiohttp, yarl
-typing==3.7.4.3           # via aiodns
 uritemplate==3.0.1        # via drf-spectacular
 urllib3==1.25.10          # via galaxy-ng (setup.py), requests
+urlman==1.3.0             # via django-lifecycle
 webencodings==0.5.1       # via bleach
 whitenoise==5.2.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 yarl==1.5.1               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -4,45 +4,45 @@
 #
 #    pip-compile --output-file=requirements/requirements.insights.txt requirements/requirements.insights.in setup.py
 #
--e git+https://github.com/pulp/pulp_ansible.git@master#egg=pulp_ansible  # via -r requirements/requirements.insights.in, galaxy-ng (setup.py)
--e git+https://github.com/pulp/pulpcore.git@master#egg=pulpcore  # via -r requirements/requirements.insights.in, galaxy-ng (setup.py), pulp-ansible
 aiodns==2.0.0             # via pulpcore
 aiofiles==0.5.0           # via pulpcore
 aiohttp==3.6.2            # via pulpcore
-ansible-lint==4.2.0       # via galaxy-importer
-ansible==2.9.11           # via ansible-lint, galaxy-importer
+ansible-lint==4.3.0       # via galaxy-importer
+ansible==2.9.12           # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
 bleach-whitelist==0.0.11  # via galaxy-importer
 bleach==3.1.5             # via galaxy-importer
-boto3==1.14.34            # via -r requirements/requirements.insights.in, django-storages, watchtower
-botocore==1.17.34         # via boto3, s3transfer
+boto3==1.14.45            # via -r requirements/requirements.insights.in, django-storages, watchtower
+botocore==1.17.45         # via boto3, s3transfer
 certifi==2020.6.20        # via galaxy-ng (setup.py), requests
-cffi==1.14.1              # via cryptography, pycares
+cffi==1.14.2              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
 cryptography==3.0         # via ansible
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
+django-currentuser==0.5.1  # via pulpcore
 django-filter==2.3.0      # via pulpcore
+django-guardian==2.3.0    # via pulpcore
 django-import-export==2.3.0  # via pulpcore
+django-lifecycle==0.7.7   # via pulpcore
 django-prometheus==2.0.0  # via galaxy-ng (setup.py)
 django-storages[boto3]==1.9.1  # via -r requirements/requirements.insights.in
-django==2.2.15            # via django-filter, django-import-export, django-storages, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django==2.2.15            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, django-storages, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
 djangorestframework==3.10.3  # via drf-nested-routers, drf-spectacular, pulpcore
 docutils==0.15.2          # via botocore
+drf-access-policy==0.6.2  # via pulpcore
 drf-nested-routers==0.91  # via pulpcore
 drf-spectacular==0.9.12   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.0.0           # via pulpcore
+dynaconf==3.1.0           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.8rc10  # via pulp-ansible
+galaxy-importer==0.2.7    # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via flake8, jsonschema, markdown
+idna==2.10                # via requests, yarl
 inflection==0.5.0         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via ansible
@@ -59,6 +59,8 @@ openpyxl==3.0.4           # via tablib
 packaging==20.4           # via bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
 psycopg2==2.8.5           # via pulpcore
+pulp-ansible==0.2.0       # via galaxy-ng (setup.py)
+pulpcore==3.6.0           # via galaxy-ng (setup.py), pulp-ansible
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
@@ -77,20 +79,18 @@ ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via ansible-lint
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via ansible-lint, bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyrsistent, python-dateutil
+six==1.15.0               # via bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyrsistent, python-dateutil
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.2  # via aiohttp, yarl
-typing==3.7.4.3           # via aiodns
 uritemplate==3.0.1        # via drf-spectacular
 urllib3==1.25.10          # via botocore, galaxy-ng (setup.py), requests
+urlman==1.3.0             # via django-lifecycle
 watchtower==0.8.0         # via -r requirements/requirements.insights.in
 webencodings==0.5.1       # via bleach
 whitenoise==5.2.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 yarl==1.5.1               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.standalone.in
+++ b/requirements/requirements.standalone.in
@@ -1,1 +1,1 @@
--e git+https://github.com/pulp/pulp-container.git@master#egg=pulp-container  # via galaxy-ng (setup.py), pulp-ansible, pulp-container
+pulp-container~=2.0.0

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -4,44 +4,43 @@
 #
 #    pip-compile --output-file=requirements/requirements.standalone.txt requirements/requirements.standalone.in setup.py
 #
--e git+https://github.com/pulp/pulp_ansible.git@master#egg=pulp_ansible  # via -r requirements/requirements.standalone.in, galaxy-ng (setup.py)
--e git+https://github.com/pulp/pulpcore.git@master#egg=pulpcore  # via -r requirements/requirements.standalone.in, galaxy-ng (setup.py), pulp-ansible, pulp-container
--e git+https://github.com/pulp/pulp_container.git@master#egg=pulp_container  # via -r requirements/requirements.standalone.in, galaxy-ng (setup.py), pulp-ansible, pulp-container
 aiodns==2.0.0             # via pulpcore
 aiofiles==0.5.0           # via pulpcore
 aiohttp==3.6.2            # via pulpcore
-ansible-lint==4.2.0       # via galaxy-importer
-ansible==2.9.11           # via ansible-lint, galaxy-importer
+ansible-lint==4.3.0       # via galaxy-importer
+ansible==2.9.12           # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
 bleach-whitelist==0.0.11  # via galaxy-importer
 bleach==3.1.5             # via galaxy-importer
 certifi==2020.6.20        # via galaxy-ng (setup.py), requests
-cffi==1.14.1              # via cryptography, pycares
+cffi==1.14.2              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
 cryptography==3.0         # via ansible, pyjwt
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
+django-currentuser==0.5.1  # via pulpcore
 django-filter==2.3.0      # via pulpcore
+django-guardian==2.3.0    # via pulpcore
 django-import-export==2.3.0  # via pulpcore
+django-lifecycle==0.7.7   # via pulpcore
 django-prometheus==2.0.0  # via galaxy-ng (setup.py)
-django==2.2.15            # via django-filter, django-import-export, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django==2.2.15            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
 djangorestframework==3.10.3  # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.6.2  # via pulpcore
 drf-nested-routers==0.91  # via pulpcore
 drf-spectacular==0.9.12   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.0.0           # via pulpcore
+dynaconf==3.1.0           # via pulpcore
 ecdsa==0.13.3             # via pulp-container
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
 future==0.18.2            # via pyjwkest
-galaxy-importer==0.2.8rc10  # via pulp-ansible
+galaxy-importer==0.2.7    # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via flake8, jsonschema, markdown
+idna==2.10                # via requests, yarl
 inflection==0.5.0         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via ansible
@@ -56,6 +55,9 @@ openpyxl==3.0.4           # via tablib
 packaging==20.4           # via bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
 psycopg2==2.8.5           # via pulpcore
+pulp-ansible==0.2.0       # via galaxy-ng (setup.py)
+pulp-container==2.0.0     # via -r requirements/requirements.standalone.in
+pulpcore==3.6.0           # via galaxy-ng (setup.py), pulp-ansible, pulp-container
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
@@ -76,19 +78,18 @@ rq==1.5.0                 # via pulpcore
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via ansible-lint
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via ansible-lint, bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyjwkest, pyrsistent, python-dateutil
+six==1.15.0               # via bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyjwkest, pyrsistent, python-dateutil, url-normalize
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.2  # via aiohttp, yarl
-typing==3.7.4.3           # via aiodns
 uritemplate==3.0.1        # via drf-spectacular
+url-normalize==1.4.2      # via pulp-container
 urllib3==1.25.10          # via galaxy-ng (setup.py), requests
+urlman==1.3.0             # via django-lifecycle
 webencodings==0.5.1       # via bleach
 whitenoise==5.2.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 yarl==1.5.1               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,8 @@ galaxy_pulp_requirements = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python
 
 requirements = galaxy_pulp_requirements + [
     "Django~=2.2.3",
-    "pulpcore @ git+https://github.com/pulp/pulpcore.git@master#egg=pulpcore",
-    "pulp_ansible @ git+https://github.com/pulp/pulp_ansible.git@master#egg=pulp_ansible",
-    "pulp_container @ git+https://github.com/pulp/pulp_container.git@master#egg=pulp_container",
+    "pulpcore~=3.6.0",
+    "pulp-ansible~=0.2.0",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
 ]


### PR DESCRIPTION
Now that all the Pulp features needed for 4.2.0b are released, we can pin to the latest packages. Reverses the work done in #330.

Closes-Issue: #380