### PR TITLE
API: Surface all remote config options

### DIFF
--- a/CHANGES/21.misc
+++ b/CHANGES/21.misc
@@ -1,0 +1,1 @@
+API: Surface all remote config options

--- a/galaxy_ng/app/api/ui/serializers/__init__.py
+++ b/galaxy_ng/app/api/ui/serializers/__init__.py
@@ -7,7 +7,6 @@ from .collection import (
     CollectionVersionSerializer,
     CollectionVersionDetailSerializer,
     CollectionVersionBaseSerializer,
-    CollectionRemoteSerializer,
 )
 from .imports import (
     ImportTaskDetailSerializer,
@@ -37,7 +36,6 @@ __all__ = (
     'CollectionVersionSerializer',
     'CollectionVersionDetailSerializer',
     'CollectionVersionBaseSerializer',
-    'CollectionRemoteSerializer',
     # imports
     'ImportTaskDetailSerializer',
     'ImportTaskListSerializer',

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -20,6 +20,7 @@ from galaxy_ng.app import models
 from galaxy_ng.app.api import base as api_base
 from galaxy_ng.app.access_control import access_policy
 from galaxy_ng.app.api.ui import serializers, versioning
+from galaxy_ng.app.api.v3.serializers.sync import CollectionRemoteSerializer
 from galaxy_ng.app.common import pulp
 
 
@@ -180,6 +181,6 @@ class CollectionImportViewSet(api_base.GenericViewSet):
 
 class CollectionRemoteViewSet(api_base.ModelViewSet):
     queryset = CollectionRemote.objects.all().order_by('name')
-    serializer_class = serializers.CollectionRemoteSerializer
+    serializer_class = CollectionRemoteSerializer
 
     permission_classes = [access_policy.CollectionRemoteAccessPolicy]

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -1,18 +1,91 @@
 from rest_framework import serializers
-from pulp_ansible.app.models import CollectionRemote
-from pulp_ansible.app.viewsets import CollectionRemoteSerializer
+
+from pulp_ansible.app import viewsets as pulp_viewsets
+from pulp_ansible.app.models import (
+    AnsibleDistribution,
+    AnsibleRepository,
+    CollectionRemote,
+)
+
 from galaxy_ng.app.constants import COMMUNITY_DOMAINS
+from galaxy_ng.app.models.collectionsync import CollectionSyncTask
 
 
-class SyncConfigSerializer(CollectionRemoteSerializer):
+class AnsibleDistributionSerializer(serializers.ModelSerializer):
+    created_at = serializers.DateTimeField(source='pulp_created')
+    updated_at = serializers.DateTimeField(source='pulp_last_updated')
+
+    class Meta:
+        model = AnsibleDistribution
+        fields = (
+            'name',
+            'base_path',
+            'content_guard',
+            'created_at',
+            'updated_at',
+        )
+
+
+class LastSyncTaskMixin:
+
+    def get_last_sync_task_queryset(self, obj):
+        raise NotImplementedError("subclass must implement get_last_sync_task_queryset")
+
+    def get_last_sync_task(self, obj):
+        sync_task = self.get_last_sync_task_queryset(obj)
+        if not sync_task:
+            # UI handles `null` as "no status"
+            return
+
+        return {
+            "task_id": sync_task.id,
+            "state": sync_task.task.state,
+            "started_at": sync_task.task.started_at,
+            "finished_at": sync_task.task.finished_at,
+            "error": sync_task.task.error
+        }
+
+
+class AnsibleRepositorySerializer(LastSyncTaskMixin, serializers.ModelSerializer):
+    distributions = serializers.SerializerMethodField()
+    last_sync_task = serializers.SerializerMethodField()
+    created_at = serializers.DateTimeField(source='pulp_created')
+    updated_at = serializers.DateTimeField(source='pulp_last_updated')
+
+    class Meta:
+        model = AnsibleRepository
+        fields = (
+            'name',
+            'description',
+            'next_version',
+            'distributions',
+            'created_at',
+            'updated_at',
+            'last_sync_task',
+        )
+
+    def get_distributions(self, obj):
+        return [
+            AnsibleDistributionSerializer(distro).data
+            for distro in obj.ansible_ansibledistribution.all()
+        ]
+
+    def get_last_sync_task_queryset(self, obj):
+        return CollectionSyncTask.objects.filter(repository=obj).last()
+
+
+class CollectionRemoteSerializer(LastSyncTaskMixin, pulp_viewsets.CollectionRemoteSerializer):
+    last_sync_task = serializers.SerializerMethodField()
     created_at = serializers.DateTimeField(source='pulp_created', required=False)
     updated_at = serializers.DateTimeField(source='pulp_last_updated', required=False)
     token = serializers.CharField(allow_null=True, required=False, max_length=2000, write_only=True)
     name = serializers.CharField(read_only=True)
+    repositories = serializers.SerializerMethodField()
 
     class Meta:
         model = CollectionRemote
         fields = (
+            'pk',
             'name',
             'url',
             'auth_url',
@@ -21,7 +94,27 @@ class SyncConfigSerializer(CollectionRemoteSerializer):
             'requirements_file',
             'created_at',
             'updated_at',
+            'username',
+            'password',
+            'proxy_url',
+            'tls_validation',
+            'client_key',
+            'client_cert',
+            'ca_cert',
+            'last_sync_task',
+            'repositories',
+            'pulp_href',
+            'download_concurrency',
         )
+        extra_kwargs = {
+            'name': {'read_only': True},
+            'pulp_href': {'read_only': True},
+            'password': {'write_only': True},
+            'token': {'write_only': True},
+            'client_key': {'write_only': True},
+            'client_cert': {'write_only': True},
+            'ca_cert': {'write_only': True},
+        }
 
     def validate(self, data):
         if not data.get('requirements_file') and any(
@@ -35,3 +128,16 @@ class SyncConfigSerializer(CollectionRemoteSerializer):
                 }
             )
         return super().validate(data)
+
+    def get_repositories(self, obj):
+        return [
+            AnsibleRepositorySerializer(repo).data
+            for repo in obj.repository_set.all()
+        ]
+
+    def get_last_sync_task_queryset(self, obj):
+        """Gets last_sync_task from Pulp using remote->repository relation"""
+
+        return CollectionSyncTask.objects.filter(
+            repository=obj.repository_set.order_by('-pulp_last_updated').first()
+        ).first()

--- a/galaxy_ng/app/api/v3/viewsets/sync.py
+++ b/galaxy_ng/app/api/v3/viewsets/sync.py
@@ -3,7 +3,7 @@ from django.http import Http404
 from pulp_ansible.app.models import AnsibleDistribution
 from galaxy_ng.app.access_control import access_policy
 from galaxy_ng.app.api import base as api_base
-from ..serializers.sync import SyncConfigSerializer
+from ..serializers.sync import CollectionRemoteSerializer
 
 
 class SyncConfigViewSet(
@@ -11,7 +11,7 @@ class SyncConfigViewSet(
     mixins.UpdateModelMixin,
     api_base.GenericViewSet,
 ):
-    serializer_class = SyncConfigSerializer
+    serializer_class = CollectionRemoteSerializer
     permission_classes = [access_policy.CollectionRemoteAccessPolicy]
 
     def get_object(self):


### PR DESCRIPTION
- Combined serializers for /remotes and /sync/config as the model is the
  same
- Used a Mixin to deduplicate existing code
- Added extra fields to the serializer: 
  - username
  - password
  - proxy_url
  - client_key
  - client_cert
  - tls_validation
  - ca_cert
  - pulp_href
  - pk
  - download_concurrecy

Issue: AAH-21

Reference: https://pulp-ansible.readthedocs.io/en/latest/restapi.html#operation/remotes_ansible_collection_list