### PR TITLE
Remove ui api non-repo collections endpoint

### DIFF
--- a/galaxy_ng/app/api/ui/old_urls.py
+++ b/galaxy_ng/app/api/ui/old_urls.py
@@ -10,7 +10,6 @@ router = routers.SimpleRouter()
 # TODO: Replace with a RedirectView
 router.register('namespaces', viewsets.NamespaceViewSet, basename='namespaces')
 router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='my-namespaces')
-router.register('collections', viewsets.CollectionViewSet, basename='collections')
 router.register('users', viewsets.UserViewSet, basename='users')
 router.register('collection-versions',
                 viewsets.CollectionVersionViewSet, basename='collection-versions')

--- a/galaxy_ng/app/api/ui/old_urls.py
+++ b/galaxy_ng/app/api/ui/old_urls.py
@@ -10,7 +10,6 @@ router = routers.SimpleRouter()
 # TODO: Replace with a RedirectView
 router.register('namespaces', viewsets.NamespaceViewSet, basename='namespaces')
 router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='my-namespaces')
-router.register('collections', viewsets.CollectionViewSetDeprecated, basename='collections')
 router.register('users', viewsets.UserViewSet, basename='users')
 router.register('collection-versions',
                 viewsets.CollectionVersionViewSet, basename='collection-versions')
@@ -32,6 +31,17 @@ urlpatterns = [
     path('', include(router.urls)),
 
     path('auth/', include(auth_views)),
+
+    path(
+        'collections/',
+        viewsets.CollectionViewSetDeprecated.as_view({'get': 'list'}),
+        name='collections-list'
+    ),
+    path(
+        'collections/<str:namespace>/<str:name>/',
+        viewsets.CollectionViewSetDeprecated.as_view({'get': 'retrieve'}),
+        name='collections-detail'
+    ),
 
     # NOTE: Using path instead of SimpleRouter because SimpleRouter expects retrieve
     # to look up values with an ID

--- a/galaxy_ng/app/api/ui/old_urls.py
+++ b/galaxy_ng/app/api/ui/old_urls.py
@@ -10,6 +10,7 @@ router = routers.SimpleRouter()
 # TODO: Replace with a RedirectView
 router.register('namespaces', viewsets.NamespaceViewSet, basename='namespaces')
 router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='my-namespaces')
+router.register('collections', viewsets.CollectionViewSetDeprecated, basename='collections')
 router.register('users', viewsets.UserViewSet, basename='users')
 router.register('collection-versions',
                 viewsets.CollectionVersionViewSet, basename='collection-versions')

