### PR TITLE
Update pulpcore to >=3.7,<3.9, pulp_ansible~=0.4.0  #476

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -101,7 +101,7 @@ if [ -z "$TRAVIS_TAG" ]; then
 fi
 
 
-git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.3.0
+git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.4.0
 if [ -n "$PULP_ANSIBLE_PR_NUMBER" ]; then
   cd pulp_ansible
   git fetch --depth=1 origin pull/$PULP_ANSIBLE_PR_NUMBER/head:$PULP_ANSIBLE_PR_NUMBER

--- a/CHANGES/476.feature
+++ b/CHANGES/476.feature
@@ -1,0 +1,4 @@
+Upgrade to pulpcore 3.7.0 and allow for 3.8.0
+
+Based on the API stability guidance at
+https://docs.pulpproject.org/pulpcore/plugins/plugin-writer/concepts/index.html#plugin-api-stability-and-deprecation-policy

--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,16 @@ help:             ## Show the help.
 	@echo "Targets:"
 	@fgrep "##" Makefile | fgrep -v fgrep
 
+# ANSIBLE_SKIP_CONFLICT_CHECK=1 tells pip/pip-compile to avoid
+# refusing to update ansbile 2.9 to ansible 2.10.
 
 .PHONY: requirements
 requirements:     ## Update python dependencies lock files (i.e. requirements.txt).
-	pip-compile -U -o requirements/requirements.common.txt \
+	ANSIBLE_SKIP_CONFLICT_CHECK=1 pip-compile -U -o requirements/requirements.common.txt \
 		setup.py
-	pip-compile -U -o requirements/requirements.standalone.txt \
+	ANSIBLE_SKIP_CONFLICT_CHECK=1 pip-compile -U -o requirements/requirements.standalone.txt \
 		setup.py requirements/requirements.standalone.in
-	pip-compile -U -o requirements/requirements.insights.txt \
+	ANSIBLE_SKIP_CONFLICT_CHECK=1 pip-compile -U -o requirements/requirements.insights.txt \
 		setup.py requirements/requirements.insights.in
 
 

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -7,42 +7,48 @@
 aiodns==2.0.0             # via pulpcore
 aiofiles==0.5.0           # via pulpcore
 aiohttp==3.6.2            # via pulpcore
-ansible-lint==4.3.0       # via galaxy-importer
-ansible==2.9.12           # via ansible-lint, galaxy-importer
+ansible-base==2.10.1      # via ansible
+ansible-lint==4.3.5       # via galaxy-importer
+ansible==2.10.0           # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via aiohttp, galaxy-importer, jsonschema
+attrs==20.2.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
 bleach-whitelist==0.0.11  # via galaxy-importer
-bleach==3.1.5             # via galaxy-importer
+bleach==3.2.1             # via galaxy-importer
 certifi==2020.6.20        # via galaxy-ng (setup.py), requests
-cffi==1.14.2              # via cryptography, pycares
+cffi==1.14.3              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
-cryptography==3.0         # via ansible
+colorama==0.4.3           # via rich
+commonmark==0.9.1         # via rich
+cryptography==3.1.1       # via ansible-base
+dataclasses==0.7          # via rich
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
+django-cleanup==5.1.0     # via pulpcore
 django-currentuser==0.5.1  # via pulpcore
 django-filter==2.3.0      # via pulpcore
 django-guardian==2.3.0    # via pulpcore
 django-import-export==2.3.0  # via pulpcore
 django-lifecycle==0.7.7   # via pulpcore
-django-prometheus==2.0.0  # via galaxy-ng (setup.py)
-django==2.2.15            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django-prometheus==2.1.0  # via galaxy-ng (setup.py)
+django==2.2.16            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.10.3  # via drf-nested-routers, drf-spectacular, pulpcore
-drf-access-policy==0.6.2  # via pulpcore
+djangorestframework==3.11.1  # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.7.0  # via pulpcore
 drf-nested-routers==0.91  # via pulpcore
