### PR TITLE
TLS: Allow one to disable certificate verification from settings file

### DIFF
--- a/galaxy_ng/app/common/pulp.py
+++ b/galaxy_ng/app/common/pulp.py
@@ -11,9 +11,10 @@ def get_configuration():
         ),
         username=settings.X_PULP_API_USER,
         password=settings.X_PULP_API_PASSWORD,
-
     )
     config.safe_chars_for_path_param = '/'
+    if 'VERIFY_SSL' in settings:
+        config.verify_ssl = settings.VERIFY_SSL
     return config
 
 


### PR DESCRIPTION
This might be me not knowing where to look for it. But I was looking to disable cert validation by enabling a toggle on the settings file and I couldn't find it. This commit allows me to do that.

If there is another way to currently do it please let me know and feel free to close this PR.

Issue: #464