### PR TITLE
Add token param to unit tests for syncconfig

### DIFF
--- a/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
@@ -89,6 +89,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
             self.build_config_url(self.certified_remote.name),
             {
                 "auth_url": "https://auth.com",
+                "token": "TEST",
                 "name": "rh-certified",
                 "policy": "immediate",
                 "requirements_file": None,
@@ -135,6 +136,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
             self.build_config_url(self.community_remote.name),
             {
                 "auth_url": "https://auth.com",
+                "token": "TEST",
                 "name": "community",
                 "policy": "immediate",
                 "requirements_file": (


### PR DESCRIPTION
Required by pulp_ansible https://github.com/pulp/pulp_ansible/pull/418

No-Issue