### PR TITLE
Make lockfiles optional for dev containers.

### DIFF
--- a/.compose.env.example
+++ b/.compose.env.example
@@ -3,7 +3,12 @@
 COMPOSE_PROFILE=standalone
 
 # Add extra paths to run project dependencies from local filesystem in editable mode
+# The order of repositories in the list is important, it is `:` separated.
+# DEV_SOURCE_PATH='pulpcore:pulp_ansible:galaxy_ng'
 DEV_SOURCE_PATH='galaxy_ng'
+
+# set to `0` to bypass requirements and install only from setup.py for each DEV_SOURCE_PATH
+LOCK_REQUIREMENTS=1
 
 # If you want to run the UI, clone https://github.com/ansible/ansible-hub-ui
 # and set this to the path for the UI

--- a/CHANGES/257.misc
+++ b/CHANGES/257.misc
@@ -1,0 +1,1 @@
+Add a new dev environment variable to bypass the installation of requirement lock files.

--- a/compose
+++ b/compose
@@ -42,5 +42,6 @@ fi
 declare -xr DEV_SOURCE_PATH=${DEV_SOURCE_PATH:-galaxy_ng}
 declare -xr COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-galaxy_ng}"
 declare -xr COMPOSE_CONTEXT=".."
+declare -xr LOCK_REQUIREMENTS="${LOCK_REQUIREMENTS:-1}"
 
 exec docker-compose "${compose_args[@]}" "$@"

--- a/dev/Dockerfile.base
+++ b/dev/Dockerfile.base
@@ -4,11 +4,13 @@ ARG USER_ID=1000
 ARG USER_NAME=galaxy
 ARG USER_GROUP=galaxy
 ARG COMPOSE_PROFILE
+ARG LOCK_REQUIREMENTS
 
 ENV LANG=en_US.UTF-8 \
     PYTHONUNBUFFERED=1 \
     PULP_SETTINGS=/etc/pulp/settings.py \
-    DJANGO_SETTINGS_MODULE=pulpcore.app.settings
+    DJANGO_SETTINGS_MODULE=pulpcore.app.settings \
+    LOCK_REQUIREMENTS="${LOCK_REQUIREMENTS}"
 
 RUN set -ex; \
     id --group "${USER_GROUP}" &>/dev/null \
@@ -42,7 +44,8 @@ COPY ./requirements/requirements.common.txt /tmp/requirements.txt
 
 RUN set -ex; \
     pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir --requirement /tmp/requirements.txt
+    && if [[ "${LOCK_REQUIREMENTS}" -eq "1" ]]; then \
+    pip install --no-cache-dir --requirement /tmp/requirements.txt; fi
 
 # Install application
 COPY . /app

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: "${COMPOSE_CONTEXT}"
       dockerfile: "dev/Dockerfile.base"
+      args:
+        LOCK_REQUIREMENTS: "${LOCK_REQUIREMENTS}"
     image: "localhost/galaxy_ng/galaxy_ng:base"
     entrypoint: "/bin/true"
     tmpfs:
@@ -17,12 +19,15 @@ services:
     build:
       context: "${COMPOSE_CONTEXT}"
       dockerfile: "dev/${COMPOSE_PROFILE}/Dockerfile"
+      args:
+        LOCK_REQUIREMENTS: "${LOCK_REQUIREMENTS}"
     image: "localhost/galaxy_ng/galaxy_ng:${COMPOSE_PROFILE}"
     command: ['run', 'api-reload']
     ports:
       - "5001:8000"
     environment:
       - "WITH_DEV_INSTALL=1"
+      - "LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS}"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
     env_file:
       - './common/galaxy_ng.env'
@@ -42,6 +47,7 @@ services:
     command: ['run', 'resource-manager']
     environment:
       - "WITH_DEV_INSTALL=1"
+      - "LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS}"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
     env_file:
       - './common/galaxy_ng.env'
@@ -61,6 +67,7 @@ services:
     command: ['run', 'worker']
     environment:
       - "WITH_DEV_INSTALL=1"
+      - "LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS}"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
     env_file:
       - './common/galaxy_ng.env'
@@ -82,6 +89,7 @@ services:
       - "24816:24816"
     environment:
       - "WITH_DEV_INSTALL=1"
+      - "LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS}"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
     env_file:
       - './common/galaxy_ng.env'

