### PR TITLE
Remove permissions from pe group in fixtures.

### DIFF
--- a/dev/automation-hub/initial_data.json
+++ b/dev/automation-hub/initial_data.json
@@ -4,7 +4,7 @@
     "pk": 1,
     "fields": {
       "name": "system:partner-engineers",
-      "permissions": [37, 266, 267, 270, 287, 288, 289, 290, 283, 284, 285, 286]
+      "permissions": []
     }
   },
   {


### PR DESCRIPTION
As we expected, putting in the IDs for permissions into the dev fixtures broke and is currently blocking the fixtures from running. 