### PR TITLE
Remove excludes from check_pulpcore_includes CI script

### DIFF
--- a/.travis/check_pulpcore_imports.sh
+++ b/.travis/check_pulpcore_imports.sh
@@ -12,7 +12,6 @@ set -uv
 # check for imports not from pulpcore.plugin. exclude tests
 MATCHES=$(grep -n -r --include \*.py "from pulpcore.*import" . \
     | grep -v "tests\|plugin" \
-    | grep -v "repository.*add_and_remove" \
     | grep -v "pulpcore.app.*viewsets")
 
 if [ $? -ne 1 ]; then

--- a/CHANGES/390.misc
+++ b/CHANGES/390.misc
@@ -1,0 +1,1 @@
+Remove excludes from check_pulpcore_includes CI script

--- a/galaxy_ng/app/tasks/synclist.py
+++ b/galaxy_ng/app/tasks/synclist.py
@@ -10,8 +10,7 @@ from pulpcore.plugin.models import (
     TaskGroup,
 )
 
-from pulpcore.app.tasks.repository import add_and_remove
-from pulpcore.plugin.tasking import enqueue_with_reservation
+from pulpcore.plugin.tasking import add_and_remove, enqueue_with_reservation
 
 from pulp_ansible.app.models import (
     AnsibleRepository,


### PR DESCRIPTION
Since we require pulpcore 3.7+ now, we don't need
these pulpcore import excludes in the travis ci checks

Issue: #390