### PR TITLE
Handle drf auth/perm exc to keep the better error msgs

### DIFF
--- a/CHANGES/206.feature
+++ b/CHANGES/206.feature
@@ -1,0 +1,1 @@
+Provide more context to access_policy permission errors

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -22,12 +22,12 @@ STANDALONE_STATEMENTS = {
             "effect": "allow",
             "condition": "has_model_or_obj_perms:galaxy.change_namespace"
         },
-        {
-            "action": ["*"],
-            "principal": "*",
-            "effect": "deny",
-            "condition": "user_is_bad_at_names:adrian",
-        },
+        # {
+        #     "action": ["*"],
+        #     "principal": "*",
+        #     "effect": "deny",
+        #     "condition": "user_is_bad_at_names:adrian",
+        # },
     ],
     'CollectionViewSet': [
         {

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -22,6 +22,12 @@ STANDALONE_STATEMENTS = {
             "effect": "allow",
             "condition": "has_model_or_obj_perms:galaxy.change_namespace"
         },
+        {
+            "action": ["*"],
+            "principal": "*",
+            "effect": "deny",
+            "condition": "user_is_bad_at_names:adrian",
+        },
     ],
     'CollectionViewSet': [
         {

--- a/galaxy_ng/app/api/base.py
+++ b/galaxy_ng/app/api/base.py
@@ -6,6 +6,7 @@ from rest_framework import views
 from rest_framework import viewsets
 from rest_framework.settings import perform_import
 
+from rest_access_policy import AccessPolicy
 
 GALAXY_EXCEPTION_HANDLER = perform_import(
     settings.GALAXY_EXCEPTION_HANDLER,
@@ -33,6 +34,32 @@ class LocalSettingsMixin:
 
     def get_exception_handler(self):
         return GALAXY_EXCEPTION_HANDLER
+
+    def get_exception_handler_context(self):
+        """
+        Returns a dict that is passed through to EXCEPTION_HANDLER,
+        as the `context` argument.
+
+        This includes the sta
+        """
+
+        # Include the deployment mode and AccessPolicy in exception context for
+        # better errors
+        access_policy = None
+        for permission in self.get_permissions():
+            if isinstance(permission, AccessPolicy):
+                access_policy = permission
+                break
+
+        access_policy_data = {}
+        if access_policy:
+            access_policy_data['name'] = access_policy.NAME
+
+        context = super().get_exception_handler_context()
+        context['deployment_mode'] = getattr(settings, 'GALAXY_DEPLOYMENT_MODE', None)
+        context['access_policy'] = access_policy_data
+
+        return context
 
 
 class APIView(LocalSettingsMixin, views.APIView):

--- a/galaxy_ng/app/api/base.py
+++ b/galaxy_ng/app/api/base.py
@@ -58,27 +58,27 @@ class LocalSettingsMixin:
 
         # Include the deployment mode and AccessPolicy in exception context for
         # better errors
-        access_policy = None
-        for permission in self.get_permissions():
-            if isinstance(permission, AccessPolicy):
-                access_policy = permission
-                break
+        # access_policy = None
+        # for permission in self.get_permissions():
+        #     if isinstance(permission, AccessPolicy):
+        #         access_policy = permission
+        #         break
 
-        access_policy_data = {}
-        if access_policy:
-            access_policy_data['name'] = access_policy.NAME
-            # access_policy_data['statements'] = \
-            #     access_policy.get_policy_statements(context['request'],
-            #                                         context['view'])
-            access_policy_data['matched'] = access_policy.matched
+        # access_policy_data = {}
+        # if access_policy:
+        #     access_policy_data['name'] = access_policy.NAME
+        #     access_policy_data['statements'] = \
+        #         access_policy.get_policy_statements(context['request'],
+        #                                             context['view'])
+        #     access_policy_data['matched'] = access_policy.matched
 
         context['deployment_mode'] = getattr(settings, 'GALAXY_DEPLOYMENT_MODE', None)
-        context['access_policy'] = access_policy_data
+        # context['access_policy'] = access_policy_data
 
-        import pprint
-        log.debug('context:\n%s', pprint.pformat(context))
-        log.debug('access_policy: %s', access_policy)
-        log.debug('id(access_policy): %s', id(access_policy))
+        # import pprint
+        # log.debug('context:\n%s', pprint.pformat(context))
+        # log.debug('access_policy: %s', access_policy)
+        # log.debug('id(access_policy): %s', id(access_policy))
         return context
 
     # This are the from the drf view/viewset classes that are used to raise

--- a/galaxy_ng/app/api/base.py
+++ b/galaxy_ng/app/api/base.py
@@ -1,5 +1,9 @@
+import logging
+import pprint
+
 from django.conf import settings
 
+from rest_framework import exceptions
 from rest_framework import generics
 from rest_framework import permissions
 from rest_framework import views
@@ -21,6 +25,8 @@ GALAXY_PAGINATION_CLASS = perform_import(
     'GALAXY_PAGINATION_CLASS'
 )
 
+log = logging.getLogger(__name__)
+
 
 class _MustImplementPermission(permissions.BasePermission):
     def has_permission(self, request, view):
@@ -32,6 +38,9 @@ class LocalSettingsMixin:
     pagination_class = GALAXY_PAGINATION_CLASS
     permission_classes = [_MustImplementPermission]
 
+    # NOTE: If we add a drf.exceptions.PermissionDenied subclass with extra info
+    #       we could make use of it in the exception_handle (esp combine with extra
+    #       context from get_exception_handler_context)
     def get_exception_handler(self):
         return GALAXY_EXCEPTION_HANDLER
 
@@ -42,6 +51,8 @@ class LocalSettingsMixin:
 
         This includes the sta
         """
+
+        context = super().get_exception_handler_context()
 
         # Include the deployment mode and AccessPolicy in exception context for
         # better errors
@@ -54,12 +65,85 @@ class LocalSettingsMixin:
         access_policy_data = {}
         if access_policy:
             access_policy_data['name'] = access_policy.NAME
+            access_policy_data['statements'] = \
+                access_policy.get_policy_statements(context['request'],
+                                                    context['view'])
+            access_policy_data['matched'] = access_policy.matched
 
-        context = super().get_exception_handler_context()
         context['deployment_mode'] = getattr(settings, 'GALAXY_DEPLOYMENT_MODE', None)
         context['access_policy'] = access_policy_data
 
+        import pprint
+        log.debug('context:\n%s', pprint.pformat(context))
+        log.debug('access_policy: %s', access_policy)
+        log.debug('id(access_policy): %s', id(access_policy))
         return context
+
+    # This are the from the drf view/viewset classes that are used to raise
+    # NotFound (404) or PermissionDenied (403) exceptions on authz/perms/access_policy fails
+    #
+    # To get extra detail in the rest reponse errors, we need to extend some of these.
+
+    # NOTE: we could extend initial / finalize_response if we need to store extra
+    #       info on the Request object  (possibly in liue of adding state to AccessPolicy
+    #       permission objects)
+
+    # TODO: raise a custom PermissionDenied that can hold extra detail/context
+    def permission_denied(self, request, message=None, code=None):
+        """
+        If request is not permitted, determine what kind of exception to raise.
+        """
+        if request.authenticators and not request.successful_authenticator:
+            raise exceptions.NotAuthenticated()
+        log.debug('our permission_denied locals:\n%s', pprint.pformat(locals()))
+        log.debug('stack', stack_info=True)
+        raise exceptions.PermissionDenied(detail=message, code=code)
+
+    # TODO: likely don't need throttled yet, but it could be extended in similar way
+    def throttled(self, request, wait):
+        """
+        If request is throttled, determine what kind of exception to raise.
+        """
+        raise exceptions.Throttled(wait)
+
+    # TODO: make these pass needed info to permission_denied
+    #       - possible the permission instance itself or some
+    #         of it's data
+    def check_permissions(self, request):
+        """
+        Check if the request should be permitted.
+        Raises an appropriate exception if the request is not permitted.
+        """
+        for permission in self.get_permissions():
+            log.debug('permission instance: %s', permission)
+            if not permission.has_permission(request, self):
+                self.permission_denied(
+                    request,
+                    message=getattr(permission, 'message', None),
+                    code=getattr(permission, 'code', None)
+                )
+
+    def check_object_permissions(self, request, obj):
+        """
+        Check if the request should be permitted for a given object.
+        Raises an appropriate exception if the request is not permitted.
+        """
+        for permission in self.get_permissions():
+            log.debug('object permission instance: %s', permission)
+            if not permission.has_object_permission(request, self, obj):
+                self.permission_denied(
+                    request,
+                    message=getattr(permission, 'message', None),
+                    code=getattr(permission, 'code', None)
+                )
+
+    # NOTE: For my reference to remind me each request returns a list of
+    #       new instances of any of the permission classes (ie, AccessPolicy for us)
+    # def get_permissions(self):
+    #     """
+    #     Instantiates and returns the list of permissions that this view requires.
+    #     """
+    #     return [permission() for permission in self.permission_classes]
 
 
 class APIView(LocalSettingsMixin, views.APIView):

--- a/galaxy_ng/app/api/base.py
+++ b/galaxy_ng/app/api/base.py
@@ -100,7 +100,7 @@ class LocalSettingsMixin:
         log.debug('our permission_denied locals:\n%s', pprint.pformat(locals()))
         log.debug('stack', stack_info=True)
         log.debug('perms instance: %s', permission)
-        log.debug('perms.matched: %s', permission.matched)
+        log.debug('perms.denied: %s', permission.denied)
         raise AccessPolicyPermissionDenied(detail=message, code=code, permission=permission)
 
     # TODO: likely don't need throttled yet, but it could be extended in similar way

--- a/galaxy_ng/app/api/exceptions.py
+++ b/galaxy_ng/app/api/exceptions.py
@@ -56,13 +56,14 @@ def _get_errors(detail, *, status, title, source=None, context=None):
         try:
             # access_policy = context['permission']['access_policy']
             permission = context['permission']
-            if permission:
-                statements = permission.get_policy_statements(context['request'],
-                                                              context['view'])
+            if permission and permission.denied:
+                # statements = permission.get_policy_statements(context['request'],
+                #                                              context['view'])
 
                 meta['access_policy'] = {'name': permission.NAME,
                                          'denied_rules': permission.denied,
-                                         'statements': statements}
+                                         # 'statements': statements,
+                                         }
 
         except KeyError:
             pass

--- a/galaxy_ng/app/api/exceptions.py
+++ b/galaxy_ng/app/api/exceptions.py
@@ -57,8 +57,13 @@ def _get_errors(detail, *, status, title, source=None, context=None):
             # access_policy = context['permission']['access_policy']
             permission = context['permission']
             if permission:
+                statements = permission.get_policy_statements(context['request'],
+                                                              context['view'])
+
                 meta['access_policy'] = {'name': permission.NAME,
-                                         'matched': permission.matched}
+                                         'failed_rules': permission.matched,
+                                         'statements': statements}
+
         except KeyError:
             pass
 

--- a/galaxy_ng/app/api/exceptions.py
+++ b/galaxy_ng/app/api/exceptions.py
@@ -61,7 +61,7 @@ def _get_errors(detail, *, status, title, source=None, context=None):
                                                               context['view'])
 
                 meta['access_policy'] = {'name': permission.NAME,
-                                         'failed_rules': permission.matched,
+                                         'denied_rules': permission.denied,
                                          'statements': statements}
 
         except KeyError:

--- a/galaxy_ng/app/api/exceptions.py
+++ b/galaxy_ng/app/api/exceptions.py
@@ -6,13 +6,13 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 
-def _get_errors(detail, *, status, title, source=None):
+def _get_errors(detail, *, status, title, source=None, context=None):
     if isinstance(detail, list):
         for item in detail:
-            yield from _get_errors(item, status=status, title=title, source=source)
+            yield from _get_errors(item, status=status, title=title, source=source, context=context)
     elif isinstance(detail, dict):
         for key, value in detail.items():
-            yield from _get_errors(value, status=status, title=title, source=key)
+            yield from _get_errors(value, status=status, title=title, source=key, context=context)
     else:
         error = {
             'status': str(status),
@@ -25,10 +25,27 @@ def _get_errors(detail, *, status, title, source=None):
         if source and source != api_settings.NON_FIELD_ERRORS_KEY:
             error['source'] = {'parameter': source}
 
+        meta = {}
+
+        # Provide the access_policy name to give a hint to origin of perm errors
+        try:
+            access_policy = context['access_policy']
+            meta['access_policy'] = access_policy
+        except KeyError:
+            pass
+
+        try:
+            deployment_mode = context['deployment_mode']
+            meta['deployment_mode'] = deployment_mode
+        except KeyError:
+            pass
+
+        error['meta'] = meta
+
         yield error
 
 
-def _handle_drf_api_exception(exc):
+def _handle_drf_api_exception(exc, context):
     headers = {}
     if getattr(exc, 'auth_header', None):
         headers['WWW-Authenticate'] = exc.auth_header
@@ -36,7 +53,7 @@ def _handle_drf_api_exception(exc):
         headers['Retry-After'] = '%d' % exc.wait
 
     title = exc.__class__.default_detail
-    errors = _get_errors(exc.detail, status=exc.status_code, title=title)
+    errors = _get_errors(exc.detail, status=exc.status_code, title=title, context=context)
     data = {'errors': list(errors)}
     return Response(data, status=exc.status_code, headers=headers)
 
@@ -46,10 +63,16 @@ def exception_handler(exc, context):
 
     if isinstance(exc, Http404):
         exc = exceptions.NotFound()
+    # Handle drf permission exceptions as drf exceptions extracting more detail
+    elif isinstance(exc,
+                    (exceptions.PermissionDenied,
+                     exceptions.AuthenticationFailed,
+                     exceptions.NotAuthenticated)):
+        return _handle_drf_api_exception(exc, context)
     elif isinstance(exc, PermissionDenied):
         exc = exceptions.PermissionDenied()
 
     if isinstance(exc, exceptions.APIException):
-        return _handle_drf_api_exception(exc)
+        return _handle_drf_api_exception(exc, context)
 
     return None

--- a/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
@@ -1,4 +1,5 @@
 import logging
+import pprint
 
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -44,6 +45,7 @@ class TestUiUserViewSet(BaseTestCase):
         }
 
         response = self.client.post(self.user_url, new_user_data, format='json')
+        log.debug('response.json:\n%s', response.json())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data['errors'][0]['source']['parameter'], 'groups')
 
