### PR TITLE
Perform partial matches on namespace keywork lookups.

### DIFF
--- a/CHANGES/166.bugfix
+++ b/CHANGES/166.bugfix
@@ -1,0 +1,1 @@
+The namespaces api now performs a partial match on namespace name and namespace company name when using the 'keywords' query parameter.

--- a/galaxy_ng/app/api/v3/viewsets/namespace.py
+++ b/galaxy_ng/app/api/v3/viewsets/namespace.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.db import transaction
+from django.db.models import Q
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend
 from pulp_ansible.app.models import AnsibleRepository, AnsibleDistribution
@@ -36,7 +37,7 @@ class NamespaceFilter(filterset.FilterSet):
         keywords = self.request.query_params.getlist('keywords')
 
         for keyword in keywords:
-            queryset = queryset.filter(name=keyword)
+            queryset = queryset.filter(Q(name__icontains=keyword) | Q(company__icontains=keyword))
 
         return queryset
 


### PR DESCRIPTION
The namespaces api now performs a partial match on namespace name and namespace company name when using the 'keywords' query parameter.