### PR TITLE
Skip git source installs for manifest generation

### DIFF
--- a/.travis/generate_python_manifest.py
+++ b/.travis/generate_python_manifest.py
@@ -33,7 +33,7 @@ def parse_args():
 
 def process_requirements(requirements):
     for req in requirements:
-        if req.is_editable:
+        if req.requirement.startswith('git+'):
             continue
         package, version = req.requirement.split('==')
         yield '{prefix}/{package}:{version}.pypi'.format(


### PR DESCRIPTION
No-Issue

Fixes master branch manifest travis logic to skip git+ source
installs instead of skipping editable installs