### PR TITLE
Add docs_blob to v3 api for collection versions

### DIFF
--- a/CHANGES/403.bugfix
+++ b/CHANGES/403.bugfix
@@ -1,0 +1,1 @@
+Add docs_blob to v3 api for collection versions

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -39,6 +39,11 @@ urlpatterns = [
         name='collection-versions-detail',
     ),
     path(
+        'collections/<str:namespace>/<str:name>/versions/<str:version>/docs-blob/',
+        viewsets.CollectionVersionDocsViewSet.as_view({'get': 'retrieve'}),
+        name='collection-versions-detail-docs',
+    ),
+    path(
         'imports/collections/<str:pk>/',
         viewsets.CollectionImportViewSet.as_view({'get': 'retrieve'}),
         name='collection-import',

--- a/galaxy_ng/app/api/v3/viewsets/__init__.py
+++ b/galaxy_ng/app/api/v3/viewsets/__init__.py
@@ -4,6 +4,7 @@ from .collection import (
     CollectionUploadViewSet,
     CollectionViewSet,
     CollectionVersionViewSet,
+    CollectionVersionDocsViewSet,
     CollectionVersionMoveViewSet,
 )
 
@@ -22,6 +23,7 @@ __all__ = (
     'CollectionUploadViewSet',
     'CollectionViewSet',
     'CollectionVersionViewSet',
+    'CollectionVersionDocsViewSet',
     'CollectionVersionMoveViewSet',
     'NamespaceViewSet',
     'TaskViewSet',

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -123,6 +123,10 @@ class CollectionVersionViewSet(LocalSettingsMixin,
         return Response(serializer.data)
 
 
+class CollectionVersionDocsViewSet(pulp_ansible_views.CollectionVersionDocsViewSet):
+    pass
+
+
 class CollectionImportViewSet(LocalSettingsMixin, pulp_ansible_views.CollectionImportViewSet):
     permission_classes = [access_policy.CollectionAccessPolicy]
 


### PR DESCRIPTION
Closes-Issue: #403

Add endpoint `v3/collections/<namespace>/<collection>/versions/<version_number>/docs-blob/` by subclassing pulp_ansible view

~~- Add `docs_blob_url` to: `v3/collections/<namespace>/<collection>/versions/<version_number>/`~~