### PR TITLE
Add more fields to /tasks endpoint

### DIFF
--- a/.travis/check_pulpcore_imports.sh
+++ b/.travis/check_pulpcore_imports.sh
@@ -13,7 +13,8 @@ set -uv
 MATCHES=$(grep -n -r --include \*.py "from pulpcore.*import" . \
     | grep -v "tests\|plugin" \
     | grep -v "pulpcore.app.*viewsets" \
-    | grep -v "pulpcore\.app.*admin")
+    | grep -v "pulpcore\.app.*admin" \
+    | grep -v "ProgressReportSerializer")
 
 if [ $? -ne 1 ]; then
   printf "\nERROR: Detected bad imports from pulpcore:\n"

--- a/CHANGES/16.misc
+++ b/CHANGES/16.misc
@@ -1,1 +1,1 @@
-Add sync tasks endpoint
+Add more fields to /tasks endpoint

--- a/CHANGES/16.misc
+++ b/CHANGES/16.misc
@@ -1,0 +1,1 @@
+Add sync tasks endpoint

--- a/galaxy_ng/app/api/v3/serializers/__init__.py
+++ b/galaxy_ng/app/api/v3/serializers/__init__.py
@@ -16,7 +16,7 @@ from .group import (
 
 from .task import (
     TaskSerializer,
-    TaskDetailSerializer,
+    TaskSummarySerializer,
 )
 
 
@@ -29,5 +29,5 @@ __all__ = (
     'NamespaceSerializer',
     'NamespaceSummarySerializer',
     'TaskSerializer',
-    'TaskDetailSerializer',
+    'TaskSummarySerializer',
 )

--- a/galaxy_ng/app/api/v3/serializers/__init__.py
+++ b/galaxy_ng/app/api/v3/serializers/__init__.py
@@ -16,6 +16,7 @@ from .group import (
 
 from .task import (
     TaskSerializer,
+    TaskDetailSerializer,
 )
 
 
@@ -28,4 +29,5 @@ __all__ = (
     'NamespaceSerializer',
     'NamespaceSummarySerializer',
     'TaskSerializer',
+    'TaskDetailSerializer',
 )

--- a/galaxy_ng/app/api/v3/serializers/task.py
+++ b/galaxy_ng/app/api/v3/serializers/task.py
@@ -10,12 +10,15 @@ from galaxy_ng.app.models import CollectionSyncTask
 log = logging.getLogger(__name__)
 
 
-class TaskSerializer(serializers.ModelSerializer):
+class BaseTaskSerializer(serializers.ModelSerializer):
     pulp_id = serializers.UUIDField(source='pk')
     name = serializers.CharField()
     state = serializers.CharField()
     started_at = serializers.DateTimeField()
     finished_at = serializers.DateTimeField()
+
+
+class TaskDetailSerializer(BaseTaskSerializer):
     created_at = serializers.DateTimeField(source='pulp_created')
     updated_at = serializers.DateTimeField(source='pulp_last_updated')
     worker = serializers.SerializerMethodField()
@@ -53,4 +56,16 @@ class TaskSerializer(serializers.ModelSerializer):
             'child_tasks',
             'repository',
             'progress_reports',
+        )
+
+
+class TaskSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Task
+        fields = (
+            'pulp_id',
+            'name',
+            'state',
+            'started_at',
+            'finished_at',
         )

--- a/galaxy_ng/app/api/v3/serializers/task.py
+++ b/galaxy_ng/app/api/v3/serializers/task.py
@@ -2,8 +2,8 @@ import logging
 from typing import Any, Dict, Optional
 from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field
+from pulpcore.app.serializers import ProgressReportSerializer
 from pulpcore.plugin.models import Task
-
 from galaxy_ng.app.models import CollectionSyncTask
 
 
@@ -20,6 +20,7 @@ class TaskSerializer(serializers.ModelSerializer):
     updated_at = serializers.DateTimeField(source='pulp_last_updated')
     worker = serializers.SerializerMethodField()
     repository = serializers.SerializerMethodField()
+    progress_reports = ProgressReportSerializer(many=True, read_only=True)
 
     @extend_schema_field(Dict[str, Any])
     def get_worker(self, obj):
@@ -50,4 +51,5 @@ class TaskSerializer(serializers.ModelSerializer):
             'parent_task',
             'child_tasks',
             'repository',
+            'progress_reports',
         )

