### PR TITLE
Add deprecated as an annotated field for empty queryset.

### DIFF
--- a/CHANGES/122.bugfix
+++ b/CHANGES/122.bugfix
@@ -1,0 +1,1 @@
+Add deprecated annotated field to empty queryset

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -65,7 +65,11 @@ class CollectionViewSet(
                 collection_versions[str(collection_id)] = version
 
         if not collection_versions.items():
-            return CollectionVersion.objects.none()
+            return CollectionVersion.objects.none().annotate(
+                # AAH-122: annotated fields must exist in all the returned querysets
+                #          in order for filters to work.
+                deprecated=Exists(AnsibleCollectionDeprecated.objects)
+            )
 
         query_params = Q()
         for collection_id, version in collection_versions.items():


### PR DESCRIPTION
All the returned querysets must keep the same fields.

Add deprecated as an annotated field for empty queryset.

Issue: AAH-122