### PR TITLE
Add sync/task endpoint to list all sync tasks

### DIFF
--- a/CHANGES/459.feature
+++ b/CHANGES/459.feature
@@ -1,0 +1,1 @@
+Add endpoint to list sync tasks `/sync/tasks`

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 from pulpcore.plugin.models import Task
 from pulp_ansible.app.models import CollectionRemote
 from pulp_ansible.app.viewsets import CollectionRemoteSerializer
@@ -45,7 +46,8 @@ class TaskSerializer(serializers.ModelSerializer):
     updated_at = serializers.DateTimeField(source='pulp_last_updated')
     worker = serializers.SerializerMethodField()
 
-    def get_worker(self, obj) -> Dict[str, Any]:
+    @extend_schema_field(Dict[str, Any])
+    def get_worker(self, obj):
         return {
             'name': obj.worker.name,
             'missing': obj.worker.missing,
@@ -66,11 +68,6 @@ class TaskSerializer(serializers.ModelSerializer):
             'parent_task',
             'child_tasks',
         )
-
-
-# Recursively add self referenced serializer field
-TaskSerializer._declared_fields['child_tasks'] = TaskSerializer(many=True, read_only=True)
-TaskSerializer._declared_fields['parent_task'] = TaskSerializer(read_only=True)
 
 
 class SyncTaskSerializer(serializers.ModelSerializer):

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -1,6 +1,9 @@
+from typing import Any, Dict
 from rest_framework import serializers
+from pulpcore.plugin.models import Task
 from pulp_ansible.app.models import CollectionRemote
 from pulp_ansible.app.viewsets import CollectionRemoteSerializer
+from galaxy_ng.app.models import CollectionSyncTask
 from galaxy_ng.app.constants import COMMUNITY_DOMAINS
 
 
@@ -35,3 +38,48 @@ class SyncConfigSerializer(CollectionRemoteSerializer):
                 }
             )
         return super().validate(data)
+
+
+class TaskSerializer(serializers.ModelSerializer):
+    created_at = serializers.DateTimeField(source='pulp_created')
+    updated_at = serializers.DateTimeField(source='pulp_last_updated')
+    worker = serializers.SerializerMethodField()
+
+    def get_worker(self, obj) -> Dict[str, Any]:
+        return {
+            'name': obj.worker.name,
+            'missing': obj.worker.missing,
+            'last_heartbeat': obj.worker.last_heartbeat,
+        }
+
+    class Meta:
+        model = Task
+        fields = (
+            'pk',
+            'created_at',
+            'updated_at',
+            'finished_at',
+            'started_at',
+            'state',
+            'error',
+            'worker',
+            'parent_task',
+            'child_tasks',
+        )
+
+
+# Recursively add self referenced serializer field
+TaskSerializer._declared_fields['child_tasks'] = TaskSerializer(many=True, read_only=True)
+TaskSerializer._declared_fields['parent_task'] = TaskSerializer(read_only=True)
+
+
+class SyncTaskSerializer(serializers.ModelSerializer):
+    task = TaskSerializer(read_only=True)
+    repository = serializers.CharField(source='repository.name')
+
+    class Meta:
+        fields = (
+            'task',
+            'repository',
+        )
+        model = CollectionSyncTask

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -27,7 +27,13 @@ sync_urls = [
         "sync/config/",
         viewsets.SyncConfigViewSet.as_view({'get': 'retrieve', 'put': 'update'}),
         name='sync-config'
+    ),
+    path(
+        "sync/tasks/",
+        viewsets.SyncTaskViewSet.as_view({'get': 'list'}),
+        name='sync-list'
     )
