### PR TITLE
Better error for invalid filename

### DIFF
--- a/CHANGES/31.bugfix
+++ b/CHANGES/31.bugfix
@@ -1,0 +1,1 @@
+Make error return for upload filename parsing errors provides an error code 'invalid'

--- a/galaxy_ng/app/api/v3/serializers/collection.py
+++ b/galaxy_ng/app/api/v3/serializers/collection.py
@@ -138,7 +138,7 @@ class CollectionUploadSerializer(Serializer):
         try:
             filename_tuple = parse_collection_filename(filename)
         except ValueError as exc:
-            errors['filename'] = _get_error_details(exc)
+            errors['filename'] = _get_error_details(exc, default_code='invalid')
             log.error('CollectionUploadSerializer validation of filename failed: %s',
                       errors['filename'])
             raise ValidationError(errors)


### PR DESCRIPTION
The ValidationError was getting raised with a 'details'
dict that didn't include a 'code', so it was unset.

Pass in a code to use _get_error_details() to generate
the 'detail' dict correctly with a valid 'invalid'.

Fixes #31