### PR TITLE
Check for path key using .get to avoid KeyError on collections

### DIFF
--- a/CHANGES/195.bugfix
+++ b/CHANGES/195.bugfix
@@ -1,0 +1,1 @@
+Fix KeyError lookup in namespace and collection viewset

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -1,5 +1,6 @@
 from django.db.models import Exists, OuterRef, Q
 from django.core.exceptions import ObjectDoesNotExist
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend, OrderingFilter
@@ -50,8 +51,12 @@ class CollectionViewSet(
 
     def get_queryset(self):
         """Returns a CollectionVersions queryset for specified distribution."""
-        distro_content = self.get_distro_content(self.kwargs["path"])
-        repo_version = self.get_repository_version(self.kwargs["path"])
+        path = self.kwargs.get('path')
+        if path is None:
+            raise Http404("Distribution base path is required")
+
+        distro_content = self.get_distro_content(path)
+        repo_version = self.get_repository_version(path)
 
         versions = CollectionVersion.objects.filter(pk__in=distro_content).values_list(
             "collection_id",

--- a/galaxy_ng/app/api/v3/viewsets/namespace.py
+++ b/galaxy_ng/app/api/v3/viewsets/namespace.py
@@ -53,8 +53,8 @@ class NamespaceViewSet(api_base.ModelViewSet):
     @transaction.atomic
     def create(self, request, *args, **kwargs):
         """Override to validate for name duplication before serializer validation."""
-        name = request.data['name']
-        if models.Namespace.objects.filter(name=name).exists():
+        name = request.data.get('name')
+        if name and models.Namespace.objects.filter(name=name).exists():
             # Ensures error raised is 409, not 400.
             raise ConflictError(
                 detail={'name': f'A namespace named {name} already exists.'}


### PR DESCRIPTION
Fix AAH-195: https://issues.redhat.com/browse/AAH-195

Fix the KeyError by replacing the getitem with the use of `.get` and letting the underlying validation to raise the proper error.

In the case of namespaces the serializer validation will raise 400 saying `name is required`

In the case of collections the error is on routing system, for some reason it is not providing the `path` key as it was detected by the monitoring system it is not easy to reproduce.

There is another issue to track the routing problems: https://issues.redhat.com/browse/AAH-157

