### PR TITLE
Add field detailing if a write only value is set or not.

### DIFF
--- a/CHANGES/120.misc
+++ b/CHANGES/120.misc
@@ -1,0 +1,1 @@
+Adds write_only_fields to remote API to inform clients if a write only field is set or not.

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -245,11 +245,12 @@ def get_write_only_fields(serializer, obj, extra_data={}):
     """
     fields = []
 
+    # returns false if field is "" or None
     def _is_set(field_name):
         if (field_name in extra_data):
-            return extra_data[field_name] is not None
+            return bool(extra_data[field_name])
         else:
-            return getattr(obj, field_name) is not None
+            return bool(getattr(obj, field_name))
 
     # There are two ways to set write_only. This checks both.
 

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -143,8 +143,6 @@ class CollectionRemoteSerializer(LastSyncTaskMixin, pulp_viewsets.CollectionRemo
             'name': {'read_only': True},
             'pulp_href': {'read_only': True},
             'client_key': {'write_only': True},
-            'client_cert': {'write_only': True},
-            'ca_cert': {'write_only': True},
         }
 
     def to_representation(self, instance):
@@ -220,7 +218,7 @@ class CollectionRemoteSerializer(LastSyncTaskMixin, pulp_viewsets.CollectionRemo
 
         for e in self.Meta.extra_kwargs:
             if self.Meta.extra_kwargs[e].get('write_only', False):
-                fields.append({"name": e, "is_set": getattr(obj, e) is None})
+                fields.append({"name": e, "is_set": getattr(obj, e) is not None})
 
         return fields
 

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -77,6 +77,7 @@ class AnsibleRepositorySerializer(LastSyncTaskMixin, serializers.ModelSerializer
 
 class CollectionRemoteSerializer(LastSyncTaskMixin, pulp_viewsets.CollectionRemoteSerializer):
     last_sync_task = serializers.SerializerMethodField()
+    write_only_fields = serializers.SerializerMethodField()
     created_at = serializers.DateTimeField(source='pulp_created', required=False)
     updated_at = serializers.DateTimeField(source='pulp_last_updated', required=False)
     proxy_url = serializers.URLField(
@@ -136,6 +137,7 @@ class CollectionRemoteSerializer(LastSyncTaskMixin, pulp_viewsets.CollectionRemo
             'proxy_url',
             'proxy_username',
             'proxy_password',
+            'write_only_fields'
         )
         extra_kwargs = {
             'name': {'read_only': True},
@@ -212,6 +214,15 @@ class CollectionRemoteSerializer(LastSyncTaskMixin, pulp_viewsets.CollectionRemo
                 }
             )
         return super().validate(data)
+
+    def get_write_only_fields(self, obj):
+        fields = []
+
+        for e in self.Meta.extra_kwargs:
+            if self.Meta.extra_kwargs[e].get('write_only', False):
+                fields.append({"name": e, "is_set": getattr(obj, e) is None})
+
+        return fields
 
     def get_repositories(self, obj):
         return [

--- a/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
@@ -202,6 +202,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
             response_names.add(field['name'])
 
         self.assertEqual(set(write_only_fields), response_names)
+        self.client.put(api_url, request_data, format='json')
 
         # Check that all write only fields are unset
         write_only = self.client.get(api_url).data['write_only_fields']

--- a/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
@@ -208,6 +208,13 @@ class TestUiSyncConfigViewSet(BaseTestCase):
         write_only = self.client.get(api_url).data['write_only_fields']
         for field in write_only:
             self.assertEqual(field['is_set'], False)
+            request_data[field['name']] = ""
+
+        self.client.put(api_url, request_data, format='json')
+
+        write_only = self.client.get(api_url).data['write_only_fields']
+        for field in write_only:
+            self.assertEqual(field['is_set'], False)
 
     def test_split_proxy_url_field(self):
         self.client.force_authenticate(user=self.admin_user)


### PR DESCRIPTION
Issue: AAH-120

Adds the following field to the sync endpoints:

```
    "write_only_fields": [
        {
            "name": "client_key",
            "is_set": false
        },
        {
            "name": "token",
            "is_set": false
        },
        {
            "name": "password",
            "is_set": false
        },
        {
            "name": "proxy_password",
            "is_set": true
        }
    ]
 ```