### PR TITLE
Fix how CI checks for Jira issue existence

### DIFF
--- a/.travis/custom_check_pull_request.py
+++ b/.travis/custom_check_pull_request.py
@@ -66,7 +66,10 @@ def check_changelog_record(issue):
 
 def check_issue_exists(issue):
     response = requests.head(JIRA_URL.format(issue=issue))
-    if not response.ok:
+    if response.status_code == 404:
+        # 200 is returned for logged in sessions
+        # 401 is for not authorized access on existing issue
+        # 404 is returned if issue is not found even for unlogged users.
         LOG.error(f"Referenced issue AAH-{issue} not found in Jira.")
         return False
     return True

--- a/CHANGES/44.bugfix
+++ b/CHANGES/44.bugfix
@@ -1,0 +1,1 @@
+Fix how travis checks for existence of Jira issues


### PR DESCRIPTION
Check for 404 status code instead of `ok` so it works
even for unlogged sessions.

Issue: AAH-44