### PR TITLE
Restrict access to pulp API from reverse proxy

### DIFF
--- a/CHANGES/473.misc
+++ b/CHANGES/473.misc
@@ -1,0 +1,1 @@
+Restricted access to pulpcore and pulp_ansible API from a reverse proxy configured by pulp installer.

--- a/galaxy_ng/app/webserver_snippets/apache.conf
+++ b/galaxy_ng/app/webserver_snippets/apache.conf
@@ -4,3 +4,29 @@ RewriteCond "%{REQUEST_FILENAME}"       !-d
 RewriteRule "^/ui*" "http://${pulp-api}/static/galaxy_ng/index.html" [P]
 ProxyPass "/ui/" "http://${pulp-api}/static/galaxy_ng/index.html"
 ProxyPassReverse "/ui/" "http://${pulp-api}/static/galaxy_ng/index.html"
+
+# WARNING: This is a workaround. It must be removed once
+#          RBAC policies are configured for pulp_ansible and pulpcore APIs.
+<Location "/pulp/api/v3/users/">
+    Deny from all;
+</Location>
+
+<Location "/pulp/api/v3/groups/">
+    Deny from all;
+</Location>
+
+<Location "/pulp/api/v3/remotes/ansible/">
+    Deny from all;
+</Location>
+
+<Location "/pulp/api/v3/repositories/ansible/">
+    Deny from all;
+</Location>
+
+<Location "/pulp/api/v3/distributions/ansible/">
+    Deny from all;
+</Location>
+
+<Location ~ "^/pulp_ansible/galaxy/">
+    Deny from all;
+</Location>

--- a/galaxy_ng/app/webserver_snippets/nginx.conf
+++ b/galaxy_ng/app/webserver_snippets/nginx.conf
@@ -8,3 +8,29 @@ location /ui/ {
     proxy_redirect off;
     proxy_pass http://pulp-api/static/galaxy_ng/index.html;
 }
+
+# WARNING: This is a workaround. It must be removed once
+#          RBAC policies are configured for pulp_ansible and pulpcore APIs.
+location /pulp/api/v3/users/ {
+    return 403;
+}
+
+location /pulp/api/v3/groups/ {
+    return 403;
+}
+
+location /pulp/api/v3/remotes/ansible/ {
+    return 403;
+}
+
+location /pulp/api/v3/repositories/ansible/ {
+    return 403;
+}
+
+location /pulp/api/v3/distributions/ansible/ {
+    return 403;
+}
+
+location ~ ^/pulp_ansible/galaxy/ {
+    return 403;
+}


### PR DESCRIPTION
Restrict access to pulpcore and pulp_ansible API from a reverse proxy
configured by pulp installer.

Issue: #473