### PR TITLE
API to return 409 in case of existing group/namespace

### DIFF
--- a/CHANGES/152.bugfix
+++ b/CHANGES/152.bugfix
@@ -1,0 +1,1 @@
+API returns 409 in case of existing group with same name.

--- a/galaxy_ng/app/api/ui/viewsets/group.py
+++ b/galaxy_ng/app/api/ui/viewsets/group.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend
 
@@ -5,6 +6,7 @@ from pulpcore.app import viewsets
 from galaxy_ng.app.access_control import access_policy
 
 from galaxy_ng.app.api.base import LocalSettingsMixin
+from galaxy_ng.app.exceptions import ConflictError
 from django.contrib.auth.models import Group
 
 
@@ -26,6 +28,15 @@ class GroupViewSet(LocalSettingsMixin, viewsets.GroupViewSet):
     filter_backends = (DjangoFilterBackend,)
     filterset_class = GroupFilter
     permission_classes = [access_policy.GroupAccessPolicy]
+
+    @transaction.atomic
+    def create(self, request, *args, **kwargs):
+        name = request.data['name']
+        if Group.objects.filter(name=name).exists():
+            raise ConflictError(
+                detail={'name': f'A group named {name} already exists.'}
+            )
+        return super().create(request, *args, **kwargs)
 
 
 class GroupModelPermissionViewSet(LocalSettingsMixin, viewsets.GroupModelPermissionViewSet):


### PR DESCRIPTION
- In case of existing group or namespace API returns 409 conflict
- Fixed error message that was not well formatted on PR #562
- Added unittest for namespace

Issue: AAH-152

### Group Error Message (to be integrated to UI)
![group_error_not_on_ui](https://user-images.githubusercontent.com/458654/99301298-7dd95800-282c-11eb-99be-fbdd937b5507.png)

### Namespace error message fixed:

**Before**:
![Screenshot_2020-11-10_16-47-00](https://user-images.githubusercontent.com/458654/99301345-95b0dc00-282c-11eb-907f-1f6fc56b2dd2.png)


**After:**
![new_namespace_message](https://user-images.githubusercontent.com/458654/99301309-816cdf00-282c-11eb-8a7d-182a10ae4904.png)

