### PR TITLE
Use filename namespace on upload when no distro specified

### DIFF
--- a/CHANGES/496.bugfix
+++ b/CHANGES/496.bugfix
@@ -1,0 +1,1 @@
+On upload use filename namespace as distro when no distro specified

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from rest_access_policy import AccessPolicy
+from rest_framework.exceptions import NotFound
 
 from galaxy_ng.app import models
 
@@ -47,7 +48,10 @@ class CollectionAccessPolicy(AccessPolicyBase):
 
     def can_create_collection(self, request, view, permission):
         data = view._get_data(request)
-        namespace = models.Namespace.objects.get(name=data['filename'].namespace)
+        try:
+            namespace = models.Namespace.objects.get(name=data['filename'].namespace)
+        except models.Namespace.DoesNotExist:
+            raise NotFound('Namespace in filename not found.')
         return request.user.has_perm('galaxy.upload_to_namespace', namespace)
 
 

--- a/galaxy_ng/app/api/urls.py
+++ b/galaxy_ng/app/api/urls.py
@@ -23,10 +23,14 @@ v3_urlpatterns = [
     # and pass in path param 'path' that actually means
     # the base_path of the Distribution. For the default case,
     # use the hard coded 'default' distro (ie, 'automation-hub')
-    path("",
-         # include((v3_urls, app_name), namespace='default-content'),
-         include((v3_urls, app_name), namespace='default-content'),
-         {'path': DEFAULT_DISTRIBUTION_BASE_PATH}),
+    path(
+        "",
+        include((v3_urls, app_name), namespace='default-content'),
+        {
+            'no_path_specified': True,
+            'path': DEFAULT_DISTRIBUTION_BASE_PATH,
+        }
+    ),
 ]
 
 content_v3_urlpatterns = [

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -29,6 +29,7 @@ STATIC_URL = "/static/"
 
 # A client connection to /api/automation-hub/ is the same as a client connection
 # to /api/automation-hub/content/<GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH>/
+# with the exception of galaxy_ng.app.api.v3.viewsets.CollectionUploadViewSet
 GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH = "published"
 
 GALAXY_API_STAGING_DISTRIBUTION_BASE_PATH = "staging"


### PR DESCRIPTION
Closes-Issue: #496

Uploads with no distro specified will use `inbound-<namespace>` distro based on filename namespace