### PR TITLE
Cleanup orphan gng col_imports before altering the table

### DIFF
--- a/galaxy_ng/app/migrations/0011_collection_import_task_id_fk.py
+++ b/galaxy_ng/app/migrations/0011_collection_import_task_id_fk.py
@@ -3,6 +3,16 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
+DELETE_ORPHAN_GALAXY_COLLECTION_IMPORTS = """
+DELETE
+FROM galaxy_collectionimport
+WHERE task_id in
+    (SELECT task_id
+     FROM galaxy_collectionimport
+     WHERE task_id not in
+         (SELECT task_id
+          FROM ansible_collectionimport));
+"""
 
 class Migration(migrations.Migration):
 
@@ -11,6 +21,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(sql=DELETE_ORPHAN_GALAXY_COLLECTION_IMPORTS,
+                          reverse_sql=migrations.RunSQL.noop),
         migrations.AlterField(
             model_name='collectionimport',
             name='task_id',


### PR DESCRIPTION
Change the 0011 migrations to cleanup any orphan
galaxy_collectionimport rows that have a task_id that
does not point to an existing ansible_collectionimport.

ie, cases where ansible_collectionimport and core_task
were cleaned up by hand but galaxy_collectionimport was not.
(There was no fk or cascade link between them, so the deletes
on ansible_collectionimport would not cause errors while
also not deleting the related rows in galaxy_collectionimport).

No-Issue