--- a/galaxy_ng/app/api/ui/serializers/__init__.py
+++ b/galaxy_ng/app/api/ui/serializers/__init__.py
@@ -2,8 +2,8 @@ from .auth import (
     LoginSerializer,
 )
 from .collection import (
-    RepositoryCollectionDetailSerializer,
-    RepositoryCollectionListSerializer,
+    CollectionDetailSerializer,
+    CollectionListSerializer,
     CollectionVersionSerializer,
     CertificationSerializer,
     CollectionVersionDetailSerializer,
@@ -33,8 +33,8 @@ __all__ = (
     # auth
     'LoginSerializer',
     # collection
-    'RepositoryCollectionDetailSerializer',
-    'RepositoryCollectionListSerializer',
+    'CollectionDetailSerializer',
+    'CollectionListSerializer',
     'CollectionVersionSerializer',
     'CertificationSerializer',
     'CollectionVersionDetailSerializer',

--- a/galaxy_ng/app/api/ui/serializers/__init__.py
+++ b/galaxy_ng/app/api/ui/serializers/__init__.py
@@ -4,8 +4,6 @@ from .auth import (
 from .collection import (
     RepositoryCollectionDetailSerializer,
     RepositoryCollectionListSerializer,
-    CollectionDetailSerializer,
-    CollectionListSerializer,
     CollectionVersionSerializer,
     CertificationSerializer,
     CollectionVersionDetailSerializer,
@@ -37,8 +35,6 @@ __all__ = (
     # collection
     'RepositoryCollectionDetailSerializer',
     'RepositoryCollectionListSerializer',
-    'CollectionDetailSerializer',
-    'CollectionListSerializer',
     'CollectionVersionSerializer',
     'CertificationSerializer',
     'CollectionVersionDetailSerializer',

--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -109,12 +109,12 @@ class CollectionVersionDetailSerializer(CollectionVersionBaseSerializer):
     docs_blob = serializers.JSONField()
 
 
-class RepositoryCollectionVersionSummarySerializer(Serializer):
+class CollectionVersionSummarySerializer(Serializer):
     version = serializers.CharField()
     created = serializers.CharField(source='pulp_created')
 
 
-class _RepositoryCollectionSerializer(Serializer):
+class _CollectionSerializer(Serializer):
     """ Serializer for pulp_ansible CollectionViewSet.
     Uses CollectionVersion object to serialize associated Collection data.
     """
@@ -154,18 +154,18 @@ class _RepositoryCollectionSerializer(Serializer):
         return next(iter(versions_in_repo), None)
 
 
-class RepositoryCollectionListSerializer(_RepositoryCollectionSerializer):
+class CollectionListSerializer(_CollectionSerializer):
     def get_latest_version(self, obj):
         version = self._get_latest_version(obj)
         return CollectionVersionBaseSerializer(version).data
 
 
-class RepositoryCollectionDetailSerializer(_RepositoryCollectionSerializer):
+class CollectionDetailSerializer(_CollectionSerializer):
     all_versions = serializers.SerializerMethodField()
 
     def get_all_versions(self, obj):
         versions_in_repo = self._get_versions_in_repo(obj)
-        return RepositoryCollectionVersionSummarySerializer(versions_in_repo, many=True).data
+        return CollectionVersionSummarySerializer(versions_in_repo, many=True).data
 
     def get_latest_version(self, obj):
         version = self._get_latest_version(obj)

--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -45,11 +45,6 @@ class ContentSerializer(Serializer):
     description = serializers.CharField()
 
 
-class CollectionVersionSummarySerializer(Serializer):
-    version = serializers.CharField()
-    created = serializers.CharField()
-
-
 class CollectionMetadataSerializer(Serializer):
     dependencies = serializers.JSONField()
     contents = serializers.JSONField()
@@ -112,40 +107,6 @@ class CertificationSerializer(Serializer):
 
 class CollectionVersionDetailSerializer(CollectionVersionBaseSerializer):
     docs_blob = serializers.JSONField()
-
-
-class _CollectionSerializer(Serializer):
-    id = serializers.UUIDField()
-    namespace = serializers.SerializerMethodField()
-    name = serializers.CharField()
-    download_count = serializers.IntegerField(default=0)
-    latest_version = CollectionVersionBaseSerializer(source='*')
-    deprecated = serializers.BooleanField()
-
-    def _get_namespace(self, obj):
-        raise NotImplementedError
-
-    def get_namespace(self, obj):
-        namespace = self._get_namespace(obj)
-        return NamespaceSummarySerializer(namespace).data
-
-
-class CollectionListSerializer(_CollectionSerializer):
-    def _get_namespace(self, obj):
-        name = obj['namespace']
-        return self.context['namespaces'].get(name, None)
-
-
-class CollectionDetailSerializer(_CollectionSerializer):
-    latest_version = CollectionVersionDetailSerializer(source='*')
-    all_versions = serializers.SerializerMethodField()
-
-    def _get_namespace(self, obj):
-        return self.context['namespace']
-
-    def get_all_versions(self, obj):
-        return [CollectionVersionSummarySerializer(version).data
-                for version in self.context['all_versions']]
 
 
 class RepositoryCollectionVersionSummarySerializer(Serializer):

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -12,6 +12,7 @@ router = routers.SimpleRouter()
 router.register('namespaces', viewsets.NamespaceViewSet, basename='namespaces')
 router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='my-namespaces')
 router.register('my-synclists', viewsets.MySyncListViewSet, basename='my-synclists')
+router.register('collections', viewsets.CollectionViewSetDeprecated, basename='collections')
 router.register('users', viewsets.UserViewSet, basename='users')
 router.register('collection-versions',
                 viewsets.CollectionVersionViewSet, basename='collection-versions')

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -12,7 +12,6 @@ router = routers.SimpleRouter()
 router.register('namespaces', viewsets.NamespaceViewSet, basename='namespaces')
 router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='my-namespaces')
 router.register('my-synclists', viewsets.MySyncListViewSet, basename='my-synclists')
-router.register('collections', viewsets.CollectionViewSetDeprecated, basename='collections')
 router.register('users', viewsets.UserViewSet, basename='users')
 router.register('collection-versions',
                 viewsets.CollectionVersionViewSet, basename='collection-versions')
@@ -79,6 +78,17 @@ paths = [
     path(
         'repo/<str:path>/<str:namespace>/<str:name>/',
         viewsets.CollectionViewSet.as_view({'get': 'retrieve'}),
+        name='collections-detail'
+    ),
+
+    path(
+        'collections/',
+        viewsets.CollectionViewSetDeprecated.as_view({'get': 'list'}),
+        name='collections-list'
+    ),
+    path(
+        'collections/<str:namespace>/<str:name>/',
+        viewsets.CollectionViewSetDeprecated.as_view({'get': 'retrieve'}),
         name='collections-detail'
     ),
 

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -12,7 +12,6 @@ router = routers.SimpleRouter()
 router.register('namespaces', viewsets.NamespaceViewSet, basename='namespaces')
 router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='my-namespaces')
 router.register('my-synclists', viewsets.MySyncListViewSet, basename='my-synclists')
-router.register('collections', viewsets.CollectionViewSet, basename='collections')
 router.register('users', viewsets.UserViewSet, basename='users')
 router.register('collection-versions',
                 viewsets.CollectionVersionViewSet, basename='collection-versions')

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -72,13 +72,13 @@ paths = [
 
     path(
         'repo/<str:path>/',
-        viewsets.RepositoryCollectionViewSet.as_view({'get': 'list'}),
-        name='repo-collections-list'
+        viewsets.CollectionViewSet.as_view({'get': 'list'}),
+        name='collections-list'
     ),
     path(
         'repo/<str:path>/<str:namespace>/<str:name>/',
-        viewsets.RepositoryCollectionViewSet.as_view({'get': 'retrieve'}),
-        name='repo-collections-detail'
+        viewsets.CollectionViewSet.as_view({'get': 'retrieve'}),
+        name='collections-detail'
     ),
 
     # NOTE: Using path instead of SimpleRouter because SimpleRouter expects retrieve

--- a/galaxy_ng/app/api/ui/viewsets/__init__.py
+++ b/galaxy_ng/app/api/ui/viewsets/__init__.py
@@ -3,7 +3,6 @@ from .namespace import (
 )
 
 from .collection import (
-    CollectionViewSet,
     RepositoryCollectionViewSet,
     CollectionVersionViewSet,
     CollectionImportViewSet,
@@ -22,7 +21,6 @@ __all__ = (
     'NamespaceViewSet',
     'MyNamespaceViewSet',
     'MySyncListViewSet',
-    'CollectionViewSet',
     'RepositoryCollectionViewSet',
     'CollectionVersionViewSet',
     'CollectionImportViewSet',

--- a/galaxy_ng/app/api/ui/viewsets/__init__.py
+++ b/galaxy_ng/app/api/ui/viewsets/__init__.py
@@ -3,7 +3,7 @@ from .namespace import (
 )
 
 from .collection import (
-    RepositoryCollectionViewSet,
+    CollectionViewSet,
     CollectionVersionViewSet,
     CollectionImportViewSet,
     CollectionRemoteViewSet
@@ -21,7 +21,7 @@ __all__ = (
     'NamespaceViewSet',
     'MyNamespaceViewSet',
     'MySyncListViewSet',
-    'RepositoryCollectionViewSet',
+    'CollectionViewSet',
     'CollectionVersionViewSet',
     'CollectionImportViewSet',
     'CollectionRemoteViewSet',

--- a/galaxy_ng/app/api/ui/viewsets/__init__.py
+++ b/galaxy_ng/app/api/ui/viewsets/__init__.py
@@ -4,6 +4,7 @@ from .namespace import (
 
 from .collection import (
     CollectionViewSet,
+    CollectionViewSetDeprecated,
     CollectionVersionViewSet,
     CollectionImportViewSet,
     CollectionRemoteViewSet
@@ -22,6 +23,7 @@ __all__ = (
     'MyNamespaceViewSet',
     'MySyncListViewSet',
     'CollectionViewSet',
+    'CollectionViewSetDeprecated',
     'CollectionVersionViewSet',
     'CollectionImportViewSet',
     'CollectionRemoteViewSet',

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -23,15 +23,15 @@ from galaxy_ng.app.api.ui import serializers, versioning
 from galaxy_ng.app.common import pulp
 
 
-class RepositoryCollectionFilter(CollectionVersionFilter):
+class CollectionFilter(CollectionVersionFilter):
     versioning_class = versioning.UIVersioning
     keywords = filters.CharFilter(field_name="keywords", method="filter_by_q")
 
 
-class RepositoryCollectionViewSet(pulp_ansible_galaxy_views.CollectionViewSet):
+class CollectionViewSet(pulp_ansible_galaxy_views.CollectionViewSet):
     """ Viewset that uses CollectionVersion to display data for Collection."""
     versioning_class = versioning.UIVersioning
-    filterset_class = RepositoryCollectionFilter
+    filterset_class = CollectionFilter
 
     # TODO(awcrosby): remove once pulp_ansible is_highest param filters by repo
     # https://pulp.plan.io/issues/7428
@@ -54,9 +54,9 @@ class RepositoryCollectionViewSet(pulp_ansible_galaxy_views.CollectionViewSet):
 
     def get_serializer_class(self):
         if self.action == 'list':
-            return serializers.RepositoryCollectionListSerializer
+            return serializers.CollectionListSerializer
         else:
-            return serializers.RepositoryCollectionDetailSerializer
+            return serializers.CollectionDetailSerializer
 
 
 class CollectionVersionFilter(filterset.FilterSet):

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -59,6 +59,16 @@ class CollectionViewSet(pulp_ansible_galaxy_views.CollectionViewSet):
             return serializers.CollectionDetailSerializer
 
 
+# TODO: Remove when ui is updated and no longer uses this endpoint
+class CollectionViewSetDeprecated(CollectionViewSet):
+    """Temporary support of old /_ui/collections/ endpoint without use of
+    certification flag. This shows content from the 'published' repo."""
+
+    def get_queryset(self):
+        self.kwargs["path"] = 'published'
+        return super().get_queryset()
+
+
 class CollectionVersionFilter(filterset.FilterSet):
     repository = filters.CharFilter(field_name='repository', method='repo_filter')
     versioning_class = versioning.UIVersioning

--- a/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
@@ -120,13 +120,13 @@ class TestUiCollectionViewSet(BaseTestCase):
         _get_create_version_in_repo(self.namespace, self.collection1, '1.0.0', self.repo2)
 
         self.repo1_list_url = get_current_ui_url(
-            'repo-collections-list', kwargs={'path': 'repo1'})
+            'collections-list', kwargs={'path': 'repo1'})
         self.repo2_list_url = get_current_ui_url(
-            'repo-collections-list', kwargs={'path': 'repo2'})
+            'collections-list', kwargs={'path': 'repo2'})
         self.repo3_list_url = get_current_ui_url(
-            'repo-collections-list', kwargs={'path': 'repo3'})
+            'collections-list', kwargs={'path': 'repo3'})
         self.repo1_collection1_detail_url = get_current_ui_url(
-            'repo-collections-detail',
+            'collections-detail',
             kwargs={
                 'path': 'repo1',
                 'namespace': namespace_name,


### PR DESCRIPTION
This endpoint is no longer used by the UI and was replaced with per-repo collections logic.