### PR TITLE
Add patchback support for auto cherry picking backports.

### DIFF
--- a/.github/patchback.yml
+++ b/.github/patchback.yml
@@ -1,0 +1,5 @@
+---
+backport_branch_prefix: patchback/backports/
+backport_label_prefix: backport-
+target_branch_prefix: stable-
+...


### PR DESCRIPTION
Patchback watches for pull requests with the `backport-{version}` label. When PRs are merged with the label, backpatch will create a backport PR that cherrypicks the commits in the PR to `stable-{version}`.

For example a PR with the `backport-4.2` label will result in a PR with cherry-picked commits on branch `stable-4.2`.