### PR TITLE
Add fixtures for rh-certified and community remotes

### DIFF
--- a/dev/automation-hub/initial_data.json
+++ b/dev/automation-hub/initial_data.json
@@ -174,5 +174,143 @@
       "repository": "787d4137-c9cf-4b26-b66a-aea0e3b6b433",
       "repository_version": null
     }
+  },
+  {
+    "model": "core.remote",
+    "pk": "80ae4b6b-bfb9-4831-aa0c-b43d32ce2fed",
+    "fields": {
+        "name": "Red Hat Certified",
+        "url": "https://cloud.redhat.com/api/automation-hub/v3/collections",
+        "pulp_created": "2020-03-12T15:56:19.071Z",
+        "pulp_last_updated": "2020-03-12T15:56:19.072Z",
+        "pulp_type": "ansible.ansible"
+    }
+  },
+  {
+    "model": "ansible.collectionremote",
+    "pk": "80ae4b6b-bfb9-4831-aa0c-b43d32ce2fed",
+    "fields": {
+        "auth_url": "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+    }
+  },
+  {
+    "model": "core.repository",
+    "pk": "7eb27e4f-1847-49a2-ba37-a1c3198f923e",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:19.071Z",
+      "pulp_last_updated": "2020-03-12T15:56:19.072Z",
+      "pulp_type": "ansible.ansible",
+      "name": "rh-certified",
+      "description": "Red Hat Certified",
+      "next_version": 1,
+      "remote": "80ae4b6b-bfb9-4831-aa0c-b43d32ce2fed"
+    }
+  },
+  {
+    "model": "core.repositoryversion",
+    "pk": "a5091fcf-5df0-49b5-8ff0-d84086befec9",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:19.075Z",
+      "pulp_last_updated": "2020-03-12T15:56:19.075Z",
+      "repository": "7eb27e4f-1847-49a2-ba37-a1c3198f923e",
+      "number": 0,
+      "complete": true,
+      "base_version": null
+    }
+  },
+  {
+    "model": "core.basedistribution",
+    "pk": "a6e40994-3c01-4e0e-8213-a9aebbf463c9",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:23.436Z",
+      "pulp_last_updated": "2020-03-12T15:56:23.436Z",
+      "pulp_type": "ansible.ansible",
+      "name": "rh-certified",
+      "base_path": "rh-certified",
+      "content_guard": null,
+      "remote": null
+    }
+  },
+  {
+    "model": "ansible.ansiblerepository",
+    "pk": "7eb27e4f-1847-49a2-ba37-a1c3198f923e",
+    "fields": {}
+  },
+  {
+    "model": "ansible.ansibledistribution",
+    "pk": "a6e40994-3c01-4e0e-8213-a9aebbf463c9",
+    "fields": {
+      "repository": "7eb27e4f-1847-49a2-ba37-a1c3198f923e",
+      "repository_version": null
+    }
+  },
+  {
+    "model": "core.remote",
+    "pk": "c90feabd-5cb6-4bab-ad07-861f000e2d18",
+    "fields": {
+        "name": "Community",
+        "url": "https://galaxy.ansible.com/api/v2/collections",
+        "pulp_created": "2020-03-12T15:56:19.071Z",
+        "pulp_last_updated": "2020-03-12T15:56:19.072Z",
+        "pulp_type": "ansible.ansible"
+    }
+  },
+  {
+    "model": "ansible.collectionremote",
+    "pk": "c90feabd-5cb6-4bab-ad07-861f000e2d18",
+    "fields": {
+        "requirements_file": "collections:\n  -name: initial.name\n    server: initial.content.com\n    api_key: NotASecret\n"
+    }
+  },
+  {
+    "model": "core.repository",
+    "pk": "03cb7d21-b9ba-4749-b6d2-987a233d2ba3",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:19.071Z",
+      "pulp_last_updated": "2020-03-12T15:56:19.072Z",
+      "pulp_type": "ansible.ansible",
+      "name": "community",
+      "description": "Community",
+      "next_version": 1,
+      "remote": "c90feabd-5cb6-4bab-ad07-861f000e2d18"
+    }
+  },
+  {
+    "model": "core.repositoryversion",
+    "pk": "4a0c516c-fdd2-4f82-9537-711b98fc007e",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:19.075Z",
+      "pulp_last_updated": "2020-03-12T15:56:19.075Z",
+      "repository": "03cb7d21-b9ba-4749-b6d2-987a233d2ba3",
+      "number": 0,
+      "complete": true,
+      "base_version": null
+    }
+  },
+  {
+    "model": "core.basedistribution",
+    "pk": "76e116e1-bd44-4e9e-9f25-dce0b4dcad83",
+    "fields": {
+      "pulp_created": "2020-03-12T15:56:23.436Z",
+      "pulp_last_updated": "2020-03-12T15:56:23.436Z",
+      "pulp_type": "ansible.ansible",
+      "name": "community",
+      "base_path": "community",
+      "content_guard": null,
+      "remote": null
+    }
+  },
+  {
+    "model": "ansible.ansiblerepository",
+    "pk": "03cb7d21-b9ba-4749-b6d2-987a233d2ba3",
+    "fields": {}
+  },
+  {
+    "model": "ansible.ansibledistribution",
+    "pk": "76e116e1-bd44-4e9e-9f25-dce0b4dcad83",
+    "fields": {
+      "repository": "03cb7d21-b9ba-4749-b6d2-987a233d2ba3",
+      "repository_version": null
+    }
   }
 ]

