### PR TITLE
Upgrade pulp_ansible to 0.5.1

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -101,7 +101,7 @@ if [ -z "$TRAVIS_TAG" ]; then
 fi
 
 
-git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.5.0
+git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.5.1
 if [ -n "$PULP_ANSIBLE_PR_NUMBER" ]; then
   cd pulp_ansible
   git fetch --depth=1 origin pull/$PULP_ANSIBLE_PR_NUMBER/head:$PULP_ANSIBLE_PR_NUMBER

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -59,7 +59,7 @@ openpyxl==3.0.5           # via tablib
 packaging==20.4           # via ansible-base, bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
 psycopg2==2.8.6           # via pulpcore
-pulp-ansible==0.5.0       # via galaxy-ng (setup.py)
+pulp-ansible==0.5.1       # via galaxy-ng (setup.py)
 pulpcore==3.7.1           # via galaxy-ng (setup.py), pulp-ansible
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -64,7 +64,7 @@ openpyxl==3.0.5           # via tablib
 packaging==20.4           # via ansible-base, bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
 psycopg2==2.8.6           # via pulpcore
-pulp-ansible==0.5.0       # via galaxy-ng (setup.py)
+pulp-ansible==0.5.1       # via galaxy-ng (setup.py)
 pulpcore==3.7.1           # via galaxy-ng (setup.py), pulp-ansible
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -61,7 +61,7 @@ openpyxl==3.0.5           # via tablib
 packaging==20.4           # via ansible-base, bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
 psycopg2==2.8.6           # via pulpcore
-pulp-ansible==0.5.0       # via galaxy-ng (setup.py)
+pulp-ansible==0.5.1       # via galaxy-ng (setup.py)
 pulp-container==2.1.0     # via -r requirements/requirements.standalone.in
 pulpcore==3.7.1           # via galaxy-ng (setup.py), pulp-ansible, pulp-container
 pycares==3.1.1            # via aiodns

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ requirements = [
     "Django~=2.2.3",
     "galaxy-importer==0.2.11",
     "pulpcore>=3.7,<3.9",
-    "pulp-ansible==0.5.0",
+    "pulp-ansible==0.5.1",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
 ]


### PR DESCRIPTION
Updates included in 0.5.1:
* allows for galaxy_ng fix: Fix the passing along of filename data #546
* track when versions for a collection have been updated https://pulp.plan.io/issues/7775, includes field updated_at to use latest instead of highest version pulp/pulp_ansible#416
* resolve token refreshes every request to cloud.redhat.com

No-Issue