### PR TITLE
[Just for checking CI status] Use pulpcore 3.10

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -101,7 +101,7 @@ if [ -z "$TRAVIS_TAG" ]; then
 fi
 
 
-git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.5.5
+git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch master
 if [ -n "$PULP_ANSIBLE_PR_NUMBER" ]; then
   cd pulp_ansible
   git fetch --depth=1 origin pull/$PULP_ANSIBLE_PR_NUMBER/head:$PULP_ANSIBLE_PR_NUMBER

--- a/galaxy_ng/__init__.py
+++ b/galaxy_ng/__init__.py
@@ -1,3 +1,1 @@
-__version__ = "4.3.0-dev"
-
 default_app_config = "galaxy_ng.app.PulpGalaxyPluginAppConfig"

--- a/galaxy_ng/app/__init__.py
+++ b/galaxy_ng/app/__init__.py
@@ -6,3 +6,4 @@ class PulpGalaxyPluginAppConfig(PulpPluginAppConfig):
 
     name = "galaxy_ng.app"
     label = "galaxy"
+    version = "4.3.0-dev"

--- a/galaxy_ng/app/api/views.py
+++ b/galaxy_ng/app/api/views.py
@@ -1,11 +1,10 @@
+from django.apps import apps
 from django.http import HttpResponseRedirect
 
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-from pulp_ansible import __version__ as pulp_ansible_version
-from galaxy_ng import __version__ as galaxy_ng_version
 from galaxy_ng.app.api import base as api_base
 
 
@@ -15,9 +14,9 @@ class ApiRootView(api_base.APIView):
     def get(self, request, *args, **kwargs):
         data = {
             "available_versions": {"v3": "v3/"},
-            "server_version": galaxy_ng_version,
-            "galaxy_ng_version": galaxy_ng_version,
-            "pulp_ansible_version": pulp_ansible_version,
+            "server_version": apps.get_app_config("galaxy").version,
+            "galaxy_ng_version": apps.get_app_config("galaxy").version,
+            "pulp_ansible_version": apps.get_app_config("ansible").version,
         }
 
         if kwargs.get("path"):

--- a/galaxy_ng/app/webserver_snippets/apache.conf
+++ b/galaxy_ng/app/webserver_snippets/apache.conf
@@ -1,9 +1,9 @@
 RewriteEngine  on
 RewriteCond "%{REQUEST_FILENAME}"       !-f
 RewriteCond "%{REQUEST_FILENAME}"       !-d
-RewriteRule "^/ui*" "http://${pulp-api}/static/galaxy_ng/index.html" [P]
-ProxyPass "/ui/" "http://${pulp-api}/static/galaxy_ng/index.html"
-ProxyPassReverse "/ui/" "http://${pulp-api}/static/galaxy_ng/index.html"
+RewriteRule "^/ui*" "${pulp-api}/static/galaxy_ng/index.html" [P]
+ProxyPass "/ui/" "${pulp-api}/static/galaxy_ng/index.html"
+ProxyPassReverse "/ui/" "${pulp-api}/static/galaxy_ng/index.html"
 
 # WARNING: This is a workaround. It must be removed once
 #          RBAC policies are configured for pulp_ansible and pulpcore APIs.

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@ from setuptools import find_packages, setup, Command
 from setuptools.command.build_py import build_py as _BuildPyCommand
 from setuptools.command.sdist import sdist as _SDistCommand
 
-from galaxy_ng import __version__
-
 
 class PrepareStaticCommand(Command):
     if os.environ.get("ALTERNATE_UI_DOWNLOAD_URL"):
@@ -60,14 +58,19 @@ class BuildPyCommand(_BuildPyCommand):
 requirements = [
     "Django~=2.2.3",
     "galaxy-importer==0.2.13",
-    "pulpcore>=3.7,<3.9",
-    "pulp-ansible==0.5.5",
+    "pulpcore",
+    "pulp-ansible",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
 ]
 
+data = {}
+with open("galaxy_ng/app/__init__.py") as fp:
+    version_line = [line.strip() for line in fp.readlines() if "version =" in line][0]
+    exec(version_line, data)
+
 package_name = os.environ.get("GALAXY_NG_ALTERNATE_NAME", "galaxy-ng")
-version = os.environ.get("ALTERNATE_VERSION", __version__)
+version = os.environ.get("ALTERNATE_VERSION", data["version"])
 
 setup(
     name=package_name,


### PR DESCRIPTION
No-Issue

Testing what is needed for pulpcore-3.10 compatibility
I've been doing some changes for checking what is required for getting galaxy-ng running on pulplift with pulpcore-3.10 and pulp-ansible-0.6.1

Pulpcore PR: https://github.com/pulp/pulpcore/pull/1075