--- a/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
@@ -1,3 +1,4 @@
+import logging
 from rest_framework import status
 from django.urls import reverse
 from django.test import override_settings
@@ -8,6 +9,8 @@ from pulp_ansible.app.models import (
 )
 from galaxy_ng.app.constants import DeploymentMode
 from .base import BaseTestCase
+
+log = logging.getLogger(__name__)
 
 
 def _create_repo(name, **kwargs):
@@ -60,6 +63,9 @@ class TestUiSyncConfigViewSet(BaseTestCase):
     def test_positive_get_config_sync_for_certified(self):
         self.client.force_authenticate(user=self.admin_user)
         response = self.client.get(self.build_config_url(self.certified_remote.name))
+        log.debug('test_positive_get_config_sync_for_certified')
+        log.debug('response: %s', response)
+        log.debug('response.data: %s', response.data)
         self.assertEqual(response.data['name'], self.certified_remote.name)
         self.assertEqual(response.data['url'], self.certified_remote.url)
         self.assertEqual(response.data['requirements_file'], None)
@@ -67,6 +73,9 @@ class TestUiSyncConfigViewSet(BaseTestCase):
     def test_positive_get_config_sync_for_community(self):
         self.client.force_authenticate(user=self.admin_user)
         response = self.client.get(self.build_config_url(self.community_remote.name))
+        log.debug('test_positive_get_config_sync_for_community')
+        log.debug('response: %s', response)
+        log.debug('response.data: %s', response.data)
         self.assertEqual(response.data['name'], self.community_remote.name)
         self.assertEqual(response.data['url'], self.community_remote.url)
         self.assertEqual(
@@ -87,6 +96,9 @@ class TestUiSyncConfigViewSet(BaseTestCase):
             },
             format='json'
         )
+        log.debug('test_positive_update_certified_repo_data')
+        log.debug('response: %s', response)
+        log.debug('response.data: %s', response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         updated = self.client.get(self.build_config_url(self.certified_remote.name))
@@ -103,10 +115,13 @@ class TestUiSyncConfigViewSet(BaseTestCase):
                 "name": "community",
                 "policy": "immediate",
                 "requirements_file": None,
-                "url": "https://galaxy.ansible.com",
+                "url": "https://galaxy.ansible.com/v3/collections",
             },
             format='json'
         )
+        log.debug('test_negative_update_community_repo_data_without_requirements_file')
+        log.debug('response: %s', response)
+        log.debug('response.data: %s', response.data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(
             'Syncing content from community domains without specifying a '
@@ -125,18 +140,26 @@ class TestUiSyncConfigViewSet(BaseTestCase):
                 "requirements_file": (
                     "collections:\n"
                     "  - name: foo.bar\n"
-                    "    server: foobar.content.com\n"
+                    "    server: https://foobar.content.com\n"
                     "    api_key: s3cr3tk3y\n"
                 ),
-                "url": "https://galaxy.ansible.com",
+                "url": "https://galaxy.ansible.com/v3/collections",
             },
             format='json'
         )
+
+        log.debug('test_positive_update_community_repo_data_with_requirements_file')
+        log.debug('response: %s', response)
+        log.debug('response.data: %s', response.data)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('foobar.content.com', response.data['requirements_file'])
 
     def test_positive_syncing_returns_a_task_id(self):
         self.client.force_authenticate(user=self.admin_user)
         response = self.client.post(self.build_sync_url(self.certified_remote.name))
+        log.debug('test_positive_syncing_returns_a_task_id')
+        log.debug('response: %s', response)
+        log.debug('response.data: %s', response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('task', response.data)


### PR DESCRIPTION
Add data to `initial_data.json` to insert remotes
for `rh-certified` and `community` repositories and
its respective distributions.

Also fixed tests because of new validation rules on pulp_ansible

```py
{
    'errors': [
        {
             'status': '400', 
             'code': 'invalid', 
              'title': 'Invalid input.', 
              'detail': "Invalid URL https://galaxy.ansible.com. Ensure the URL ends in either '/v2/collections' or '/v3/collections'"
         }
      ]
}
```