### PR TITLE
Added create-remote management command.

### DIFF
--- a/CHANGES/430.misc
+++ b/CHANGES/430.misc
@@ -1,0 +1,1 @@
+Added a new `create-remote` management command to create and associate remote with repository and distribution.

--- a/galaxy_ng/app/management/commands/create-remote.py
+++ b/galaxy_ng/app/management/commands/create-remote.py
@@ -127,10 +127,11 @@ class Command(BaseCommand):
         return repository
 
     def create_distribution(self, data, remote, repository):
-        distribution, distro_created = AnsibleDistribution.objects.get_or_create(
-            name=data["distribution"] or data["name"],
-            base_path=data["distribution"] or data["name"],
-        )
+        distro_name = data['distribution'] or data['name']
+        distribution, distro_created = AnsibleDistribution.objects.get_or_create(name=distro_name)
+
+        if not distribution.base_path:
+            distribution.base_path = distro_name
 
         distribution.repository = repository
         distribution.remote = remote

--- a/galaxy_ng/app/management/commands/create-remote.py
+++ b/galaxy_ng/app/management/commands/create-remote.py
@@ -1,0 +1,160 @@
+from galaxy_ng.app.constants import COMMUNITY_DOMAINS
+import os
+from rest_framework.serializers import ValidationError
+from django.db.utils import IntegrityError
+from django.utils.text import slugify
+from django.core.management.base import BaseCommand, CommandError
+
+from pulp_ansible.app.models import AnsibleDistribution, AnsibleRepository, CollectionRemote
+from pulp_ansible.app.tasks.utils import parse_collections_requirements_file
+
+
+class Command(BaseCommand):
+    """Django management command for creating new remotes.
+
+    Example:
+
+    $ create-remote rh-certified https://cloud.redhat.com/api/automation-hub/v3/collections
+
+    $ create-remote community https://galaxy.ansible.com -r /tmp/reqs.yaml
+
+    """
+
+    def load_requirements_file(self, requirements_file):
+        """Loads  and validates the requirements file
+
+        If the requirements_file is an absolute path for a file it is
+        opened and read.
+        """
+        if os.path.exists(requirements_file) and requirements_file.endswith((".yaml", ".yml")):
+            with open(requirements_file) as file_obj:
+                requirements_file = file_obj.read()
+
+        try:
+            parse_collections_requirements_file(requirements_file)
+        except ValidationError as e:
+            raise CommandError("Error parsing requirements_file {}".format(str(e)))
+
+        return requirements_file
+
+    def valid_url(self, url):
+        if url.endswith("/"):
+            raise CommandError("url should not end with '/'")
+        return url
+
+    def add_arguments(self, parser):
+        # required positional arguments
+        parser.add_argument('name', type=slugify, help="Remote Name")
+        parser.add_argument(
+            "url",
+            type=self.valid_url,
+            help=(
+                "Remote Feed URL, "
+                "Should not end with a '/', "
+                "should end in v2/collections or v3/collections"
+            )
+        )
+
+        # optional named arguments
+        parser.add_argument("--token", type=str, help="Remote Auth Token")
+        parser.add_argument("--policy", type=str, help="Remote Download Policy")
+        parser.add_argument("--auth_url", type=str, help="Remote Auth URL")
+        parser.add_argument(
+            "--repository",
+            type=slugify,
+            help="Name of a repository to create or associate, defaults to [name]"
+        )
+        parser.add_argument(
+            "--distribution",
+            type=slugify,
+            help="Name of a distribution to create or associate, defaults to [name]"
+        )
+        parser.add_argument(
+            "-r",
+            "--requirements_file",
+            type=self.load_requirements_file,
+            help="Either an abs path ending in .yaml|.yml to be loaded or the literal YAML string."
+        )
+
+    def validate(self, data):
+        if not data["requirements_file"] and any(
+            [domain in data["url"] for domain in COMMUNITY_DOMAINS]
+        ):
+            raise CommandError(
+                'Syncing content from community domains without specifying a '
+                'requirements file is not allowed.'
+            )
+        return data
+
+    def create_remote(self, data):
+        try:
+            remote = CollectionRemote.objects.create(
+                name=data["name"],
+                url=data["url"],
+                auth_url=data["auth_url"],
+                token=data["token"],
+                requirements_file=data["requirements_file"]
+            )
+        except IntegrityError as e:
+            raise CommandError("Cannot create {} remote, error: {}".format(data["name"], str(e)))
+        else:
+            self.stdout.write("Created new CollectionRemote {}".format(remote.name))
+
+        return remote
+
+    def create_repository(self, data, remote):
+        repository, repo_created = AnsibleRepository.objects.get_or_create(
+            name=data["repository"] or data["name"]
+        )
+        if repository.remote:
+            raise CommandError(
+                "Repository {} is already associated with a remote {}".format(
+                    repository.name, repository.remote.name
+                )
+            )
+
+        repository.remote = remote
+        repository.save()
+        self.stdout.write(
+            "{} Repository {}".format(
+                "Created new" if repo_created else "Associated existing",
+                repository.name,
+            )
+        )
+        return repository
+
+    def create_distribution(self, data, remote, repository):
+        distribution, distro_created = AnsibleDistribution.objects.get_or_create(
+            name=data["distribution"] or data["name"],
+            base_path=data["distribution"] or data["name"],
+        )
+        if distribution.repository:
+            raise CommandError(
+                "Distribution {} is already associated with a repository {}".format(
+                    distribution.name, distribution.repository.name
+                )
+            )
+
+        if distribution.remote:
+            raise CommandError(
+                "Distribution {} is already associated with a remote {}".format(
+                    distribution.name, distribution.remote.name
+                )
+            )
+
+        distribution.repository = repository
+        distribution.remote = remote
+        distribution.save()
+        self.stdout.write(
+            "{} Distribution {}".format(
+                "Created new" if distro_created else "Associated existing",
+                distribution.name,
+            )
+        )
+        return distribution
+
+    def handle(self, *args, **data):
+        data = self.validate(data)
+        remote = self.create_remote(data)
+        repository = self.create_repository(data, remote)
+        self.create_distribution(data, remote, repository)