--- a/galaxy_ng/app/api/v3/serializers/task.py
+++ b/galaxy_ng/app/api/v3/serializers/task.py
@@ -22,13 +22,14 @@ class TaskSerializer(serializers.ModelSerializer):
     repository = serializers.SerializerMethodField()
     progress_reports = ProgressReportSerializer(many=True, read_only=True)
 
-    @extend_schema_field(Dict[str, Any])
+    @extend_schema_field(Optional[Dict[str, Any]])
     def get_worker(self, obj):
-        return {
-            'name': obj.worker.name,
-            'missing': obj.worker.missing,
-            'last_heartbeat': obj.worker.last_heartbeat,
-        }
+        if obj.worker:
+            return {
+                'name': obj.worker.name,
+                'missing': obj.worker.missing,
+                'last_heartbeat': obj.worker.last_heartbeat,
+            }
 
     @extend_schema_field(Optional[str])
     def get_repository(self, obj):

--- a/galaxy_ng/app/api/v3/viewsets/task.py
+++ b/galaxy_ng/app/api/v3/viewsets/task.py
@@ -3,10 +3,15 @@ import logging
 from pulpcore.plugin import viewsets as pulp_core_viewsets
 
 from galaxy_ng.app.api.base import LocalSettingsMixin
-from galaxy_ng.app.api.v3.serializers import TaskSerializer
+from galaxy_ng.app.api.v3.serializers import TaskSerializer, TaskDetailSerializer
 from galaxy_ng.app.access_control import access_policy
 
 log = logging.getLogger(__name__)
+
+
+class TaskDetailViewSet(LocalSettingsMixin, pulp_core_viewsets.TaskViewSet):
+    permission_classes = [access_policy.TaskAccessPolicy]
+    serializer_class = TaskDetailSerializer
 
 
 class TaskViewSet(LocalSettingsMixin, pulp_core_viewsets.TaskViewSet):

--- a/galaxy_ng/app/api/v3/viewsets/task.py
+++ b/galaxy_ng/app/api/v3/viewsets/task.py
@@ -3,17 +3,18 @@ import logging
 from pulpcore.plugin import viewsets as pulp_core_viewsets
 
 from galaxy_ng.app.api.base import LocalSettingsMixin
-from galaxy_ng.app.api.v3.serializers import TaskSerializer, TaskDetailSerializer
+from galaxy_ng.app.api.v3.serializers import TaskSerializer, TaskSummarySerializer
 from galaxy_ng.app.access_control import access_policy
 
 log = logging.getLogger(__name__)
 
 
-class TaskDetailViewSet(LocalSettingsMixin, pulp_core_viewsets.TaskViewSet):
-    permission_classes = [access_policy.TaskAccessPolicy]
-    serializer_class = TaskDetailSerializer
-
-
 class TaskViewSet(LocalSettingsMixin, pulp_core_viewsets.TaskViewSet):
     permission_classes = [access_policy.TaskAccessPolicy]
     serializer_class = TaskSerializer
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return TaskSummarySerializer
+        else:
+            return self.serializer_class