--- a/dev/standalone/Dockerfile
+++ b/dev/standalone/Dockerfile
@@ -3,4 +3,6 @@ FROM localhost/galaxy_ng/galaxy_ng:base
 COPY requirements/requirements.standalone.txt /tmp/requirements.standalone.txt
 
 RUN set -ex; \
-    pip install --no-cache-dir --requirement /tmp/requirements.standalone.txt
+    if [[ "${LOCK_REQUIREMENTS}" -eq "1" ]]; then \
+    pip install --no-cache-dir --requirement /tmp/requirements.standalone.txt; \
+    fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,6 +7,7 @@ set -o pipefail
 readonly WITH_MIGRATIONS="${WITH_MIGRATIONS:-0}"
 readonly WITH_DEV_INSTALL="${WITH_DEV_INSTALL:-0}"
 readonly DEV_SOURCE_PATH="${DEV_SOURCE_PATH:-}"
+readonly LOCK_REQUIREMENTS="${LOCK_REQUIREMENTS:-1}"
 
 
 log_message() {
@@ -23,7 +24,13 @@ install_local_deps() {
         src_path="/src/${item}"
         if [[ -d "$src_path" ]]; then
             log_message "Installing path ${item} in editable mode."
-            pip install --no-cache-dir --no-deps --editable "$src_path" >/dev/null
+
+            if [[ "${LOCK_REQUIREMENTS}" -eq "1" ]]; then
+                pip install --no-cache-dir --no-deps --editable "$src_path" >/dev/null
+            else
+                pip install --no-cache-dir --editable "$src_path" >/dev/null
+            fi
+
         else
             log_message "WARNING: Source path ${item} is not a directory."
         fi


### PR DESCRIPTION
## Changes 

Add `LOCK_REQUIREMENTS` variable on `.compose.env`
when this variable is set to `0` compose build will
bypass the installation of `requirements/*` lock files
avoiding VersionConflicts when using `master` checkout
for `pulpcore` and `pulp_ansible`.

also if that variable is set to `0` the entrypoint invoked
by `./compose up|run` will bypass the optization argument
`--no-deps` allowing the installation of bleeding edge
requirements introduced by pulp_ansible/pulpcore.

**NO** breaking change is added, the new variable is by default set to `1` to keep the current behaviour.

## Steps to run dev environment with specific upstream branch

1. **Clone** locally `galaxy_ng`, `pulpcore` and `pulp_ansible` all the
   repos must be located at the same directory level.
   ```
   cd ~/projects/
   git clone https://github.com/pulp/pulpcore
   git clone https://github.com/pulp/pulp_ansible
   git clone https://github.com/ansible/galaxy_ng
   # and optionally
   git clone https://github.com/ansible/ansible-hub-ui
   git clone https://github.com/ansible/galaxy_importer
   ```
2. **Checkout to desired branches.**
    `pulp_ansible` master is compatible with a specific range of `pulpcore`
   versions. So the recommended is to checkout to specific branch or
   tag following the contraints defined on pulp_ansible/requirements.txt
   or leave it checked out to master if you know it is compatible with
   the pulp_ansible branch you have.
   Example:
   ```
   cd ~/projects/pulpcore
   git checkout 3.9.0
   ```
   This is also possible to checkout to specific pull-requests by its
   `refs/pull/id`.
3. Edit the `galaxy_ng/.compose.env` file.
   ```
   cd ~/projects/galaxy_ng
   cat .compose.env

   COMPOSE_PROFILE=standalone
   DEV_SOURCE_PATH='pulpcore:pulp_ansible:galaxy_ng'
   LOCK_REQUIREMENTS=0
   ```
   **DEV_SOURCE_PATH** refers to the repositories you cloned
   locally, the order is important from the highest to the low
   dependecy, otherwise pip will raise version conflicts.

   So **pulpcore** is a dependency to **pulp_ansible** which is a dependency to **galaxy_ng**, this order must be respected on **DEV_SOURCE_PATH** variable.

   **LOCK_REQUIREMENTS** when set to 0 it tells docker to
   bypass the install of pinned requirements and rely
   only on packages defined on `setup.py` for each repo.
4. Run `./compose build` to make those changes efective.
5. Run desired compose command: `./compose up`, `./compose run` etc...

Further details on How to run galaxy_ng dev environment
with specific git branched are written on the galaxy_ng/wiki.

Issue: AAH-257