### PR TITLE
On changes to golden repo, trigger all synclist tasks

### DIFF
--- a/CHANGES/428.feature
+++ b/CHANGES/428.feature
@@ -1,0 +1,1 @@
+The task for curating content needs to be initiated whenever a new collection lands in the golden repository.


### PR DESCRIPTION
In the CollectionMoveViewSet, if either of the repositories
involved is the 'golden' repo, then enqueue a
'curate_all_synclist_repository' task that start
tasks that curate all synclist repositories based on
the synclist associated with it.

ie, when the main repo changes, kick off tasks to update
all the repos based on it.

Issue: #428