### PR TITLE
Resolve dep issues in pulp-ansible and galaxy-importer

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -35,7 +35,7 @@ drf-yasg==1.17.1          # via pulpcore
 dynaconf==2.2.3           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.2             # via galaxy-importer
-galaxy-importer==0.2.8rc9  # via pulp-ansible
+galaxy-importer==0.2.8rc12  # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via idna-ssl, requests, yarl

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -39,7 +39,7 @@ drf-yasg==1.17.1          # via pulpcore
 dynaconf==2.2.3           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.2             # via galaxy-importer
-galaxy-importer==0.2.8rc9  # via pulp-ansible
+galaxy-importer==0.2.8rc12  # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via idna-ssl, requests, yarl

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -37,7 +37,7 @@ ecdsa==0.13.3             # via pulp-container
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
 future==0.18.2            # via pyjwkest
-galaxy-importer==0.2.8rc9  # via pulp-ansible
+galaxy-importer==0.2.8rc12  # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via idna-ssl, requests, yarl

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -36,7 +36,7 @@ ecdsa==0.13.3             # via pulp-container
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.2             # via galaxy-importer
 future==0.18.2            # via pyjwkest
-galaxy-importer==0.2.4    # via pulp-ansible
+galaxy-importer==0.2.8rc12  # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via idna-ssl, requests, yarl

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ galaxy_pulp_requirements = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python
 requirements = galaxy_pulp_requirements + [
     "Django~=2.2.3",
     "pulpcore~=3.5.0",
-    "pulp-ansible>=0.2.0b13",
+    "pulp-ansible==0.2.0b15",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
 ]


### PR DESCRIPTION
No-Issue

* pulp-ansible was pinned as ">=" which used latest and had a version
conflict with our pulpcore pinned to 3.5 in stable.
* galaxy-importer used old attrs which conflicted with travis build

Signed-off-by: Andrew Crosby <acrosby@redhat.com>