### PR TITLE
Add endpoints for sync/config management

### DIFF
--- a/CHANGES/282.feature
+++ b/CHANGES/282.feature
@@ -1,0 +1,1 @@
+Add endpoints to manage Content Sync for community and rh-certified repositories.

--- a/galaxy_ng/app/access_control/statements/insights.py
+++ b/galaxy_ng/app/access_control/statements/insights.py
@@ -51,9 +51,15 @@ INSIGHTS_STATEMENTS = {
     ],
     'CollectionRemoteViewSet': [
         {
-            "action": ["list"],
+            "action": ["list", "retrieve"],
             "principal": "authenticated",
             "effect": "allow"
+        },
+        {
+            "action": ["sync", "update", "partial_update"],
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:ansible.change_collectionremote"
         }
     ],
     'UserViewSet': [

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -55,9 +55,15 @@ STANDALONE_STATEMENTS = {
     ],
     'CollectionRemoteViewSet': [
         {
-            "action": ["list"],
+            "action": ["list", "retrieve"],
             "principal": "authenticated",
             "effect": "allow"
+        },
+        {
+            "action": ["sync", "update", "partial_update"],
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:ansible.change_collectionremote"
         }
     ],
     'UserViewSet': [

--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -212,6 +212,10 @@ class CollectionRemoteSerializer(serializers.ModelSerializer):
             'updated_at',
             'last_sync_task'
         )
+        extra_kwargs = {
+            'name': {'read_only': True},
+            'token': {'write_only': True},
+        }
 
     def get_last_sync_task(self, obj):
         """Gets last_sync_task from Pulp using remote->repository relation"""

--- a/galaxy_ng/app/api/ui/serializers/user.py
+++ b/galaxy_ng/app/api/ui/serializers/user.py
@@ -104,7 +104,8 @@ class CurrentUserSerializer(UserSerializer):
             'galaxy.add_namespace',
             'galaxy.change_namespace',
             'galaxy.upload_to_namespace',
-            'ansible.modify_ansible_repo_content'
+            'ansible.modify_ansible_repo_content',
+            'ansible.change_collectionremote',
         ])
 
     def get_model_permissions(self, obj):
@@ -113,6 +114,7 @@ class CurrentUserSerializer(UserSerializer):
             "upload_to_namespace": obj.has_perm('galaxy.upload_to_namespace'),
             "change_namespace": obj.has_perm('galaxy.change_namespace'),
             "move_collection": obj.has_perm('ansible.modify_ansible_repo_content'),
+            "change_remote": obj.has_perm('ansible.change_collectionremote'),
             "view_user": obj.has_perm('galaxy.view_user'),
             "delete_user": obj.has_perm('galaxy.delete_user'),
             "change_user": obj.has_perm('galaxy.change_user'),

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -14,6 +14,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
+from galaxy_ng.app.constants import VALID_DISTRO_NAMES
 from galaxy_ng.app import models
 from galaxy_ng.app.api import base as api_base
 from galaxy_ng.app.access_control import access_policy
@@ -314,7 +315,7 @@ class CollectionImportViewSet(api_base.GenericViewSet):
 
 
 class CollectionRemoteViewSet(api_base.ModelViewSet):
-    queryset = CollectionRemote.objects.filter(name__in=['rh-certified', 'community'])
+    queryset = CollectionRemote.objects.filter(name__in=VALID_DISTRO_NAMES)
     serializer_class = serializers.CollectionRemoteSerializer
 
     permission_classes = [access_policy.CollectionRemoteAccessPolicy]

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -14,7 +14,6 @@ from rest_framework.exceptions import NotFound
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
-from galaxy_ng.app.constants import VALID_DISTRO_NAMES
 from galaxy_ng.app import models
 from galaxy_ng.app.api import base as api_base
 from galaxy_ng.app.access_control import access_policy
@@ -315,7 +314,7 @@ class CollectionImportViewSet(api_base.GenericViewSet):
 
 
 class CollectionRemoteViewSet(api_base.ModelViewSet):
-    queryset = CollectionRemote.objects.filter(name__in=VALID_DISTRO_NAMES)
+    queryset = CollectionRemote.objects.all()
     serializer_class = serializers.CollectionRemoteSerializer
 
     permission_classes = [access_policy.CollectionRemoteAccessPolicy]

