### PR TITLE
Make consistent access control data types

### DIFF
--- a/galaxy_ng/app/access_control/statements/insights.py
+++ b/galaxy_ng/app/access_control/statements/insights.py
@@ -123,7 +123,7 @@ INSIGHTS_STATEMENTS = {
             "action": ["list"],
             "principal": "authenticated",
             "effect": "allow",
-            "condition": ["has_rh_entitlements"]
+            "condition": "has_rh_entitlements"
         },
         {
             "action": ["retrieve"],


### PR DESCRIPTION
In the access control statements, make consistent the
data type for condition when there is a single condition

No-Issue