### PR TITLE
Fix my-synclist to show only synclists with obj permissions

### DIFF
--- a/CHANGES/97.bugfix
+++ b/CHANGES/97.bugfix
@@ -1,0 +1,1 @@
+Fix my-synclist to show only synclists with obj permissions

--- a/galaxy_ng/app/api/ui/viewsets/my_synclist.py
+++ b/galaxy_ng/app/api/ui/viewsets/my_synclist.py
@@ -27,7 +27,11 @@ class MySyncListViewSet(SyncListViewSet):
         Returns all synclists for the user.
         """
         return get_objects_for_user(
-            self.request.user, "galaxy.change_synclist", any_perm=True, klass=models.SyncList
+            self.request.user,
+            "galaxy.change_synclist",
+            any_perm=True,
+            accept_global_perms=False,
+            klass=models.SyncList,
         )
 
     @action(detail=True, methods=["post"])


### PR DESCRIPTION
Apply 'accept_global_perms' fix from https://github.com/ansible/galaxy_ng/pull/523 to my-synclist

Issue: AAH-97