-drf-spectacular==0.9.12   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.1.0           # via pulpcore
+drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
+dynaconf==3.1.1           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.8rc11  # via pulp-ansible
+galaxy-importer==0.2.8    # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna==2.10                # via requests, yarl
-importlib-metadata==1.7.0  # via flake8, jsonschema, markdown
-inflection==0.5.0         # via drf-spectacular
+idna-ssl==1.1.0           # via aiohttp
+idna==2.10                # via idna-ssl, requests, yarl
+importlib-metadata==2.0.0  # via flake8, jsonschema, markdown
+inflection==0.5.1         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
-jinja2==2.11.2            # via ansible
+jinja2==2.11.2            # via ansible-base, pulpcore
 jsonschema==3.2.0         # via drf-spectacular
 markdown==3.2.2           # via galaxy-importer
 markuppy==1.14            # via tablib
@@ -50,33 +56,36 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 multidict==4.7.6          # via aiohttp, yarl
 odfpy==1.4.1              # via tablib
-openpyxl==3.0.4           # via tablib
-packaging==20.4           # via bleach, pulp-ansible
+openpyxl==3.0.5           # via tablib
+packaging==20.4           # via ansible-base, bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
-psycopg2==2.8.5           # via pulpcore
-pulp-ansible==0.3.0       # via galaxy-ng (setup.py)
-pulpcore==3.6.0           # via galaxy-ng (setup.py), pulp-ansible
+psycopg2==2.8.6           # via pulpcore
+pulp-ansible==0.4.0       # via galaxy-ng (setup.py)
+pulpcore==3.7.0           # via galaxy-ng (setup.py), pulp-ansible
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
 pyflakes==2.2.0           # via flake8
+pygments==2.7.1           # via rich
 pygtrie==2.3.3            # via pulpcore
 pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via jsonschema
+pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via galaxy-ng (setup.py)
 python-gnupg==0.4.6       # via pulpcore
 pytz==2020.1              # via django
-pyyaml==5.3.1             # via ansible, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+pyyaml==5.3.1             # via ansible-base, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
 redis==3.5.3              # via pulpcore, rq
 requests==2.24.0          # via galaxy-importer
-rq==1.5.0                 # via pulpcore
-ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml==0.16.10      # via ansible-lint
+rich==7.0.0               # via ansible-lint
+rq==1.5.2                 # via pulpcore
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
+ruamel.yaml==0.16.12      # via ansible-lint
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyrsistent, python-dateutil
+six==1.15.0               # via bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, python-dateutil
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.2  # via ansible-lint, yarl
+typing-extensions==3.7.4.3  # via aiohttp, ansible-lint, rich, yarl
+typing==3.7.4.3           # via aiodns
 uritemplate==3.0.1        # via drf-spectacular
 urllib3==1.25.10          # via galaxy-ng (setup.py), requests
 urlman==1.3.0             # via django-lifecycle
@@ -84,8 +93,8 @@ webencodings==0.5.1       # via bleach
 whitenoise==5.2.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
-yarl==1.5.1               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
+yarl==1.6.0               # via aiohttp
+zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -7,46 +7,51 @@
 aiodns==2.0.0             # via pulpcore
 aiofiles==0.5.0           # via pulpcore
 aiohttp==3.6.2            # via pulpcore
-ansible-lint==4.3.0       # via galaxy-importer
-ansible==2.9.12           # via ansible-lint, galaxy-importer
+ansible-base==2.10.1      # via ansible
+ansible-lint==4.3.5       # via galaxy-importer
+ansible==2.10.0           # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via aiohttp, galaxy-importer, jsonschema
+attrs==20.2.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
 bleach-whitelist==0.0.11  # via galaxy-importer
-bleach==3.1.5             # via galaxy-importer
-boto3==1.14.45            # via -r requirements/requirements.insights.in, django-storages, watchtower
-botocore==1.17.45         # via boto3, s3transfer
+bleach==3.2.1             # via galaxy-importer
+boto3==1.15.4             # via -r requirements/requirements.insights.in, django-storages, watchtower
+botocore==1.18.4          # via boto3, s3transfer
 certifi==2020.6.20        # via galaxy-ng (setup.py), requests
