### PR TITLE
Add api endpoint for starting collection syncs.

### DIFF
--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -58,6 +58,12 @@ STANDALONE_STATEMENTS = {
             "action": ["list"],
             "principal": "authenticated",
             "effect": "allow"
+        },
+        {
+            "action": ["sync"],
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:ansible.update_ansible_remote"
         }
     ],
     'UserViewSet': [

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -19,6 +19,11 @@ auth_urls = [
 
 urlpatterns = [
     path(
+        'sync/',
+        views.SyncRemoteView.as_view(),
+        name="sync"
+    ),
+    path(
         'collections/',
         viewsets.CollectionViewSet.as_view({'get': 'list'}),
         name='collections-list'

--- a/galaxy_ng/app/api/v3/views/__init__.py
+++ b/galaxy_ng/app/api/v3/views/__init__.py
@@ -1,4 +1,4 @@
 from .auth import TokenView
+from .sync import SyncRemoteView
 
-
-__all__ = ("TokenView",)
+__all__ = ("TokenView", "SyncRemoteView")

--- a/galaxy_ng/app/api/v3/views/sync.py
+++ b/galaxy_ng/app/api/v3/views/sync.py
@@ -1,0 +1,61 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError
+
+from django.shortcuts import get_object_or_404
+
+from pulp_ansible.app import models as pulp_models
+from pulp_ansible.app.tasks.collections import sync as collection_sync
+
+from pulpcore.plugin.tasking import enqueue_with_reservation
+from pulpcore.plugin.models import Task
+
+from galaxy_ng.app.api import base as api_base
+from galaxy_ng.app.access_control import access_policy
+from galaxy_ng.app import models
+
+
+class SyncRemoteView(api_base.APIView):
+    permission_classes = [access_policy.CollectionRemoteAccessPolicy]
+    action = 'sync'
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        distro_path = kwargs['path']
+        distro = get_object_or_404(pulp_models.AnsibleDistribution, base_path=distro_path)
+
+        if not distro.repository or not distro.repository.remote:
+            raise ValidationError(
+                detail={'remote': f'The {distro_path} distribution does not have'
+                                  ' any remotes associated with it.'})
+
+        remote = distro.repository.remote
+
+        # check if the user is pulling from api v2 (galaxy.ansible.com)
+        # if no requirements file is set, prevent the sync from happening
+        if 'api/v2' in remote.url and not remote.requirements_file:
+            raise ValidationError(
+                detail={
+                    'requirements_file':
+                        'Syncing content from galaxy.ansible.com without specifying a'
+                        'requirements file is not allowed.'
+                })
+
+        result = enqueue_with_reservation(
+            collection_sync,
+            [distro.repository, remote],
+            kwargs={
+                "remote_pk": remote.pk,
+                "repository_pk": distro.repository.pk,
+                "mirror": False
+            },
+        )
+
+        repo = pulp_models.AnsibleRepository.objects.get(pk=distro.repository.pk)
+        task = Task.objects.get(pk=result.id)
+
+        models.CollectionSyncTask.objects.create(
+            repository=repo,
+            task=task
+        )
+
+        return Response({'task': task.pk})

--- a/galaxy_ng/app/models/__init__.py
+++ b/galaxy_ng/app/models/__init__.py
@@ -14,6 +14,10 @@ from .synclist import (
     SyncList,
 )
 
+from .collectionsync import (
+    CollectionSyncTask
+)
+
 __all__ = (
     'Group',
     'User',
@@ -21,4 +25,5 @@ __all__ = (
     'Namespace',
     'NamespaceLink',
     'SyncList',
+    'CollectionSyncTask'
 )


### PR DESCRIPTION
Add a `/api/automation-hub/content/<distribution>/v3/sync/` endpoint that allows users to start syncs on the collection remote attached to the specified distribution.

Syncs are kicked off with a `POST` request and return the ID of the task.

Response
```json
{
    "task": "3024deed-4df2-44c7-a3f1-a38124c6ccf7"
}
```