### PR TITLE
Fix entrypoint script name in Dockerfile.rhel8 (#422)

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -35,7 +35,7 @@ RUN set -ex; \
                                /var/lib/pulp/tmp \
                                /tmp/ansible && \
     install -Dm 0644 /app/ansible.cfg /etc/ansible/ansible.cfg && \
-    install -Dm 0755 /app/docker/entrypoint.sh /entrypoint && \
+    install -Dm 0755 /app/docker/entrypoint.sh /entrypoint.sh && \
     install -Dm 0755 /app/docker/bin/* /usr/local/bin/
 
 USER galaxy
@@ -43,4 +43,4 @@ WORKDIR /app
 VOLUME [ "/var/lib/pulp/artifact", \
          "/var/lib/pulp/tmp", \
          "/tmp/ansible" ]
-ENTRYPOINT [ "/entrypoint" ]
+ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
(cherry picked from commit 7c67690b2480d535eb727d1db1bd27a2101aab43)

Backport: #422 