### PR TITLE
Revert "Fix the passing along of filename data (#546)"

### DIFF
--- a/galaxy_ng/app/api/v3/serializers/collection.py
+++ b/galaxy_ng/app/api/v3/serializers/collection.py
@@ -146,9 +146,6 @@ class CollectionUploadSerializer(Serializer):
 
         data.update({
             "filename": filename_tuple,
-            "expected_namespace": filename_tuple.namespace,
-            "expected_name": filename_tuple.name,
-            "expected_version": filename_tuple.version,
             "mimetype": (mimetypes.guess_type(filename)[0] or 'application/octet-stream')
         })
         return data

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -136,7 +136,6 @@ class CollectionUploadViewSet(api_base.LocalSettingsMixin,
                               pulp_ansible_views.CollectionUploadViewSet):
     permission_classes = [access_policy.CollectionAccessPolicy]
     parser_classes = [AnsibleGalaxy29MultiPartParser]
-    serializer_class = CollectionUploadSerializer
 
     def _dispatch_import_collection_task(self, temp_file_pk, repository=None, **kwargs):
         """Dispatch a pulp task started on upload of collection version."""

--- a/galaxy_ng/app/tasks/publishing.py
+++ b/galaxy_ng/app/tasks/publishing.py
@@ -39,13 +39,8 @@ def import_and_move_to_staging(temp_file_pk, **kwargs):
     This task will not wait for the enqueued tasks to finish.
     """
     inbound_repository_pk = kwargs.get('repository_pk')
-    import_collection(
-        temp_file_pk=temp_file_pk,
-        repository_pk=inbound_repository_pk,
-        expected_namespace=kwargs['expected_namespace'],
-        expected_name=kwargs['expected_name'],
-        expected_version=kwargs['expected_version'],
-    )
+    import_collection(temp_file_pk=temp_file_pk,
+                      repository_pk=inbound_repository_pk)
 
     try:
         staging_repo = AnsibleDistribution.objects.get(name=STAGING_NAME).repository
@@ -69,13 +64,7 @@ def import_and_auto_approve(temp_file_pk, **kwargs):
     manual approval action needs to occur.
     """
     inbound_repository_pk = kwargs.get('repository_pk')
-    import_collection(
-        temp_file_pk=temp_file_pk,
-        repository_pk=inbound_repository_pk,
-        expected_namespace=kwargs['expected_namespace'],
-        expected_name=kwargs['expected_name'],
-        expected_version=kwargs['expected_version'],
-    )
+    import_collection(temp_file_pk=temp_file_pk, repository_pk=inbound_repository_pk)
 
     try:
         golden_repo = AnsibleDistribution.objects.get(name=GOLDEN_NAME).repository

--- a/galaxy_ng/tests/unit/app/test_tasks.py
+++ b/galaxy_ng/tests/unit/app/test_tasks.py
@@ -113,13 +113,7 @@ class TestTaskPublish(TestCase):
 
         mocked_get_created.return_value = [self.collection_version]
 
-        import_and_auto_approve(
-            self.pulp_temp_file.pk,
-            repository_pk=inbound_repo.pk,
-            expected_namespace='',
-            expected_name='',
-            expected_version='',
-        )
+        import_and_auto_approve(self.pulp_temp_file.pk, repository_pk=inbound_repo.pk)
 
         self.assertTrue(mocked_import.call_count == 1)
         self.assertTrue(mocked_enqueue.call_count == 2)
@@ -129,13 +123,7 @@ class TestTaskPublish(TestCase):
         golden_repo.save()
         mocked_get_created.side_effect = AnsibleDistribution.DoesNotExist
         with self.assertRaises(AnsibleDistribution.DoesNotExist):
-            import_and_auto_approve(
-                self.artifact.pk,
-                repository_pk=inbound_repo.pk,
-                expected_namespace='',
-                expected_name='',
-                expected_version='',
-            )
+            import_and_auto_approve(self.artifact.pk, repository_pk=inbound_repo.pk)
 
     @mock.patch('galaxy_ng.app.tasks.publishing.get_created_collection_versions')
     @mock.patch('galaxy_ng.app.tasks.publishing.import_collection')
@@ -151,13 +139,7 @@ class TestTaskPublish(TestCase):
 
         mocked_get_created.return_value = [self.collection_version]
 
-        import_and_move_to_staging(
-            self.pulp_temp_file.pk,
-            repository_pk=inbound_repo.pk,
-            expected_namespace='',
-            expected_name='',
-            expected_version='',
-        )
+        import_and_move_to_staging(self.pulp_temp_file.pk, repository_pk=inbound_repo.pk)
 
         self.assertTrue(mocked_import.call_count == 1)
         self.assertTrue(mocked_enqueue.call_count == 2)
@@ -167,10 +149,4 @@ class TestTaskPublish(TestCase):
         staging_repo.save()
         mocked_get_created.side_effect = AnsibleDistribution.DoesNotExist
         with self.assertRaises(AnsibleDistribution.DoesNotExist):
-            import_and_move_to_staging(
-                self.pulp_temp_file.pk,
-                repository_pk=inbound_repo.pk,
-                expected_namespace='',
-                expected_name='',
-                expected_version='',
-            )
+            import_and_move_to_staging(self.pulp_temp_file.pk, repository_pk=inbound_repo.pk)


### PR DESCRIPTION
This reverts commit 0ab1e0f00a661bda5b8decf07a4a0b91df472ddd.
This reverted commit requires pulp_ansible 0.5.1.

No-Issue