### PR TITLE
Set galaxy-importer back to 0.2.8rc10

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -36,7 +36,7 @@ drf-spectacular==0.9.12   # via galaxy-ng (setup.py), pulpcore
 dynaconf==3.1.0           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.7    # via pulp-ansible
+galaxy-importer==0.2.8rc10  # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna==2.10                # via requests, yarl
 inflection==0.5.0         # via drf-spectacular

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -40,7 +40,7 @@ drf-spectacular==0.9.12   # via galaxy-ng (setup.py), pulpcore
 dynaconf==3.1.0           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.7    # via pulp-ansible
+galaxy-importer==0.2.8rc10  # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna==2.10                # via requests, yarl
 inflection==0.5.0         # via drf-spectacular

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -38,7 +38,7 @@ ecdsa==0.13.3             # via pulp-container
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
 future==0.18.2            # via pyjwkest
-galaxy-importer==0.2.7    # via pulp-ansible
+galaxy-importer==0.2.8rc10  # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna==2.10                # via requests, yarl
 inflection==0.5.0         # via drf-spectacular

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -36,7 +36,7 @@ ecdsa==0.13.3             # via pulp-container
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.2             # via galaxy-importer
 future==0.18.2            # via pyjwkest
-galaxy-importer==0.2.4    # via pulp-ansible
+galaxy-importer==0.2.8rc10  # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via idna-ssl, requests, yarl


### PR DESCRIPTION
No-Issue

Undoing the version change `galaxy-importer` from `0.2.8rc10` to `0.2.7` done in 3c3924f