### PR TITLE
Fix for 2 issues reported on AHH-132

### DIFF
--- a/CHANGES/132.bugfix
+++ b/CHANGES/132.bugfix
@@ -1,0 +1,1 @@
+Fix NamespaceLink creation and Validation on duplicated name.

--- a/galaxy_ng/app/api/v3/serializers/namespace.py
+++ b/galaxy_ng/app/api/v3/serializers/namespace.py
@@ -106,6 +106,7 @@ class NamespaceSerializer(serializers.ModelSerializer):
         # create NamespaceLink objects if needed
         new_links = []
         for link_data in links_data:
+            link_data["namespace"] = instance
             ns_link, created = models.NamespaceLink.objects.get_or_create(**link_data)
             new_links.append(ns_link)
 

--- a/galaxy_ng/app/api/v3/viewsets/namespace.py
+++ b/galaxy_ng/app/api/v3/viewsets/namespace.py
@@ -3,13 +3,13 @@ import logging
 from django.db import transaction
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend
-from rest_framework.exceptions import ValidationError
 from pulp_ansible.app.models import AnsibleRepository, AnsibleDistribution
 
 from galaxy_ng.app import models
 from galaxy_ng.app.access_control.access_policy import NamespaceAccessPolicy
 from galaxy_ng.app.api import base as api_base
 from galaxy_ng.app.api.v3 import serializers
+from galaxy_ng.app.exceptions import ConflictError
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class NamespaceViewSet(api_base.ModelViewSet):
         """Override to also create inbound pulp repository and distribution."""
 
         if models.Namespace.objects.filter(name=request.data['name']).exists():
-            raise ValidationError(detail={
+            raise ConflictError(detail={
                 'name': 'There is an existing namespace with the same name, choose a different name'
             })
 

--- a/galaxy_ng/app/exceptions.py
+++ b/galaxy_ng/app/exceptions.py
@@ -1,0 +1,9 @@
+from django.utils.translation import gettext_lazy as _
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+
+
+class ConflictError(ValidationError):
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = _('Data conflicts with existing entity.')
+    default_code = 'conflict'


### PR DESCRIPTION
Related isssue: https://issues.redhat.com/browse/AAH-132

1. Namespace creation fails when links are associated.
  solution: link_data was missing relationship with namespace instance

2. Error 500 was raised when trying to create a namespace with existing name.
  solution: validate for existence before the creation of dependent instances on ViewSet.create method.

```
❯ http post :8002/api/automation-hub/_ui/v1/namespaces/ "Authorization: Token b1a99acc28ebfd33fc2ce4684408079456efe6de" <<<'{"name":"testing15","company":"Redhat","email":"user@example.com","avatar_url":"https://www.redhat.com/cms/managed-files/styles/wysiwyg_full_width/s3/Logo-RedHat-Hat-Color-CMYK%20%281%29.jpg?itok=Mf0Ff9jq","description":"string","links":[{"name": "homepage","url":"http://www.google.com"}],"groups":[{"name":"system:partner-engineers","object_permissions":["change_namespace","upload_to_namespace"]}]}'
HTTP/1.1 409 Conflict
X-Powered-By: Express
allow: GET, POST, HEAD, OPTIONS
connection: close
content-length: 210
content-type: application/json
date: Tue, 10 Nov 2020 18:28:12 GMT
server: gunicorn/20.0.4
vary: Accept, Cookie
x-frame-options: SAMEORIGIN

{
    "errors": [
        {
            "code": "conflict",
            "detail": "There is an existing namespace with the same name, choose a different name",
            "source": {
                "parameter": "name"
            },
            "status": "409",
            "title": "Data conflicts with existing entity."
        }
    ]
}
```