### PR TITLE
Update ui collection endpoint to subclass pulp and support search

### DIFF
--- a/CHANGES/439.misc
+++ b/CHANGES/439.misc
@@ -1,0 +1,1 @@
+Fix ui collection endpoint to support keyword search and tag filtering

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -72,12 +72,12 @@ paths = [
     path('groups/', include(group_paths)),
 
     path(
-        'repo/<str:repo_name>/',
+        'repo/<str:path>/',
         viewsets.RepositoryCollectionViewSet.as_view({'get': 'list'}),
         name='repo-collections-list'
     ),
     path(
-        'repo/<str:repo_name>/<str:namespace>/<str:name>/',
+        'repo/<str:path>/<str:namespace>/<str:name>/',
         viewsets.RepositoryCollectionViewSet.as_view({'get': 'retrieve'}),
         name='repo-collections-detail'
     ),

--- a/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
@@ -28,6 +28,7 @@ def _create_remote(name, url, **kwargs):
 def _get_create_version_in_repo(namespace, collection, version, repo):
     collection_version, _ = CollectionVersion.objects.get_or_create(
         namespace=namespace,
+        name=collection.name,
         collection=collection,
         version=version,
     )
@@ -119,15 +120,15 @@ class TestUiCollectionViewSet(BaseTestCase):
         _get_create_version_in_repo(self.namespace, self.collection1, '1.0.0', self.repo2)
 
         self.repo1_list_url = get_current_ui_url(
-            'repo-collections-list', kwargs={'repo_name': 'repo1'})
+            'repo-collections-list', kwargs={'path': 'repo1'})
         self.repo2_list_url = get_current_ui_url(
-            'repo-collections-list', kwargs={'repo_name': 'repo2'})
+            'repo-collections-list', kwargs={'path': 'repo2'})
         self.repo3_list_url = get_current_ui_url(
-            'repo-collections-list', kwargs={'repo_name': 'repo3'})
+            'repo-collections-list', kwargs={'path': 'repo3'})
         self.repo1_collection1_detail_url = get_current_ui_url(
             'repo-collections-detail',
             kwargs={
-                'repo_name': 'repo1',
+                'path': 'repo1',
                 'namespace': namespace_name,
                 'name': collection1_name})
 


### PR DESCRIPTION
Closes-Issue: #439

Changes the ui collection endpoint view to subclass pulp which adds keyword search and tag filtering support. Further duplication can be removed once the noted pulp issue is resolved.