### PR TITLE
Split proxy password field

### DIFF
--- a/CHANGES/291.bugfix
+++ b/CHANGES/291.bugfix
@@ -1,0 +1,1 @@
+split proxy_url in 3 fields: username, password, address

--- a/galaxy_ng/app/common/proxy_url.py
+++ b/galaxy_ng/app/common/proxy_url.py
@@ -1,0 +1,74 @@
+"""
+This module is temporarily added to address the
+issue AAH-291.
+
+The change that this module is solving
+is going to be implemented on pulpcore
+and then this module and its references
+can be removed or replaces with pulpcore
+implementation.
+"""
+from typing import List, Tuple, Optional
+from urllib3.util import parse_url, Url
+
+
+def get_parsed_url(parsed: Url, auth_items: Optional[List[Optional[str]]]) -> str:
+    """
+    parsed: Url instance
+    auth_items: Optional list of str ["user": "password"]
+    returns: str e.g: http://user:pass@foo.bar:9999
+    """
+    return Url(
+        scheme=parsed.scheme,
+        auth=auth_items and ":".join(auth_items) or None,
+        host=parsed.host,
+        port=parsed.port,
+        path=parsed.path,
+        query=parsed.query,
+        fragment=parsed.fragment,
+    ).url
+
+
+def strip_auth_from_url(url: str) -> Tuple[str, Optional[str], Optional[str]]:
+    """
+    Gets a full proxy address and strips its auth
+    # url: http://bruno:1234@foo.bar:9999/zaz/traz/?a#e;w
+    # returns: tuple, e.g: "http://foo.bar:9999/zaz/traz/?a#e;w", bruno, 1234
+    """
+
+    if not url.startswith(("http://", "https://")):
+        url = "http://" + url
+
+    parsed = parse_url(url)
+    auth = parsed.auth and parsed.auth.split(":")
+    username = auth and auth[0] or None
+    password = auth and len(auth) > 1 and auth[1] or None
+    return (
+        get_parsed_url(parsed, None),
+        username,
+        password,
+    )
+
+
+def join_proxy_url(address: str, username: Optional[str], password: Optional[str]) -> str:
+    """
+    Gets a splitted address, username, password
+    returns: Joined URL forming proxy_url
+    """
+    # http://username:password@address
+
+    if not address.startswith(("http://", "https://")):
+        address = "http://" + address
+
+    parsed = parse_url(address)
+    auth_items = []
+
+    if username:
+        auth_items.append(str(username))
+
+        # password is set only if there is a username
+        # to avoid it being set as e.g: http://:1234@foo.bar
+        if password:
+            auth_items.append(str(password))
+
+    return get_parsed_url(parsed, auth_items)

