### PR TITLE
Move /curate/ over to /api/automation-hub/_ui/v1/repo/<str:repo_name>/curate/

### DIFF
--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -79,6 +79,11 @@ paths = [
         viewsets.RepositoryCollectionViewSet.as_view({'get': 'retrieve'}),
         name='repo-collections-detail'
     ),
+    path(
+        "repo/<str:repo_name>/curate/",
+        viewsets.RepositoryCollectionViewSet.as_view({"post": "curate"}),
+        name="repo-collections-curate",
+    ),
 
     # NOTE: Using path instead of SimpleRouter because SimpleRouter expects retrieve
     # to look up values with an ID


### PR DESCRIPTION
The /api/automation-hub/content/{repo_name}/v3/collections/curate endpoint, but moved under to
under the /ui/ endpoints at /api/automation-hub/_ui/v1/repo/<str:repo_name>/curate/

Low priority at the moment, but putting up the pr since I had it from yesterday.

No-Issue