### PR TITLE
Fix repo content count 

### DIFF
--- a/CHANGES/94.misc
+++ b/CHANGES/94.misc
@@ -1,0 +1,1 @@
+Fix repo content count so that it shows the content in the current repo version and not all repo versions.

--- a/galaxy_ng/app/api/ui/serializers/distribution.py
+++ b/galaxy_ng/app/api/ui/serializers/distribution.py
@@ -16,7 +16,7 @@ class RepositorySerializer(serializers.ModelSerializer):
         )
 
     def get_content_count(self, repo):
-        return repo.content.count()
+        return repo.latest_version().content.count()
 
 
 class DistributionSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Previously repo content counts were showing the sum of all content across all repo versions. This update will only show the content in the latest version.

Issue: AAH-94