### PR TITLE
Remove v3 CollectionVersion certified flag filter

### DIFF
--- a/CHANGES/120.feature
+++ b/CHANGES/120.feature
@@ -1,0 +1,1 @@
+Remove v3 api CollectionVersion certified flag filter

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -81,13 +81,6 @@ class CollectionVersionViewSet(LocalSettingsMixin,
     serializer_class = CollectionVersionSerializer
     permission_classes = [access_policy.CollectionAccessPolicy]
 
-    # FIXME(akl): This can be removed when we move to multiple repos for managing "certifiaction"
-    def get_queryset(self):
-        """
-        Returns a CollectionVersions queryset for specified distribution filtering on certification.
-        """
-        return super().get_queryset().filter(certification="certified")
-
     # TODO: This is cut&paste from pulp_ansible_views.CollectionVersionViewSet.list, so
     #       the serializer class can be overridden. Should be able to remove this
     #       once pulp_ansible serializers use something like _get_href that names


### PR DESCRIPTION
Related-Issue: #120

With the certified flag on a CollectionVersion no longer denoting
whether or not the version is certfied, the filter is being removed from
the CollectionVersionViewSet.

Signed-off-by: Andrew Crosby <acrosby@redhat.com>