### PR TITLE
Users or admins cant delete admins 266

### DIFF
--- a/CHANGES/265.bufix
+++ b/CHANGES/265.bufix
@@ -1,0 +1,3 @@
+Users should not be able to delete themselves.
+
+Even if they have 'delete-user' perms.

--- a/CHANGES/266.bugfix
+++ b/CHANGES/266.bugfix
@@ -1,0 +1,1 @@
+Prevent users with delete-user perms from deleting admin users

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -238,6 +238,9 @@ class CollectionRemoteAccessPolicy(AccessPolicyBase):
 class UserAccessPolicy(AccessPolicyBase):
     NAME = 'UserViewSet'
 
+    def is_current_user(self, request, view, action):
+        return request.user == view.get_object()
+
 
 class MyUserAccessPolicy(AccessPolicyBase):
     NAME = 'MyUserViewSet'

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -238,6 +238,10 @@ class CollectionRemoteAccessPolicy(AccessPolicyBase):
 class UserAccessPolicy(AccessPolicyBase):
     NAME = 'UserViewSet'
 
+    def user_is_superuser(self, request, view, action):
+        user = view.get_object()
+        return user.is_superuser
+
     def is_current_user(self, request, view, action):
         return request.user == view.get_object()
 

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -83,15 +83,19 @@ STANDALONE_STATEMENTS = {
             "action": "destroy",
             "principal": "*",
             "effect": "deny",
-            "condition": "is_current_user"
-
+            "condition": ["user_is_superuser"]
+        },
+        {
+            "action": "destroy",
+            "principal": "*",
+            "effect": "deny",
+            "condition": ["is_current_user"]
         },
         {
             "action": "destroy",
             "principal": "*",
             "effect": "allow",
             "condition": "has_model_perms:galaxy.delete_user"
-
         },
         {
             "action": "create",

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -82,6 +82,13 @@ STANDALONE_STATEMENTS = {
         {
             "action": "destroy",
             "principal": "*",
+            "effect": "deny",
+            "condition": "is_current_user"
+
+        },
+        {
+            "action": "destroy",
+            "principal": "*",
             "effect": "allow",
             "condition": "has_model_perms:galaxy.delete_user"
 


### PR DESCRIPTION
Prevent admin users from deleting admin users

Don't allow users that are 'superuser' or are
called 'admin' to be deleted.

Add conditionals to UserViewSet policy for
'user_is_superuser' and 'user_is_admin'.

Issue: AAH-266


(Currently includes changes for AAH-265 as well, since they are needed)