### PR TITLE
Users shouldn't be able to delete themselves (AAH-265)

### DIFF
--- a/CHANGES/265.bufix
+++ b/CHANGES/265.bufix
@@ -1,0 +1,3 @@
+Users should not be able to delete themselves.
+
+Even if they have 'delete-user' perms.

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -238,6 +238,9 @@ class CollectionRemoteAccessPolicy(AccessPolicyBase):
 class UserAccessPolicy(AccessPolicyBase):
     NAME = 'UserViewSet'
 
+    def is_current_user(self, request, view, action):
+        return request.user == view.get_object()
+
 
 class MyUserAccessPolicy(AccessPolicyBase):
     NAME = 'MyUserViewSet'

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -82,6 +82,13 @@ STANDALONE_STATEMENTS = {
         {
             "action": "destroy",
             "principal": "*",
+            "effect": "deny",
+            "condition": "is_current_user"
+
+        },
+        {
+            "action": "destroy",
+            "principal": "*",
             "effect": "allow",
             "condition": "has_model_perms:galaxy.delete_user"
 


### PR DESCRIPTION
Add and use is_current_user to the user 'destroy' condition.

Any requests for a user to delete themselves is denied, causing
a 403 response.

Fix name of TestUiUserViewSet
Add a unit test for user delete

Issue: AAH-265


This is one potential approach to AAH-265. Using access_policy to raise a 403 error on attempts for a user to delete themselves.