--- a/galaxy_ng/tests/unit/api/test_api_v3_tasks.py
+++ b/galaxy_ng/tests/unit/api/test_api_v3_tasks.py
@@ -1,0 +1,83 @@
+import logging
+from rest_framework import status
+from django.urls import reverse
+from django.test import override_settings
+from pulp_ansible.app.models import (
+    AnsibleDistribution,
+    AnsibleRepository,
+    CollectionRemote
+)
+from galaxy_ng.app.constants import DeploymentMode
+from .base import BaseTestCase
+
+log = logging.getLogger(__name__)
+
+
+def _create_repo(name, **kwargs):
+    repo = AnsibleRepository.objects.create(name=name, **kwargs)
+    AnsibleDistribution.objects.create(name=name, base_path=name, repository=repo)
+    return repo
+
+
+def _create_remote(name, url, **kwargs):
+    return CollectionRemote.objects.create(
+        name=name, url=url, **kwargs
+    )
+
+
+@override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value)
+class TestUiTaskListViewSet(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.admin_user = self._create_user("admin")
+        self.pe_group = self._create_partner_engineer_group()
+        self.admin_user.groups.add(self.pe_group)
+        self.admin_user.save()
+
+        self.certified_remote = _create_remote(
+            name='rh-certified',
+            url='https://a.certified.url.com/api/v2/collections',
+            requirements_file=None
+        )
+        _create_repo(name='rh-certified', remote=self.certified_remote)
+
+    def build_sync_url(self, path):
+        return reverse('galaxy:api:content:v3:sync', kwargs={'path': path})
+
+    def build_task_url(self):
+        return reverse('galaxy:api:v3:default-content:tasks-list')
+
+    def test_tasks_required_fields(self):
+        # Spawn a task
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(self.build_sync_url(self.certified_remote.name))
+        log.debug('test_positive_syncing_returns_a_task_id')
+        log.debug('response: %s', response)
+        log.debug('response.data: %s', response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('task', response.data)
+
+        # Ensure all required fields are present
+        response = self.client.get(self.build_task_url())
+        log.debug('response: %s', response)
+        log.debug('response.data: %s', response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreater(response.data['meta']['count'], 0)
+        required_fields = (
+            'pulp_id',
+            'name',
+            'created_at',
+            'updated_at',
+            'finished_at',
+            'started_at',
+            'state',
+            'error',
+            'worker',
+            'parent_task',
+            'child_tasks',
+            'repository',
+            'progress_reports',
+        )
+        for field in required_fields:
+            self.assertIn(field, response.data['data'][0])


### PR DESCRIPTION

Issue: AAH-16

Replaces #488 

/tasks/
```json
GET /api/automation-hub/v3/tasks/
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "meta": {
        "count": 2
    },
    "links": {
        "first": "/api/automation-hub/v3/tasks/?limit=10&offset=0",
        "previous": null,
        "next": null,
        "last": "/api/automation-hub/v3/tasks/?limit=10&offset=0"
    },
    "data": [
        {
            "pulp_id": "4a02f4b2-201c-4c71-8d5b-56a717332d20",
            "name": "pulp_ansible.app.tasks.collections.sync",
            "repository": "rh-certified",
            "state": "failed",
            "started_at": "2020-11-09T16:32:47.436947Z",
            "finished_at": "2020-11-09T16:32:48.340957Z",
            "href": "/api/automation-hub/v3/tasks/4a02f4b2-201c-4c71-8d5b-56a717332d20/"
        },
        {
            "pulp_id": "51d13b1d-328b-4354-b832-b1c706055522",
            "name": "pulp_ansible.app.tasks.collections.sync",
            "repository": "community",
            "state": "failed",
            "started_at": "2020-11-05T21:10:37.050173Z",
            "finished_at": "2020-11-05T21:10:38.158190Z",
            "href": "/api/automation-hub/v3/tasks/51d13b1d-328b-4354-b832-b1c706055522/"
        }
    ]
}
```

/tasks/pk/

```json
GET /api/automation-hub/v3/tasks/4a02f4b2-201c-4c71-8d5b-56a717332d20/
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "pulp_id": "4a02f4b2-201c-4c71-8d5b-56a717332d20",
    "name": "pulp_ansible.app.tasks.collections.sync",
    "created_at": "2020-11-09T16:32:47.310079Z",
    "updated_at": "2020-11-09T16:32:48.341382Z",
    "finished_at": "2020-11-09T16:32:48.340957Z",
    "started_at": "2020-11-09T16:32:47.436947Z",
    "state": "failed",
    "error": {
        "traceback": "  File \"/venv/lib64/python3.6/site-packages/rq/worker.py\", line 936, in perform_job\n    rv = job.perform()\n  File \"/venv/lib64/python3.6/site-packages/rq/job.py\", line 684, in perform\n    self._result = self._execute()\n  File \"/venv/lib64/python3.6/site-packages/rq/job.py\", line 690, in _execute\n    return self.func(*self.args, **self.kwargs)\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/tasks/collections.py\", line 82, in sync\n    d_version.create()\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/plugin/stages/declarative_version.py\", line 148, in create\n    loop.run_until_complete(pipeline)\n  File \"/usr/lib64/python3.6/asyncio/base_events.py\", line 484, in run_until_complete\n    return future.result()\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/plugin/stages/api.py\", line 225, in create_pipeline\n    await asyncio.gather(*futures)\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/plugin/stages/api.py\", line 43, in __call__\n    await self.run()\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/tasks/collections.py\", line 290, in run\n    async for metadata in self._fetch_collections():\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/tasks/collections.py\", line 441, in _fetch_collections\n    count = await _loop_through_pages(not_done)\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/tasks/collections.py\", line 399, in _loop_through_pages\n    url = await _get_url(1, versions_url)\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/tasks/collections.py\", line 387, in _get_url\n    api_endpoint, api_version = await _get_collection_api(remote.url)\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/tasks/collections.py\", line 361, in _get_collection_api\n    api_data = parse_metadata(await downloader.run())\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/download/base.py\", line 227, in run\n    return await self._run(extra_data=extra_data)\n  File \"/venv/lib64/python3.6/site-packages/backoff/_async.py\", line 133, in retry\n    ret = await target(*args, **kwargs)\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/downloaders.py\", line 88, in _run\n    return await super()._run(extra_data=extra_data)\n  File \"/venv/lib64/python3.6/site-packages/backoff/_async.py\", line 133, in retry\n    ret = await target(*args, **kwargs)\n  File \"/venv/lib64/python3.6/site-packages/pulpcore/download/http.py\", line 210, in _run\n    self.raise_for_status(response)\n  File \"/venv/lib64/python3.6/site-packages/pulp_ansible/app/downloaders.py\", line 66, in raise_for_status\n    response.raise_for_status()\n  File \"/venv/lib64/python3.6/site-packages/aiohttp/client_reqrep.py\", line 946, in raise_for_status\n    headers=self.headers)\n",
        "description": "401, message='Unauthorized', url=URL('https://cloud.redhat.com/api/automation-hub/v3/collections/api/')"
    },
    "worker": {
        "name": "1@d038415f3345",
        "missing": false,
        "last_heartbeat": "2020-11-09T20:22:33.770831Z"
    },
    "parent_task": null,
    "child_tasks": [],
    "repository": "rh-certified",
    "progress_reports": [
        {
            "message": "Parsing CollectionVersion Metadata",
            "code": "parsing.metadata",
            "state": "failed",
            "total": null,
            "done": 0,
            "suffix": null
        },
        {
            "message": "Parsing Galaxy Collections API",
            "code": "parsing.collections",
            "state": "failed",
            "total": null,
            "done": 0,
            "suffix": null
        },
        {
            "message": "Downloading Artifacts",
            "code": "downloading.artifacts",
            "state": "canceled",
            "total": null,
            "done": 0,
            "suffix": null
        },
        {
            "message": "Downloading Artifacts",
            "code": "downloading.artifacts",
            "state": "canceled",
            "total": null,
            "done": 0,
            "suffix": null
        },
        {
            "message": "Associating Content",
            "code": "associating.content",
            "state": "canceled",
            "total": null,
            "done": 0,
            "suffix": null
        }
    ]
}
```