### PR TITLE
Pull centos:8 from quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # NOTE: This Dockerfile is currently used to build release images. So it is leaved as is.
 # It should be removed once migration to standalone Dockerfile for release images
 # is complete.
-FROM docker.io/centos:8
+FROM quay.io/centos/centos:8
 
 ARG USER_ID=1000
 ARG USER_NAME=galaxy


### PR DESCRIPTION
This looks to be the official place container images are published now
from the centos team. It also means we can avoid getting ratelimits from
dockerhub.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>