@@ -89,6 +91,7 @@ class TestUiUserViewSet(BaseTestCase):
         log.debug('self.client.__dict__: %s', self.client.__dict__)
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
             response = self.client.get(self.user_url)
+            log.debug('response.json:\n%s', response.json())
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         self.client.force_authenticate(user=self.admin_user)
@@ -100,6 +103,7 @@ class TestUiUserViewSet(BaseTestCase):
 
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.INSIGHTS.value):
             response = self.client.get(self.user_url)
+            log.debug('response.json:\n%s', response.json())
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_user_get(self):
@@ -109,12 +113,15 @@ class TestUiUserViewSet(BaseTestCase):
         self.client.force_authenticate(user=self.user)
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
             response = self.client.get(url)
+            log.debug('response.json:\n%s', response.json())
+            log.debug('response.data:\n%s', pprint.pformat(response.data))
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         # But not other users
         url = '{}{}/'.format(self.user_url, self.admin_user.id)
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
             response = self.client.get(url)
+            log.debug('response.data:\n%s', pprint.pformat(response.data))
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         url = '{}{}/'.format(self.user_url, self.user.id)
@@ -137,12 +144,15 @@ class TestUiUserViewSet(BaseTestCase):
         self.client.force_authenticate(user=auth_user)
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.INSIGHTS.value):
             response = method_call(self.user_url, new_user_data, format='json')
