### PR TITLE
HOTFIX: Remove policy field from SyncConfig serializer

### DIFF
--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -7,10 +7,6 @@ from galaxy_ng.app.constants import COMMUNITY_DOMAINS
 class SyncConfigSerializer(CollectionRemoteSerializer):
     created_at = serializers.DateTimeField(source='pulp_created', required=False)
     updated_at = serializers.DateTimeField(source='pulp_last_updated', required=False)
-    policy = serializers.ChoiceField(
-        choices=CollectionRemote.POLICY_CHOICES,
-        default=CollectionRemote.ON_DEMAND
-    )
     token = serializers.CharField(allow_null=True, required=False, max_length=2000, write_only=True)
     name = serializers.CharField(read_only=True)
 


### PR DESCRIPTION
According to comment by @bmbouter on
https://github.com/ansible/galaxy_ng/pull/410/files#r486534931

Our Serializer should not override policy field until
pulp_ansible supports other policies.

No-Issue