--- a/galaxy_ng/tests/unit/app/management/commands/test_create_remote.py
+++ b/galaxy_ng/tests/unit/app/management/commands/test_create_remote.py
@@ -1,0 +1,145 @@
+import tempfile
+from io import StringIO
+
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+from pulp_ansible.app.models import (
+    AnsibleDistribution,
+    AnsibleRepository,
+    CollectionRemote,
+)
+
+REQUIREMENTS_FILE_STR = (
+    "collections:\n"
+    "  - name: initial.name\n"
+    "    server: https://initial.content.com/v3/collections\n"
+    "    api_key: NotASecret\n"
+)
+
+
+class TestCreateRemoteCommand(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        CollectionRemote.objects.create(
+            name="test-remote",
+            url="https://test.remote/v3/collections"
+        )
+
+    def test_command_output(self):
+        with self.assertRaisesMessage(
+            CommandError, "Error: the following arguments are required: name, url"
+        ):
+            call_command('create-remote')
+
+    def test_remote_already_exists(self):
+        with self.assertRaisesMessage(
+            CommandError,
+            'Cannot create test-remote remote, error: duplicate key value violates unique '
+            'constraint "core_remote_name_key"'
+        ):
+            call_command('create-remote', 'test-remote', 'https://test.remote/v3/collections')
+
+    def test_remote_created(self):
+        out = StringIO()
+        call_command('create-remote', 'new-remote', 'https://new.remote/v3/collections', stdout=out)
+
+        self.assertIn('Created new CollectionRemote new-remote', out.getvalue())
+        self.assertIn('Created new Repository new-remote', out.getvalue())
+        self.assertIn('Created new Distribution new-remote', out.getvalue())
+
+        self.assertTrue(CollectionRemote.objects.filter(name='new-remote').exists())
+        self.assertTrue(AnsibleRepository.objects.filter(name='new-remote').exists())
+        self.assertTrue(AnsibleDistribution.objects.filter(base_path='new-remote').exists())
+
+    def test_associate_existing_entities(self):
+        out = StringIO()
+
+        AnsibleRepository.objects.create(name='existing-repo')
+        AnsibleDistribution.objects.create(name='existing-distro', base_path='existing-distro')
+
+        call_command(
+            'create-remote',
+            'new-remote-with-existing-entities',
+            'https://new.remote/v3/collections',
+            '--repository', 'existing-repo',
+            '--distribution', 'existing-distro',
+            stdout=out
+        )
+
+        self.assertIn(
+            'Created new CollectionRemote new-remote-with-existing-entities',
+            out.getvalue()
+        )
+        self.assertIn('Associated existing Repository existing-repo', out.getvalue())
+        self.assertIn('Associated existing Distribution existing-distro', out.getvalue())
+
+        remote = CollectionRemote.objects.get(name='new-remote-with-existing-entities')
+        repo = AnsibleRepository.objects.get(name='existing-repo')
+        distro = AnsibleDistribution.objects.get(name='existing-distro')
+
+        self.assertEqual(distro.remote.pk, remote.pk)
+        self.assertEqual(distro.remote.pk, repo.remote.pk)
+        self.assertEqual(distro.repository.pk, repo.pk)
+        self.assertEqual(repo.pk, remote.repository_set.first().pk)
+
+    def test_invalid_url(self):
+        with self.assertRaisesMessage(
+            CommandError, "url should not end with '/'"
+        ):
+            call_command('create-remote', 'invalid-remote', 'https://invalid.url/foo/')
+
+    def test_cannot_create_community_wo_requirements_file(self):
+        with self.assertRaisesMessage(
+            CommandError,
+            'Syncing content from community domains without specifying a '
+            'requirements file is not allowed.'
+        ):
+            call_command('create-remote', 'community', 'https://galaxy.ansible.com/v3/collections')
+
+    def test_create_community_remote_with_requirements_file_str(self):
+        out = StringIO()
+        call_command(
+            'create-remote',
+            'community',
+            'https://galaxy.ansible.com/v3/collections',
+            '-r', REQUIREMENTS_FILE_STR,
+            stdout=out
+        )
+
+        self.assertIn('Created new CollectionRemote community', out.getvalue())
+        self.assertIn('Created new Repository community', out.getvalue())
+        self.assertIn('Created new Distribution community', out.getvalue())
+
+        self.assertEqual(
+            CollectionRemote.objects.get(name='community').requirements_file,
+            REQUIREMENTS_FILE_STR
+        )
+
+    def test_invalid_requirements_file(self):
+        with self.assertRaisesMessage(
+            CommandError,
+            "Error parsing requirements_file"
+        ):
+            call_command('create-remote', 'foo', 'https://bar.com', '-r', 'invalid_file_str')
+
+    def test_load_requirements_file_from_path(self):
+        out = StringIO()
+
+        with tempfile.NamedTemporaryFile(mode='w+', suffix='.yaml') as requirements_file:
+            requirements_file.write(REQUIREMENTS_FILE_STR)
+            requirements_file.seek(0)
+
+            call_command(
+                'create-remote',
+                'community-from-file',
+                'https://galaxy.ansible.com/v3/collections',
+                '-r', requirements_file.name,
+                stdout=out
+            )
+
+            self.assertIn('Created new CollectionRemote community', out.getvalue())
+            self.assertIn('Created new Repository community', out.getvalue())
+            self.assertIn('Created new Distribution community', out.getvalue())
+
+            self.assertIn('requirements_file loaded and parsed', out.getvalue())


### PR DESCRIPTION
```
$ create-remote rh-certified https://url.tld/v3/collections --options
```

or loading a requirement_file

```
$ create-remote community https://galaxy.ansible.com/v3/collections -r
/tmp/my_requirements.yaml
```

```
❯ manage.py create-remote --help
usage: django-admin create-remote [-h] [--token TOKEN] [--policy POLICY]
                                  [--auth_url AUTH_URL]
                                  [--repository REPOSITORY]
                                  [--distribution DISTRIBUTION]
                                  [-r REQUIREMENTS_FILE] [--version]
                                  [-v {0,1,2,3}] [--settings SETTINGS]
                                  [--pythonpath PYTHONPATH] [--traceback]
                                  [--no-color] [--force-color]
                                  name url

positional arguments:
  name                  Remote Name
  url                   Remote Feed URL, Should not end with a '/', should end
                        in v2/collections or v3/collections

optional arguments:
  -h, --help            show this help message and exit
  --token TOKEN         Remote Auth Token
  --policy POLICY       Remote Download Policy
  --auth_url AUTH_URL   Remote Auth URL
  --repository REPOSITORY
                        Name of a repository to create or associate, defaults
                        to [name]
  --distribution DISTRIBUTION
                        Name of a distribution to create or associate,
                        defaults to [name]
  -r REQUIREMENTS_FILE, --requirements_file REQUIREMENTS_FILE
                        Either an abs path ending in .yaml|.yml to be loaded
                        or the literal YAML string.
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  --force-color         Force colorization of the command output.

```

Issue: #430