### PR TITLE
Add account enhanced API metrics.

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     environment:
       - "WITH_DEV_INSTALL=1"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
+      - "ACCOUNT_ENHANCED_METRICS=${ACCOUNT_ENHANCED_METRICS-False}"
     env_file:
       - './common/galaxy_ng.env'
     volumes:

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -1,5 +1,17 @@
+import os
+
+
+PROMETHEUS_BEFORE_MIDDLEWARE = 'django_prometheus.middleware.PrometheusBeforeMiddleware'
+PROMETHEUS_AFTER_MIDDLEWARE = 'django_prometheus.middleware.PrometheusAfterMiddleware'
+PROM_ACCT_BEFORE = 'galaxy_ng.contrib.metrics_middleware.AccountEnhancedMetricsBeforeMiddleware'
+PROM_ACCT_AFTER = 'galaxy_ng.contrib.metrics_middleware.AccountEnhancedMetricsAfterMiddleware'
+ACCOUNT_ENHANCED_METRICS = os.environ.get('ACCOUNT_ENHANCED_METRICS', False) in (True, 'True')
+if ACCOUNT_ENHANCED_METRICS:
+    PROMETHEUS_BEFORE_MIDDLEWARE = PROM_ACCT_BEFORE
+    PROMETHEUS_AFTER_MIDDLEWARE = PROM_ACCT_AFTER
+
 MIDDLEWARE = [
-    'django_prometheus.middleware.PrometheusBeforeMiddleware',
+    PROMETHEUS_BEFORE_MIDDLEWARE,
     # BEGIN: Pulp standard middleware
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
@@ -10,7 +22,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     # END: Pulp standard middleware
-    'django_prometheus.middleware.PrometheusAfterMiddleware',
+    PROMETHEUS_AFTER_MIDDLEWARE,
     'django_currentuser.middleware.ThreadLocalUserMiddleware',
 ]
 

--- a/galaxy_ng/contrib/metrics_middleware.py
+++ b/galaxy_ng/contrib/metrics_middleware.py
@@ -1,0 +1,50 @@
+import base64
+import json
+
+from django_prometheus.middleware import (
+    Metrics,
+    PrometheusAfterMiddleware,
+    PrometheusBeforeMiddleware,
+)
+
+from galaxy_ng.app.auth.auth import RHIdentityAuthentication
+
+
+EXTENDED_METRICS = [
+    "django_http_requests_latency_seconds_by_view_method",
+    "django_http_responses_total_by_status_view_method",
+    "django_http_requests_total_by_view_transport_method",
+]
+
+
+class AccountEnhancedMetrics(Metrics):
+    def register_metric(self, metric_cls, name, documentation, labelnames=(), **kwargs):
+        if name in EXTENDED_METRICS:
+            labelnames += ("account",)
+        return super().register_metric(
+            metric_cls, name, documentation, labelnames=labelnames, **kwargs
+        )
+
+
+class AccountEnhancedMetricsBeforeMiddleware(PrometheusBeforeMiddleware):
+    metrics_cls = AccountEnhancedMetrics
+
+
+class AccountEnhancedMetricsAfterMiddleware(PrometheusAfterMiddleware):
+    metrics_cls = AccountEnhancedMetrics
+
+    def label_metric(self, metric, request, response=None, **labels):
+        new_labels = labels
+        if metric._name in EXTENDED_METRICS:
+            account = "unknown"
+            encoded_identity = request.META.get(RHIdentityAuthentication.header)
+            if encoded_identity is not None:
+                try:
+                    json_string = base64.b64decode(encoded_identity)
+                    identity_header = json.loads(json_string)
+                    account = identity_header.get("identity", {}).get("account_number", "unknown")
+                except ValueError:
+                    pass
+            new_labels = {"account": account}
+            new_labels.update(labels)
+        return super().label_metric(metric, request, response=response, **new_labels)


### PR DESCRIPTION
* Add account label to django API request metrics
* Update settings to optionally apply metrics to avoid impacting standalone
* Update dev docker-compose.yml with environment variable

Uses the following capability: https://github.com/korfuri/django-prometheus#adding-custom-labels-to-middleware-requestresponse-metrics

# Local Testing
Add `ACCOUNT_ENHANCED_METRICS=True` to `.compose.env`
./compose up

Launch `insights-proxy` and `automation-hub-ui`, login with QA account and view UI

Next check `/metrics` endpoint for data with added *account* label.

```
# HELP django_http_requests_latency_seconds_by_view_method Histogram of request processing time labelled by view.
# TYPE django_http_requests_latency_seconds_by_view_method histogram
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="0.01",method="GET",view="galaxy:api:ui:v1:me"} 0.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="0.025",method="GET",view="galaxy:api:ui:v1:me"} 0.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="0.05",method="GET",view="galaxy:api:ui:v1:me"} 0.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="0.075",method="GET",view="galaxy:api:ui:v1:me"} 0.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="0.1",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="0.25",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="0.5",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="0.75",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="1.0",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="2.5",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="5.0",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="7.5",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="10.0",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="25.0",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="50.0",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="75.0",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_bucket{account="6089xyz",le="+Inf",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_count{account="6089xyz",method="GET",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_latency_seconds_by_view_method_sum{account="6089xyz",method="GET",view="galaxy:api:ui:v1:me"} 0.0929204998537898
```

```
# HELP django_http_requests_total_by_view_transport_method_total Count of requests by view, transport, method.
# TYPE django_http_requests_total_by_view_transport_method_total counter
django_http_requests_total_by_view_transport_method_total{account="6089xyz",method="GET",transport="http",view="galaxy:api:ui:v1:me"} 1.0
django_http_requests_total_by_view_transport_method_total{account="unknown",method="GET",transport="http",view="prometheus-django-metrics"} 2.0
```