+            log.debug('response.data:\n%s', pprint.pformat(response.data))
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
             # set user with invalid password
             new_user_data['password'] = '12345678'
             response = method_call(url, new_user_data, format='json')
+            log.debug('response.data:\n%s', pprint.pformat(response.data))
+
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
             error_messages = set([])
@@ -213,6 +223,7 @@ class TestUiUserViewSet(BaseTestCase):
         self.client.force_authenticate(user=self.user)
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
             response = self.client.put(put_url, new_user_data, format='json')
+            log.debug('response.json:\n%s', response.json())
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         self._test_create_or_update(

--- a/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
@@ -45,7 +45,7 @@ class TestUiUserViewSet(BaseTestCase):
         }
 
         response = self.client.post(self.user_url, new_user_data, format='json')
-        log.debug('response.json:\n%s', response.json())
+        log.debug('response.data:\n%s', pprint.pformat(response.data))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data['errors'][0]['source']['parameter'], 'groups')
 
@@ -91,7 +91,7 @@ class TestUiUserViewSet(BaseTestCase):
         log.debug('self.client.__dict__: %s', self.client.__dict__)
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
             response = self.client.get(self.user_url)
-            log.debug('response.json:\n%s', response.json())
+            log.debug('response.data:\n%s', pprint.pformat(response.data))
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         self.client.force_authenticate(user=self.admin_user)
@@ -103,7 +103,7 @@ class TestUiUserViewSet(BaseTestCase):
 
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.INSIGHTS.value):
             response = self.client.get(self.user_url)