--- a/galaxy_ng/app/api/urls.py
+++ b/galaxy_ng/app/api/urls.py
@@ -35,6 +35,7 @@ content_v3_urlpatterns = [
     path("<str:path>/v3/",
          # include((v3_urls, app_name))),
          include(v3_urls)),
+    path("<str:path>/v3/", include(v3_urls.sync_urls)),
 ]
 
 content_urlpatterns = [

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -1,12 +1,18 @@
 from rest_framework import serializers
 from pulp_ansible.app.models import CollectionRemote
 from pulp_ansible.app.viewsets import CollectionRemoteSerializer
-from galaxy_ng.app.constants import COMMUNITY_DOMAINS, VALID_DISTRO_NAMES
+from galaxy_ng.app.constants import COMMUNITY_DOMAINS
 
 
 class SyncConfigSerializer(CollectionRemoteSerializer):
     created_at = serializers.DateTimeField(source='pulp_created', required=False)
     updated_at = serializers.DateTimeField(source='pulp_last_updated', required=False)
+    policy = serializers.ChoiceField(
+        choices=CollectionRemote.POLICY_CHOICES,
+        default=CollectionRemote.ON_DEMAND
+    )
+    token = serializers.CharField(allow_null=True, required=False, max_length=2000, write_only=True)
+    name = serializers.CharField(read_only=True)
 
     class Meta:
         model = CollectionRemote
@@ -14,6 +20,7 @@ class SyncConfigSerializer(CollectionRemoteSerializer):
             'name',
             'url',
             'auth_url',
+            'token',
             'policy',
             'requirements_file',
             'created_at',
@@ -21,24 +28,14 @@ class SyncConfigSerializer(CollectionRemoteSerializer):
         )
 
     def validate(self, data):
