### PR TITLE
Fix sort=created on ui /imports/collections/  (AAH-98)

### DIFF
--- a/CHANGES/98.bugfix
+++ b/CHANGES/98.bugfix
@@ -1,0 +1,1 @@
+Fix sort=created on ui /imports/collections/

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -129,11 +129,11 @@ class CollectionImportFilter(filterset.FilterSet):
     namespace = filters.CharFilter(field_name='galaxy_import__namespace__name')
     name = filters.CharFilter(field_name='galaxy_import__name')
     version = filters.CharFilter(field_name='galaxy_import__version')
-    created = filters.DateFilter(field_name='created_at')
+    created = filters.DateFilter(field_name='galaxy_import__created_at')
     versioning_class = versioning.UIVersioning
 
     sort = OrderingFilter(
-        fields=(('created_at', 'created'),)
+        fields=(('galaxy_import__created_at', 'created'),)
     )
 
     class Meta:


### PR DESCRIPTION
The fields list tuple passed to OrderedFilter needs
'field_name' and 'parameter_name'.

The field_name needs to use the related field
description syntax (ie, 'galaxy_import__created_at')

Closes-Issue: AAH-98