-            log.debug('response.json:\n%s', response.json())
+            log.debug('response.data:\n%s', pprint.pformat(response.data))
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_user_get(self):
@@ -113,7 +113,6 @@ class TestUiUserViewSet(BaseTestCase):
         self.client.force_authenticate(user=self.user)
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
             response = self.client.get(url)
-            log.debug('response.json:\n%s', response.json())
             log.debug('response.data:\n%s', pprint.pformat(response.data))
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -128,6 +127,7 @@ class TestUiUserViewSet(BaseTestCase):
         self.client.force_authenticate(user=self.admin_user)
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
             response = self.client.get(url)
+            log.debug('response.data:\n%s', pprint.pformat(response.data))
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             data = response.data
             self.assertEqual(data['email'], self.user.email)
@@ -167,6 +167,7 @@ class TestUiUserViewSet(BaseTestCase):
             # set valid user
             new_user_data['password'] = 'trekkie4Lyfe1701'
             response = method_call(url, new_user_data, format='json')
+            log.debug('response.data:\n%s', pprint.pformat(response.data))
             self.assertEqual(response.status_code, crud_status)
             data = response.data
             self.assertEqual(data['email'], new_user_data['email'])
@@ -223,7 +224,7 @@ class TestUiUserViewSet(BaseTestCase):
         self.client.force_authenticate(user=self.user)
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
             response = self.client.put(put_url, new_user_data, format='json')