-cffi==1.14.2              # via cryptography, pycares
+cffi==1.14.3              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
-cryptography==3.0         # via ansible
+colorama==0.4.3           # via rich
+commonmark==0.9.1         # via rich
+cryptography==3.1.1       # via ansible-base
+dataclasses==0.7          # via rich
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
+django-cleanup==5.1.0     # via pulpcore
 django-currentuser==0.5.1  # via pulpcore
 django-filter==2.3.0      # via pulpcore
 django-guardian==2.3.0    # via pulpcore
 django-import-export==2.3.0  # via pulpcore
 django-lifecycle==0.7.7   # via pulpcore
-django-prometheus==2.0.0  # via galaxy-ng (setup.py)
-django-storages[boto3]==1.9.1  # via -r requirements/requirements.insights.in
-django==2.2.15            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, django-storages, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django-prometheus==2.1.0  # via galaxy-ng (setup.py)
+django-storages[boto3]==1.10.1  # via -r requirements/requirements.insights.in
+django==2.2.16            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, django-storages, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.10.3  # via drf-nested-routers, drf-spectacular, pulpcore
-docutils==0.15.2          # via botocore
-drf-access-policy==0.6.2  # via pulpcore
+djangorestframework==3.11.1  # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.7.0  # via pulpcore
 drf-nested-routers==0.91  # via pulpcore
-drf-spectacular==0.9.12   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.1.0           # via pulpcore
+drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
+dynaconf==3.1.1           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.8rc11  # via pulp-ansible
+galaxy-importer==0.2.8    # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna==2.10                # via requests, yarl
-importlib-metadata==1.7.0  # via flake8, jsonschema, markdown
-inflection==0.5.0         # via drf-spectacular
+idna-ssl==1.1.0           # via aiohttp
+idna==2.10                # via idna-ssl, requests, yarl
+importlib-metadata==2.0.0  # via flake8, jsonschema, markdown
+inflection==0.5.1         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
-jinja2==2.11.2            # via ansible
+jinja2==2.11.2            # via ansible-base, pulpcore
 jmespath==0.10.0          # via boto3, botocore
 jsonschema==3.2.0         # via drf-spectacular
 logstash-formatter==0.5.17  # via -r requirements/requirements.insights.in
@@ -56,34 +61,37 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 multidict==4.7.6          # via aiohttp, yarl
 odfpy==1.4.1              # via tablib
-openpyxl==3.0.4           # via tablib
-packaging==20.4           # via bleach, pulp-ansible
+openpyxl==3.0.5           # via tablib
+packaging==20.4           # via ansible-base, bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
-psycopg2==2.8.5           # via pulpcore
-pulp-ansible==0.3.0       # via galaxy-ng (setup.py)
-pulpcore==3.6.0           # via galaxy-ng (setup.py), pulp-ansible
+psycopg2==2.8.6           # via pulpcore
+pulp-ansible==0.4.0       # via galaxy-ng (setup.py)
+pulpcore==3.7.0           # via galaxy-ng (setup.py), pulp-ansible
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
 pyflakes==2.2.0           # via flake8
+pygments==2.7.1           # via rich
 pygtrie==2.3.3            # via pulpcore
 pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via jsonschema
+pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via botocore, galaxy-ng (setup.py)
 python-gnupg==0.4.6       # via pulpcore
 pytz==2020.1              # via django
-pyyaml==5.3.1             # via ansible, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+pyyaml==5.3.1             # via ansible-base, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
 redis==3.5.3              # via pulpcore, rq
 requests==2.24.0          # via galaxy-importer