-        data = super().validate(data)
-        errors = {}
-        name = data['name']
-        requirements_file = data['requirements_file']
-        url = data['url']
-
-        if name not in VALID_DISTRO_NAMES:
-            errors['name'] = (
-                f'{name} is not a valid name, possible values are {VALID_DISTRO_NAMES}'
+        if not data['requirements_file'] and any(
+            [domain in data['url'] for domain in COMMUNITY_DOMAINS]
+        ):
+            raise serializers.ValidationError(
+                detail={
+                    'requirements_file':
+                        'Syncing content from community domains without specifying a '
+                        'requirements file is not allowed.'
+                }
             )
-
-        if not requirements_file and any([domain in url for domain in COMMUNITY_DOMAINS]):
-            errors['requirements_file'] = (
-                'Syncing content from community domains without specifying a '
-                'requirements file is not allowed.'
-            )
-
-        if errors:
-            raise serializers.ValidationError(detail=errors)
-
-        return data
+        return super().validate(data)

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -1,0 +1,44 @@
+from rest_framework import serializers
+from pulp_ansible.app.models import CollectionRemote
+from pulp_ansible.app.viewsets import CollectionRemoteSerializer
+from galaxy_ng.app.constants import COMMUNITY_DOMAINS, VALID_DISTRO_NAMES
+
+
+class SyncConfigSerializer(CollectionRemoteSerializer):
+    created_at = serializers.DateTimeField(source='pulp_created', required=False)
+    updated_at = serializers.DateTimeField(source='pulp_last_updated', required=False)
+
+    class Meta:
+        model = CollectionRemote
+        fields = (
+            'name',
+            'url',
+            'auth_url',
+            'policy',
+            'requirements_file',
+            'created_at',
+            'updated_at',
+        )
+
+    def validate(self, data):
+        data = super().validate(data)
+        errors = {}
+        name = data['name']
+        requirements_file = data['requirements_file']
+        url = data['url']
+
+        if name not in VALID_DISTRO_NAMES:
+            errors['name'] = (
+                f'{name} is not a valid name, possible values are {VALID_DISTRO_NAMES}'
+            )
+
+        if not requirements_file and any([domain in url for domain in COMMUNITY_DOMAINS]):
+            errors['requirements_file'] = (
+                'Syncing content from community domains without specifying a '
+                'requirements file is not allowed.'
+            )
+
+        if errors:
+            raise serializers.ValidationError(detail=errors)
+
+        return data

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -16,6 +16,19 @@ auth_urls = [
     path("auth/token/", views.TokenView.as_view(), name="auth-token"),
 ]
 
+# these are included in the base router so that they only appear under `content/<distro>/v3`
+sync_urls = [
+    # path(
+    #    "sync/",
+    #    SyncView...
+    #    name='sync'
+    # ),
+    path(
+        "sync/config/",
+        viewsets.SyncConfigViewSet.as_view({'get': 'retrieve', 'put': 'update'}),
+        name='sync-config'
+    )
+]
 
 urlpatterns = [
     path(

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -18,11 +18,11 @@ auth_urls = [
 
 # these are included in the base router so that they only appear under `content/<distro>/v3`
 sync_urls = [
-    # path(
-    #    "sync/",
-    #    SyncView...
-    #    name='sync'
-    # ),
+    path(
+        "sync/",
+        views.SyncRemoteView.as_view(),
+        name='sync'
+    ),
     path(
         "sync/config/",
         viewsets.SyncConfigViewSet.as_view({'get': 'retrieve', 'put': 'update'}),

--- a/galaxy_ng/app/api/v3/views/__init__.py
+++ b/galaxy_ng/app/api/v3/views/__init__.py
@@ -1,4 +1,5 @@
 from .auth import TokenView
+from .sync import SyncRemoteView
 
 
-__all__ = ("TokenView",)
+__all__ = ("TokenView", "SyncRemoteView")

--- a/galaxy_ng/app/api/v3/views/sync.py
+++ b/galaxy_ng/app/api/v3/views/sync.py
@@ -1,0 +1,62 @@
+from galaxy_ng.app.constants import COMMUNITY_DOMAINS
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError
+
+from django.shortcuts import get_object_or_404
+
+from pulp_ansible.app import models as pulp_models
+from pulp_ansible.app.tasks.collections import sync as collection_sync
+
+from pulpcore.plugin.tasking import enqueue_with_reservation
+from pulpcore.plugin.models import Task
+
+from galaxy_ng.app.api import base as api_base
+from galaxy_ng.app.access_control import access_policy
+from galaxy_ng.app import models
+
+
+class SyncRemoteView(api_base.APIView):
+    permission_classes = [access_policy.CollectionRemoteAccessPolicy]
+    action = 'sync'
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        distro_path = kwargs['path']
+        distro = get_object_or_404(pulp_models.AnsibleDistribution, base_path=distro_path)
+
+        if not distro.repository or not distro.repository.remote:
+            raise ValidationError(
+                detail={'remote': f'The {distro_path} distribution does not have'
+                                  ' any remotes associated with it.'})
+
+        remote = distro.repository.remote.ansible_collectionremote
+
+        if not remote.requirements_file and any(
+            [domain in remote.url for domain in COMMUNITY_DOMAINS]
+        ):
+            raise ValidationError(
+                detail={
+                    'requirements_file':
+                        'Syncing content from galaxy.ansible.com without specifying a '
+                        'requirements file is not allowed.'
+                })
+
+        result = enqueue_with_reservation(
+            collection_sync,
+            [distro.repository, remote],
+            kwargs={
+                "remote_pk": remote.pk,
+                "repository_pk": distro.repository.pk,
+                "mirror": False
+            },
+        )
+
+        repo = pulp_models.AnsibleRepository.objects.get(pk=distro.repository.pk)
+        task = Task.objects.get(pk=result.id)
+
+        models.CollectionSyncTask.objects.create(
+            repository=repo,
+            task=task
+        )
+
+        return Response({'task': task.pk})

--- a/galaxy_ng/app/api/v3/viewsets/__init__.py
+++ b/galaxy_ng/app/api/v3/viewsets/__init__.py
@@ -15,6 +15,8 @@ from .task import (
     TaskViewSet,
 )
 
+from .sync import SyncConfigViewSet
+
 
 __all__ = (
     'CollectionArtifactDownloadView',
@@ -24,5 +26,6 @@ __all__ = (
     'CollectionVersionViewSet',
     'CollectionVersionMoveViewSet',
     'NamespaceViewSet',
+    'SyncConfigViewSet',
     'TaskViewSet',
 )

--- a/galaxy_ng/app/api/v3/viewsets/sync.py
+++ b/galaxy_ng/app/api/v3/viewsets/sync.py
@@ -1,0 +1,21 @@
+from rest_framework import mixins
+from django.http import Http404
+from pulp_ansible.app.models import AnsibleDistribution
+from galaxy_ng.app.access_control import access_policy
+from galaxy_ng.app.api import base as api_base
+from ..serializers.sync import SyncConfigSerializer
+
+
+class SyncConfigViewSet(
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    api_base.GenericViewSet,
+):
+    serializer_class = SyncConfigSerializer
+    permission_classes = [access_policy.CollectionRemoteAccessPolicy]
+
+    def get_object(self):
+        distribution = AnsibleDistribution.objects.get(base_path=self.kwargs['path'])
+        if distribution and distribution.repository:
+            return distribution.repository.remote.ansible_collectionremote
+        raise Http404

--- a/galaxy_ng/app/constants.py
+++ b/galaxy_ng/app/constants.py
@@ -15,8 +15,6 @@ class DeploymentMode(enum.Enum):
 CURRENT_UI_API_VERSION = 'v1'
 ALL_UI_API_VERSION = {'v1': 'v1/'}
 
-VALID_DISTRO_NAMES = ("rh-certified", "community")
-
 COMMUNITY_DOMAINS = (
     'galaxy.ansible.com',
     'galaxy-dev.ansible.com',

--- a/galaxy_ng/app/constants.py
+++ b/galaxy_ng/app/constants.py
@@ -14,3 +14,11 @@ class DeploymentMode(enum.Enum):
 
 CURRENT_UI_API_VERSION = 'v1'
 ALL_UI_API_VERSION = {'v1': 'v1/'}
+
+VALID_DISTRO_NAMES = ("rh-certified", "community")
+
+COMMUNITY_DOMAINS = (
+    'galaxy.ansible.com',
+    'galaxy-dev.ansible.com',
+    'galaxy-qa.ansible.com',
+)

--- a/galaxy_ng/app/models/__init__.py
+++ b/galaxy_ng/app/models/__init__.py
@@ -14,6 +14,9 @@ from .synclist import (
     SyncList,
 )
 
+from .collectionsync import (
+    CollectionSyncTask
+)
 __all__ = (
     'Group',
     'User',
@@ -21,4 +24,5 @@ __all__ = (
     'Namespace',
     'NamespaceLink',
     'SyncList',
+    'CollectionSyncTask',
 )

--- a/galaxy_ng/tests/unit/api/base.py
+++ b/galaxy_ng/tests/unit/api/base.py
@@ -82,6 +82,9 @@ class BaseTestCase(APITestCase):
             'galaxy.change_synclist',
             'galaxy.view_synclist',
             'galaxy.add_synclist',
+
+            # sync config
+            'ansible.change_collectionremote',
         ]
         pe_group = auth_models.Group.objects.create(
             name='partner-engineers')

--- a/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
@@ -165,7 +165,6 @@ class TestUiCollectionRemoteViewSet(BaseTestCase):
         self.remote_data = {
             'name': 'rh-certified',
             'url': 'https://rh-certified.test',
-            'token': 'fff67131-3f46-4c0d-a54a-2b0243bacae9',
         }
         self.remote = _create_remote(**self.remote_data)
         self.repository = _create_repo(name='rh-certified-repo', remote=self.remote)

--- a/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
@@ -1,0 +1,149 @@
+from rest_framework import status
+from django.urls import reverse
+from django.test import override_settings
+from pulp_ansible.app.models import (
+    AnsibleDistribution,
+    AnsibleRepository,
+    CollectionRemote
+)
+from galaxy_ng.app.constants import DeploymentMode
+from .base import BaseTestCase
+
+
+def _create_repo(name, **kwargs):
+    repo = AnsibleRepository.objects.create(name=name, **kwargs)
+    AnsibleDistribution.objects.create(name=name, base_path=name, repository=repo)
+    return repo
+
+
+def _create_remote(name, url, **kwargs):
+    return CollectionRemote.objects.create(
+        name=name, url=url, **kwargs
+    )
+
+
+@override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value)
+class TestUiSyncConfigViewSet(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.admin_user = self._create_user("admin")
+        self.pe_group = self._create_partner_engineer_group()
+        self.admin_user.groups.add(self.pe_group)
+        self.admin_user.save()
+
+        self.certified_remote = _create_remote(
+            name='rh-certified',
+            url='https://a.certified.url.com/api/v2/',
+            requirements_file=None
+        )
+        _create_repo(name='rh-certified', remote=self.certified_remote)
+
+        self.community_remote = _create_remote(
+            name='community',
+            url='https://galaxy.ansible.com',
+            requirements_file=(
+                "collections:\n"
+                "  - name: initial.name\n"
+                "    server: initial.content.com\n"
+                "    api_key: NotASecret\n"
+            )
+        )
+        _create_repo(name='community', remote=self.community_remote)
+
+    def build_url(self, path):
+        return reverse('galaxy:api:content:v3:sync-config', kwargs={'path': path})
+
+    def test_positive_get_config_sync_for_certified(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get(self.build_url(self.certified_remote.name))
+        self.assertEqual(response.data['name'], self.certified_remote.name)
+        self.assertEqual(response.data['url'], self.certified_remote.url)
+        self.assertEqual(response.data['requirements_file'], None)
+
+    def test_positive_get_config_sync_for_community(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get(self.build_url(self.community_remote.name))
+        self.assertEqual(response.data['name'], self.community_remote.name)
+        self.assertEqual(response.data['url'], self.community_remote.url)
+        self.assertEqual(
+            response.data['requirements_file'],
+            self.community_remote.requirements_file
+        )
+
+    def test_positive_update_certified_repo_data(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.put(
+            self.build_url(self.certified_remote.name),
+            {
+                "auth_url": "https://auth.com",
+                "name": "rh-certified",
+                "policy": "immediate",
+                "requirements_file": None,
+                "url": "https://updated.url.com",
+            },
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        updated = self.client.get(self.build_url(self.certified_remote.name))
+        self.assertEqual(updated.data["auth_url"], "https://auth.com")
+        self.assertEqual(updated.data["url"], "https://updated.url.com")
+        self.assertIsNone(updated.data["requirements_file"])
+
+    def test_negative_update_certified_repo_data_with_wrong_name(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.put(
+            self.build_url(self.certified_remote.name),
+            {
+                "auth_url": "https://auth.com",
+                "name": "arbitraty-name",
+                "policy": "immediate",
+                "requirements_file": None,
+                "url": "https://updated.url.com",
+            },
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('arbitraty-name is not a valid name', str(response.data['errors']))
+
+    def test_negative_update_community_repo_data_without_requirements_file(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.put(
+            self.build_url(self.community_remote.name),
+            {
+                "auth_url": "https://auth.com",
+                "name": "community",
+                "policy": "immediate",
+                "requirements_file": None,
+                "url": "https://galaxy.ansible.com",
+            },
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            'Syncing content from community domains without specifying a '
+            'requirements file is not allowed.',
+            str(response.data['errors'])
+        )
+
+    def test_positive_update_community_repo_data_with_requirements_file(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.put(
+            self.build_url(self.community_remote.name),
+            {
+                "auth_url": "https://auth.com",
+                "name": "community",
+                "policy": "immediate",
+                "requirements_file": (
+                    "collections:\n"
+                    "  - name: foo.bar\n"
+                    "    server: foobar.content.com\n"
+                    "    api_key: s3cr3tk3y\n"
+                ),
+                "url": "https://galaxy.ansible.com",
+            },
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('foobar.content.com', response.data['requirements_file'])


### PR DESCRIPTION
- endpoint: `/content/<distribution>/v3/sync/config/`
- methods: GET/PUT

- endpoint: `/content/<distribution>/v3/sync/`  (taken from #409) 
- methods: POST

Issue: #282

- [x] Add endpoints for `sync/config` GET and PUT
- [x] Add endpoint for `sync/` POST
- [x] Validate PUT data assuring `rh-certified` repository has a `null` `requirement-file` and the opposite for `community` repository
- [x] Validate PUT data assuring that `name` is a `VALID_REMOTE_NAME`
- [x] Add access policies and permissions
- [x] Write unit tests