--- a/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
@@ -165,3 +165,133 @@ class TestUiSyncConfigViewSet(BaseTestCase):
         log.debug('response.data: %s', response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('task', response.data)
+
+    def test_sensitive_fields_are_not_exposed(self):
+        self.client.force_authenticate(user=self.admin_user)
+        api_url = self.build_config_url(self.certified_remote.name)
+        response = self.client.get(api_url)
+        self.assertNotIn('password', response.data)
+        self.assertNotIn('token', response.data)
+        self.assertNotIn('proxy_password', response.data)
+
+    def test_split_proxy_url_field(self):
+        self.client.force_authenticate(user=self.admin_user)
+
+        # ensure proxy_url is blank
+        api_url = self.build_config_url(self.certified_remote.name)
+        response = self.client.get(api_url)
+        self.assertIsNone(response.data['proxy_url'])
+        self.assertIsNone(response.data['proxy_username'])
+
+        data = {'name': response.data['name'], 'url': response.data['url']}
+
+        # PUT proxy url without auth
+        self.client.put(api_url, {'proxy_url': 'http://proxy.com:4242', **data}, format='json')
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], 'http://proxy.com:4242')
+        self.assertEqual(response.data['proxy_username'], None)
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, 'http://proxy.com:4242')
+
+        # PUT proxy url with only username
+        self.client.put(
+            api_url,
+            {'proxy_url': 'http://proxy.com:4242', 'proxy_username': 'User1', **data}, format='json'
+        )
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], 'http://proxy.com:4242')
+        self.assertEqual(response.data['proxy_username'], 'User1')
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, 'http://User1@proxy.com:4242')
+
+        # PUT proxy url with username and password
+        self.client.put(
+            api_url,
+            {
+                'proxy_url': 'http://proxy.com:4242',
+                'proxy_username': 'User1',
+                'proxy_password': 'MyPrecious42',
+                **data
+            },
+            format='json'
+        )
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], 'http://proxy.com:4242')
+        self.assertEqual(response.data['proxy_username'], 'User1')
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, 'http://User1:MyPrecious42@proxy.com:4242')
+
+        # Edit password
+        self.client.put(api_url, {'proxy_password': 'MyPrecious43', **data}, format='json')
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], 'http://proxy.com:4242')
+        self.assertEqual(response.data['proxy_username'], 'User1')
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, 'http://User1:MyPrecious43@proxy.com:4242')
+
+        # Edit username
+        self.client.put(api_url, {'proxy_username': 'User2', **data}, format='json')
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], 'http://proxy.com:4242')
+        self.assertEqual(response.data['proxy_username'], 'User2')
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, 'http://User2:MyPrecious43@proxy.com:4242')
+
+        # Edit url using IP
+        self.client.put(api_url, {'proxy_url': 'http://192.168.0.42:4242', **data}, format='json')
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], 'http://192.168.0.42:4242')
+        self.assertEqual(response.data['proxy_username'], 'User2')
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, 'http://User2:MyPrecious43@192.168.0.42:4242')
+
+        # Edit url without scheme
+        response = self.client.put(
+            api_url, {'proxy_url': '192.168.0.42:4242', **data}, format='json'
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['errors'][0]['detail'], 'Enter a valid URL.')
+
+        # Edit url
+        self.client.put(api_url, {'proxy_url': 'http://proxy2.com:4242', **data}, format='json')
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], 'http://proxy2.com:4242')
+        self.assertEqual(response.data['proxy_username'], 'User2')
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, 'http://User2:MyPrecious43@proxy2.com:4242')
+
+        # Cleanup password
+        self.client.put(api_url, {'proxy_password': None, **data}, format='json')
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], 'http://proxy2.com:4242')
+        self.assertEqual(response.data['proxy_username'], 'User2')
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, 'http://User2@proxy2.com:4242')
+
+        # Cleanup username even if password is set  (avoid http://:1234@...)
+        self.client.put(
+            api_url, {'proxy_password': '1234', 'proxy_username': None, **data}, format='json'
+        )
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], 'http://proxy2.com:4242')
+        self.assertEqual(response.data['proxy_username'], None)
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, 'http://proxy2.com:4242')
+
+        # Cleanup everything
+        self.client.put(api_url, {'proxy_url': None, **data}, format='json')
+        response = self.client.get(api_url)
+        self.assertEqual(response.data['proxy_url'], None)
+        self.assertEqual(response.data['proxy_username'], None)
+        self.assertNotIn('proxy_password', response.data)
+        instance = CollectionRemote.objects.get(pk=response.data['pk'])
+        self.assertEqual(instance.proxy_url, None)


### PR DESCRIPTION
the pulpcore database field proxy_url holds
information in form: `http://user:pass@host:port`

## Representation.

This PR splits that field in 3 different fields
only for API retrieval (GET)

proxy_address - `http://host:port`
proxy_username - `user`
proxy_password - `pass`

## Saving.

As those 3 fields doesn;t exist (yet) in pulpcore database model
in order to save we need to rejoin those 3 fields so
it get back to it regular form.

## Why?

we want to omit the `:pass` fragment from our retrieval API, but still expose user, host and port fragments

Issue: AAH-291