-rq==1.5.0                 # via pulpcore
-ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml==0.16.10      # via ansible-lint
+rich==7.0.0               # via ansible-lint
+rq==1.5.2                 # via pulpcore
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
+ruamel.yaml==0.16.12      # via ansible-lint
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyrsistent, python-dateutil
+six==1.15.0               # via bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, python-dateutil
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.2  # via ansible-lint, yarl
+typing-extensions==3.7.4.3  # via aiohttp, ansible-lint, rich, yarl
+typing==3.7.4.3           # via aiodns
 uritemplate==3.0.1        # via drf-spectacular
 urllib3==1.25.10          # via botocore, galaxy-ng (setup.py), requests
 urlman==1.3.0             # via django-lifecycle
@@ -92,8 +100,8 @@ webencodings==0.5.1       # via bleach
 whitenoise==5.2.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
-yarl==1.5.1               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
+yarl==1.6.0               # via aiohttp
+zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.standalone.in
+++ b/requirements/requirements.standalone.in
@@ -1,1 +1,1 @@
-pulp-container~=2.0.0
+pulp-container~=2.1.0

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -7,44 +7,50 @@
 aiodns==2.0.0             # via pulpcore
 aiofiles==0.5.0           # via pulpcore
 aiohttp==3.6.2            # via pulpcore
-ansible-lint==4.3.0       # via galaxy-importer
-ansible==2.9.12           # via ansible-lint, galaxy-importer
+ansible-base==2.10.1      # via ansible
+ansible-lint==4.3.5       # via galaxy-importer
+ansible==2.10.0           # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via aiohttp, galaxy-importer, jsonschema
+attrs==20.2.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
 bleach-whitelist==0.0.11  # via galaxy-importer
-bleach==3.1.5             # via galaxy-importer
+bleach==3.2.1             # via galaxy-importer
 certifi==2020.6.20        # via galaxy-ng (setup.py), requests
-cffi==1.14.2              # via cryptography, pycares
+cffi==1.14.3              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
-cryptography==3.0         # via ansible, pyjwt
+colorama==0.4.3           # via rich
+commonmark==0.9.1         # via rich
+cryptography==3.1.1       # via ansible-base, pyjwt
+dataclasses==0.7          # via rich
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
+django-cleanup==5.1.0     # via pulpcore
 django-currentuser==0.5.1  # via pulpcore
 django-filter==2.3.0      # via pulpcore
 django-guardian==2.3.0    # via pulpcore
 django-import-export==2.3.0  # via pulpcore
 django-lifecycle==0.7.7   # via pulpcore
-django-prometheus==2.0.0  # via galaxy-ng (setup.py)
-django==2.2.15            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django-prometheus==2.1.0  # via galaxy-ng (setup.py)
+django==2.2.16            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.10.3  # via drf-nested-routers, drf-spectacular, pulpcore
-drf-access-policy==0.6.2  # via pulpcore
+djangorestframework==3.11.1  # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.7.0  # via pulpcore
 drf-nested-routers==0.91  # via pulpcore
-drf-spectacular==0.9.12   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.1.0           # via pulpcore
+drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
+dynaconf==3.1.1           # via pulpcore
 ecdsa==0.13.3             # via pulp-container
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
 future==0.18.2            # via pyjwkest
-galaxy-importer==0.2.8rc11  # via pulp-ansible
+galaxy-importer==0.2.8    # via pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna==2.10                # via requests, yarl
-importlib-metadata==1.7.0  # via flake8, jsonschema, markdown
-inflection==0.5.0         # via drf-spectacular
+idna-ssl==1.1.0           # via aiohttp
+idna==2.10                # via idna-ssl, requests, yarl
+importlib-metadata==2.0.0  # via flake8, jsonschema, markdown
+inflection==0.5.1         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
-jinja2==2.11.2            # via ansible
+jinja2==2.11.2            # via ansible-base, pulpcore
 jsonschema==3.2.0         # via drf-spectacular
 markdown==3.2.2           # via galaxy-importer
 markuppy==1.14            # via tablib
@@ -52,37 +58,40 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 multidict==4.7.6          # via aiohttp, yarl
 odfpy==1.4.1              # via tablib