-            log.debug('response.json:\n%s', response.json())
+            log.debug('response.data:\n%s', pprint.pformat(response.data))
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         self._test_create_or_update(
@@ -269,6 +270,7 @@ class TestUiUserViewSet(BaseTestCase):
         url = '{}{}/'.format(self.user_url, user.id)
 
         response = self.client.put(url, new_user_data, format='json')
+        log.debug('response.data:\n%s', pprint.pformat(response.data))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_me_delete(self):

--- a/galaxy_ng/tests/unit/api/test_api_v3_auth_views.py
+++ b/galaxy_ng/tests/unit/api/test_api_v3_auth_views.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 
 from django.test import override_settings
 from django.urls import reverse
@@ -12,6 +13,8 @@ from galaxy_ng.app.constants import DeploymentMode
 from galaxy_ng.app.models import auth as auth_models
 
 from .base import get_current_ui_url
+
+log = logging.getLogger(__name__)
 
 
 @override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value)
@@ -71,6 +74,7 @@ class TestTokenViewStandalone(APITestCase):
         new_client = APIClient()
 
         response: Response = new_client.get(self.me_url)
+        log.debug('response.data:\n%s', response.data)
         self.assertEqual(response.status_code, http_code.HTTP_403_FORBIDDEN)
         self.assertEqual(
             response.data,


### PR DESCRIPTION
All of the drf auth and perm related exceptions are
subclasses of ApiException, so check the auth related
ones first, to avoid raising a PermissionDenied() with
no info

Pass drf exception context to our exception handler

The exc context includes the request and view objects
and the request args/kwargs

Add AccessPolicy and deployment mode to api exc context