### PR TITLE
Temporary django admin site at custom URL

### DIFF
--- a/.travis/check_pulpcore_imports.sh
+++ b/.travis/check_pulpcore_imports.sh
@@ -12,7 +12,8 @@ set -uv
 # check for imports not from pulpcore.plugin. exclude tests
 MATCHES=$(grep -n -r --include \*.py "from pulpcore.*import" . \
     | grep -v "tests\|plugin" \
-    | grep -v "pulpcore.app.*viewsets")
+    | grep -v "pulpcore.app.*viewsets" \
+    | grep -v "pulpcore\.app.*admin")
 
 if [ $? -ne 1 ]; then
   printf "\nERROR: Detected bad imports from pulpcore:\n"

--- a/galaxy_ng/app/customadmin.py
+++ b/galaxy_ng/app/customadmin.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+
+from pulpcore.app.admin import TaskAdmin
+from pulpcore.plugin.models import Task
+
+
+site = admin.AdminSite(name="galaxy-admin")
+site.register(Task, TaskAdmin)

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -26,6 +26,7 @@ AUTH_USER_MODEL = 'galaxy.User'
 #                  2. Rename API_PATH_PREFIX to GALAXY_API_ROOT
 GALAXY_API_PATH_PREFIX = "/api/galaxy"
 STATIC_URL = "/static/"
+ADMIN_SITE_URL = "automation-hub/admin/"
 
 # A client connection to /api/automation-hub/ is the same as a client connection
 # to /api/automation-hub/content/<GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH>/

--- a/galaxy_ng/app/urls.py
+++ b/galaxy_ng/app/urls.py
@@ -2,13 +2,19 @@ from django.conf import settings
 from django.urls import include, path
 
 from galaxy_ng.app.api import urls as api_urls
+from galaxy_ng.app import customadmin as admin
 from galaxy_ng.ui import urls as ui_urls
 
-API_PATH_PREFIX = settings.GALAXY_API_PATH_PREFIX.strip('/')
 
-app_name = "galaxy"
-urlpatterns = [
-    path("", include(ui_urls)),
+API_PATH_PREFIX = settings.GALAXY_API_PATH_PREFIX.strip("/")
+
+galaxy_urls = [
     path(f"{API_PATH_PREFIX}/", include(api_urls)),
-    path('', include('django_prometheus.urls')),
+]
+
+urlpatterns = [
+    path("", include((galaxy_urls, "api"), namespace="galaxy")),
+    path("", include(ui_urls)),
+    path("", include("django_prometheus.urls")),
+    path(settings.ADMIN_SITE_URL, admin.site.urls),
 ]


### PR DESCRIPTION
This change enables custom admin site at configurable URL
It is temporary workaround and should be removed when
pulp/pulpcore#948 is released.

No-Issue