### PR TITLE
Fix my-distributions show only sycnlist distros with obj perms

### DIFF
--- a/CHANGES/27.bugfix
+++ b/CHANGES/27.bugfix
@@ -1,0 +1,1 @@
+Fix my-distributions show only sycnlist distros with obj perms

--- a/galaxy_ng/app/api/ui/viewsets/distribution.py
+++ b/galaxy_ng/app/api/ui/viewsets/distribution.py
@@ -30,6 +30,7 @@ class MyDistributionViewSet(DistributionViewSet):
             self.request.user,
             'galaxy.change_synclist',
             any_perm=True,
+            accept_global_perms=False,
             klass=models.SyncList
         )
 


### PR DESCRIPTION
Add 'accept_global_perms' to the get_objects_for_user() request
to avoid hitting scenario 2 mentioned in
https://django-guardian.readthedocs.io/en/stable/api/guardian.shortcuts.html#get-objects-for-user

The default for 'accept_global_perms' is True, which makes
get_objects_for_user() match any objects based on model
perms not object perms.

Issue: AAH-27