### PR TITLE
Fix OpenAPI spec auth url

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -91,7 +91,7 @@ paths:
   # Authentication
   # -------------------------------------
 
-  /auth/token/:
+  /v3/auth/token/:
     post:
       summary: "Issue Auth Token"
       operationId: createAuthToken


### PR DESCRIPTION
* Fix authentication url
* Change server url to match the dev environment.

## Details

The OpenAPI spec had an incorrect url for authentication, as it hadn't been updated since the URL was changed from `/auth/token` to `/v3/auth/token`.

~~I've also changed the server url so that it properly matches the dev environment, which starts the server on port 8002 rather than 5001.~~ EDIT 3: This change resulted due to my misunderstanding of the containerization setup, and I've revised the PR to omit it.

EDIT: you can view my changes at https://petstore.swagger.io/?url=https://raw.githubusercontent.com/hendersonreed/galaxy_ng/fix-openapi-spec-auth-url/openapi/openapi.yaml#/

EDIT 2: pasted the wrong url in my first edit, so I fixed that.