+
 ]
 
 urlpatterns = [

--- a/galaxy_ng/app/api/v3/viewsets/__init__.py
+++ b/galaxy_ng/app/api/v3/viewsets/__init__.py
@@ -16,7 +16,10 @@ from .task import (
     TaskViewSet,
 )
 
-from .sync import SyncConfigViewSet
+from .sync import (
+    SyncConfigViewSet,
+    SyncTaskViewSet,
+)
 
 
 __all__ = (
@@ -29,5 +32,6 @@ __all__ = (
     'CollectionVersionMoveViewSet',
     'NamespaceViewSet',
     'SyncConfigViewSet',
+    'SyncTaskViewSet',
     'TaskViewSet',
 )

--- a/galaxy_ng/app/api/v3/viewsets/sync.py
+++ b/galaxy_ng/app/api/v3/viewsets/sync.py
@@ -3,7 +3,8 @@ from django.http import Http404
 from pulp_ansible.app.models import AnsibleDistribution
 from galaxy_ng.app.access_control import access_policy
 from galaxy_ng.app.api import base as api_base
-from ..serializers.sync import SyncConfigSerializer
+from galaxy_ng.app.models import CollectionSyncTask
+from ..serializers.sync import SyncConfigSerializer, SyncTaskSerializer
 
 
 class SyncConfigViewSet(
@@ -18,4 +19,15 @@ class SyncConfigViewSet(
         distribution = AnsibleDistribution.objects.get(base_path=self.kwargs['path'])
         if distribution and distribution.repository:
             return distribution.repository.remote.ansible_collectionremote
+        raise Http404
+
+
+class SyncTaskViewSet(mixins.ListModelMixin, api_base.GenericViewSet):
+    serializer_class = SyncTaskSerializer
+    permission_classes = [access_policy.CollectionRemoteAccessPolicy]
+
+    def get_queryset(self):
+        distribution = AnsibleDistribution.objects.get(base_path=self.kwargs['path'])
+        if distribution and distribution.repository:
+            return CollectionSyncTask.objects.filter(repository=distribution.repository)
         raise Http404

--- a/galaxy_ng/app/api/v3/viewsets/sync.py
+++ b/galaxy_ng/app/api/v3/viewsets/sync.py
@@ -22,9 +22,12 @@ class SyncConfigViewSet(
         raise Http404
 
 
-class SyncTaskViewSet(mixins.ListModelMixin, api_base.GenericViewSet):
+class SyncTaskViewSet(api_base.ModelViewSet):
+    """List of Synchronization tasks spawned for collections."""
+
     serializer_class = SyncTaskSerializer
     permission_classes = [access_policy.CollectionRemoteAccessPolicy]
+    model = CollectionSyncTask
 
     def get_queryset(self):
         distribution = AnsibleDistribution.objects.get(base_path=self.kwargs['path'])


### PR DESCRIPTION
- Added `/sync/tasks/` endpoint
- Serializer includes Worker, Child and Parent tasks info
- Using same accesspolicy of CollectionRemote

Issue: #459

<details>

<summary>Endpoint results</summary>

```json
galaxy_ng on  sync_tasks [$] via  v3.8.5 (galaxy_ng) took 4s
❯ galaxy /api/automation-hub/content/rh-certified/v3/sync/tasks/
HTTP/1.1 200 OK
X-Powered-By: Express
allow: GET, HEAD, OPTIONS
connection: close
content-length: 3111
content-type: application/json
date: Thu, 24 Sep 2020 19:04:21 GMT
server: gunicorn/20.0.4
vary: Accept, Cookie
x-frame-options: SAMEORIGIN

{
    "data": [
        {
            "repository": "rh-certified",
            "task": {
                "child_tasks": [],
                "created_at": "2020-09-23T19:48:40.918537Z",
                "error": {
                    "description": "401, message='Unauthorized', url=URL('https://cloud.redhat.com/api/automation-hub/v3/collections?offset=0&limit=100')",
                    "traceback": "  File \"/venv/lib64/python3.6/site-packages/rq/worker.py\", line 934, in perform_job\n    rv = job.perform()\n  File \"/venv/lib64/python3.6/site-packages/rq/job.py\", line 686, in perform\n    self._result = self._execute()\n  File \"/venv/lib64/python3.6/site-packages/rq/job.py\", line 692, in _execute\n    return self.func(*self.args, **self.kwargs)\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/tasks/collections.py\", line 81, in sync\n    d_version.create()\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/plugin/stages/declarative_version.py\", line 148, in create\n    loop.run_until_complete(pipeline)\n  File \"/usr/lib64/python3.6/asyncio/base_events.py\", line 484, in run_until_complete\n    return future.result()\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/plugin/stages/api.py\", line 225, in create_pipeline\n    await asyncio.gather(*futures)\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/plugin/stages/api.py\", line 43, in __call__\n    await self.run()\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/tasks/collections.py\", line 288, in run\n    async for metadata in self._fetch_collections():\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/tasks/collections.py\", line 354, in _fetch_collections\n    initial_data = parse_metadata(await downloader.run())\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/download/base.py\", line 227, in run\n    return await self._run(extra_data=extra_data)\n  File \"/venv/lib64/python3.6/site-packages/backoff/_async.py\", line 133, in retry\n    ret = await target(*args, **kwargs)\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/downloaders.py\", line 88, in _run\n    return await super()._run(extra_data=extra_data)\n  File \"/venv/lib64/python3.6/site-packages/backoff/_async.py\", line 133, in retry\n    ret = await target(*args, **kwargs)\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/download/http.py\", line 210, in _run\n    self.raise_for_status(response)\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/downloaders.py\", line 66, in raise_for_status\n    response.raise_for_status()\n  File \"/venv/lib64/python3.6/site-packages/aiohttp/client_reqrep.py\", line 946, in raise_for_status\n    headers=self.headers)\n"
                },
                "finished_at": "2020-09-23T19:48:42.133145Z",
                "parent_task": null,
                "pk": "01c28d6e-ff23-435b-9f90-263c378ca62f",
                "started_at": "2020-09-23T19:48:41.088785Z",
                "state": "failed",
                "updated_at": "2020-09-23T19:48:42.134071Z",
                "worker": {
                    "last_heartbeat": "2020-09-24T19:04:09.825210Z",
                    "missing": false,
                    "name": "1@a2e32df5e8b2"
                }
            }
        }
    ],
    "links": {
        "first": "/api/automation-hub/content/rh-certified/v3/sync/tasks/?limit=10&offset=0",
        "last": "/api/automation-hub/content/rh-certified/v3/sync/tasks/?limit=10&offset=0",
        "next": null,
        "previous": null
    },
    "meta": {
        "count": 1
    }
}
```

</details>