-openpyxl==3.0.4           # via tablib
-packaging==20.4           # via bleach, pulp-ansible
+openpyxl==3.0.5           # via tablib
+packaging==20.4           # via ansible-base, bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
-psycopg2==2.8.5           # via pulpcore
-pulp-container==2.0.0     # via -r requirements/requirements.standalone.in
-pulp-ansible==0.3.0       # via galaxy-ng (setup.py)
-pulpcore==3.6.0           # via galaxy-ng (setup.py), pulp-ansible, pulp-container
+psycopg2==2.8.6           # via pulpcore
+pulp-ansible==0.4.0       # via galaxy-ng (setup.py)
+pulp-container==2.1.0     # via -r requirements/requirements.standalone.in
+pulpcore==3.7.0           # via galaxy-ng (setup.py), pulp-ansible, pulp-container
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pyflakes==2.2.0           # via flake8
+pygments==2.7.1           # via rich
 pygtrie==2.3.3            # via pulpcore
 pyjwkest==1.4.2           # via pulp-container
 pyjwt[crypto]==1.7.1      # via pulp-container
 pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via jsonschema
+pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via galaxy-ng (setup.py)
 python-gnupg==0.4.6       # via pulpcore
 pytz==2020.1              # via django
-pyyaml==5.3.1             # via ansible, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+pyyaml==5.3.1             # via ansible-base, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
 redis==3.5.3              # via pulpcore, rq
 requests==2.24.0          # via galaxy-importer, pyjwkest
-rq==1.5.0                 # via pulpcore
-ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml==0.16.10      # via ansible-lint
+rich==7.0.0               # via ansible-lint
+rq==1.5.2                 # via pulpcore
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
+ruamel.yaml==0.16.12      # via ansible-lint
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyjwkest, pyrsistent, python-dateutil, url-normalize
+six==1.15.0               # via bleach, cryptography, galaxy-ng (setup.py), jsonschema, packaging, pyjwkest, python-dateutil, url-normalize
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.2  # via ansible-lint, yarl
+typing-extensions==3.7.4.3  # via aiohttp, ansible-lint, rich, yarl
+typing==3.7.4.3           # via aiodns
 uritemplate==3.0.1        # via drf-spectacular
 url-normalize==1.4.2      # via pulp-container
 urllib3==1.25.10          # via galaxy-ng (setup.py), requests
@@ -91,8 +100,8 @@ webencodings==0.5.1       # via bleach
 whitenoise==5.2.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
-yarl==1.5.1               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
+yarl==1.6.0               # via aiohttp
+zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ galaxy_pulp_requirements = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python
 
 requirements = galaxy_pulp_requirements + [
     "Django~=2.2.3",
-    "pulpcore~=3.6.0",
-    "pulp-ansible~=0.3.0",
+    "pulpcore>=3.7,<3.9",
+    "pulp-ansible~=0.4.0",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
 ]


### PR DESCRIPTION
The ANSIBLE_SKIP_CONFLICT_CHECK additions to
the pip-compile lines are because otherwise
pip-compile fails with error:

  Upgrading directly from ansible-2.9 or less to ansible-2.10 or greater with pip is
  known to cause problems.  Please uninstall the old version found at:

  /home/adrian/venvs/galaxy_ng_2/lib64/python3.6/site-packages/ansible/__init__.py

  and install the new version:

      pip uninstall ansible
      pip install ansible

  If you have a broken installation, perhaps because ansible-base was installed before
  ansible was upgraded, try this to resolve it:

      pip install --force-reinstall ansible ansible-base

  If ansible is installed in a different location than you will be installing it now
  (for example, if the old version is installed by a system package manager to
  /usr/lib/python3.8/site-packages/ansible but you are installing the new version into
  ~/.local/lib/python3.8/site-packages/ansible with `pip install --user ansible`)
  or you want to install anyways and cleanup any breakage afterwards, then you may set
  the ANSIBLE_SKIP_CONFLICT_CHECK environment variable to ignore this check:

      ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install --user ansible

Issue: #476