### PR TITLE
Update requirement files to use new pip-tools format

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -4,98 +4,190 @@
 #
 #    pip-compile --output-file=requirements/requirements.common.txt setup.py
 #
-aiodns==2.0.0             # via pulpcore
-aiofiles==0.5.0           # via pulpcore
-aiohttp==3.6.2            # via pulpcore
-ansible-base==2.10.1      # via ansible
-ansible-builder==0.2.2    # via galaxy-importer
-ansible-lint==4.3.5       # via galaxy-importer
-ansible==2.10.0           # via ansible-lint, galaxy-importer
-async-timeout==3.0.1      # via aiohttp
-attrs==20.2.0             # via aiohttp, galaxy-importer, jsonschema
-backoff==1.10.0           # via pulpcore
-bleach-whitelist==0.0.11  # via galaxy-importer
-bleach==3.2.1             # via galaxy-importer
-certifi==2020.6.20        # via requests
-cffi==1.14.3              # via cryptography, pycares
-chardet==3.0.4            # via aiohttp, requests
-click==7.1.2              # via rq
-colorama==0.4.3           # via rich
-commonmark==0.9.1         # via rich
-cryptography==3.1.1       # via ansible-base
-dataclasses==0.7          # via rich
-defusedxml==0.6.0         # via odfpy
-diff-match-patch==20200713  # via django-import-export
-django-cleanup==5.1.0     # via pulpcore
-django-currentuser==0.5.1  # via pulpcore
-django-filter==2.3.0      # via pulpcore
-django-guardian==2.3.0    # via pulpcore
-django-import-export==2.3.0  # via pulpcore
-django-lifecycle==0.7.7   # via pulpcore
-django-prometheus==2.1.0  # via galaxy-ng (setup.py)
-django==2.2.16            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
-djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.11.2  # via drf-nested-routers, drf-spectacular, pulpcore
-drf-access-policy==0.7.0  # via pulpcore
-drf-nested-routers==0.91  # via pulpcore
-drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.1.1           # via pulpcore
-et-xmlfile==1.0.1         # via openpyxl
-flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.14   # via galaxy-ng (setup.py), pulp-ansible
-gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via flake8, jsonschema, markdown
-inflection==0.5.1         # via drf-spectacular
-jdcal==1.4.1              # via openpyxl
-jinja2==2.11.2            # via ansible-base, pulpcore
-jsonschema==3.2.0         # via drf-spectacular, pulp-ansible
-markdown==3.2.2           # via galaxy-importer
-markuppy==1.14            # via tablib
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8
-multidict==4.7.6          # via aiohttp, yarl
-odfpy==1.4.1              # via tablib
-openpyxl==3.0.5           # via tablib
-packaging==20.4           # via ansible-base, bleach, pulp-ansible
-prometheus-client==0.8.0  # via django-prometheus
-psycopg2==2.8.6           # via pulpcore
-pulp-ansible==0.5.5       # via galaxy-ng (setup.py)
-pulpcore==3.7.1           # via galaxy-ng (setup.py), pulp-ansible
-pycares==3.1.1            # via aiodns
-pycodestyle==2.6.0        # via flake8
-pycparser==2.20           # via cffi
-pyflakes==2.2.0           # via flake8
-pygments==2.7.1           # via rich
-pygtrie==2.3.3            # via pulpcore
-pyparsing==2.4.7          # via packaging
-pyrsistent==0.17.3        # via jsonschema
-python-gnupg==0.4.6       # via pulpcore
-pytz==2020.1              # via django
-pyyaml==5.3.1             # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
-redis==3.5.3              # via pulpcore, rq
-requests==2.24.0          # via galaxy-importer
-requirements-parser==0.2.0  # via ansible-builder
-rich==7.1.0               # via ansible-lint
-rq==1.5.2                 # via pulpcore
-ruamel.yaml.clib==0.2.2   # via ruamel.yaml
-ruamel.yaml==0.16.12      # via ansible-lint
-semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via bleach, cryptography, jsonschema, packaging
-sqlparse==0.3.1           # via django
-tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.3  # via aiohttp, ansible-lint, rich, yarl
-typing==3.7.4.3           # via aiodns
-uritemplate==3.0.1        # via drf-spectacular
-urllib3==1.25.10          # via requests
-urlman==1.3.0             # via django-lifecycle
-webencodings==0.5.1       # via bleach
-whitenoise==5.2.0         # via pulpcore
-xlrd==1.2.0               # via tablib
-xlwt==1.3.0               # via tablib
-yarl==1.6.0               # via aiohttp
-zipp==3.2.0               # via importlib-metadata
+aiodns==2.0.0
+    # via pulpcore
+aiofiles==0.5.0
+    # via pulpcore
+aiohttp==3.6.2
+    # via pulpcore
+ansible-base==2.10.1
+    # via ansible
+ansible-builder==0.2.2
+    # via galaxy-importer
+ansible-lint==4.3.5
+    # via galaxy-importer
+ansible==2.10.0
+    # via ansible-lint, galaxy-importer
+async-timeout==3.0.1
+    # via aiohttp
+attrs==20.2.0
+    # via aiohttp, galaxy-importer, jsonschema
+backoff==1.10.0
+    # via pulpcore
+bleach-whitelist==0.0.11
+    # via galaxy-importer
+bleach==3.2.1
+    # via galaxy-importer
+certifi==2020.6.20
+    # via requests
+cffi==1.14.3
+    # via cryptography, pycares
+chardet==3.0.4
+    # via aiohttp, requests
+click==7.1.2
+    # via rq
+colorama==0.4.3
+    # via rich
+commonmark==0.9.1
+    # via rich
+cryptography==3.1.1
+    # via ansible-base
+dataclasses==0.7
+    # via rich
+defusedxml==0.6.0
+    # via odfpy
+diff-match-patch==20200713
+    # via django-import-export
+django-cleanup==5.1.0
+    # via pulpcore
+django-currentuser==0.5.1
+    # via pulpcore
+django-filter==2.3.0
+    # via pulpcore
+django-guardian==2.3.0
+    # via pulpcore
+django-import-export==2.3.0
+    # via pulpcore
+django-lifecycle==0.7.7
+    # via pulpcore
+django-prometheus==2.1.0
+    # via galaxy-ng (setup.py)
+django==2.2.16
+    # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+djangorestframework-queryfields==1.0.0
+    # via pulpcore
+djangorestframework==3.11.2
+    # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.7.0
+    # via pulpcore
+drf-nested-routers==0.91
+    # via pulpcore
+drf-spectacular==0.9.13
+    # via galaxy-ng (setup.py), pulpcore
+dynaconf==3.1.1
+    # via pulpcore
+et-xmlfile==1.0.1
+    # via openpyxl
+flake8==3.8.3
+    # via galaxy-importer
+galaxy-importer==0.2.14
+    # via galaxy-ng (setup.py), pulp-ansible
+gunicorn==20.0.4
+    # via pulpcore
+idna-ssl==1.1.0
+    # via aiohttp
+idna==2.10
+    # via idna-ssl, requests, yarl
+importlib-metadata==2.0.0
+    # via flake8, jsonschema, markdown
+inflection==0.5.1
+    # via drf-spectacular
+jdcal==1.4.1
+    # via openpyxl
+jinja2==2.11.2
+    # via ansible-base, pulpcore
+jsonschema==3.2.0
+    # via drf-spectacular, pulp-ansible
+markdown==3.2.2
+    # via galaxy-importer
+markuppy==1.14
+    # via tablib
+markupsafe==1.1.1
+    # via jinja2
+mccabe==0.6.1
+    # via flake8
+multidict==4.7.6
+    # via aiohttp, yarl
+odfpy==1.4.1
+    # via tablib
+openpyxl==3.0.5
+    # via tablib
+packaging==20.4
+    # via ansible-base, bleach, pulp-ansible
+prometheus-client==0.8.0
+    # via django-prometheus
+psycopg2==2.8.6
+    # via pulpcore
+pulp-ansible==0.5.5
+    # via galaxy-ng (setup.py)
+pulpcore==3.7.1
+    # via galaxy-ng (setup.py), pulp-ansible
+pycares==3.1.1
+    # via aiodns
+pycodestyle==2.6.0
+    # via flake8
+pycparser==2.20
+    # via cffi
+pyflakes==2.2.0
+    # via flake8
+pygments==2.7.1
+    # via rich
+pygtrie==2.3.3
+    # via pulpcore
+pyparsing==2.4.7
+    # via packaging
+pyrsistent==0.17.3
+    # via jsonschema
+python-gnupg==0.4.6
+    # via pulpcore
+pytz==2020.1
+    # via django
+pyyaml==5.3.1
+    # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+redis==3.5.3
+    # via pulpcore, rq
+requests==2.24.0
+    # via galaxy-importer
+requirements-parser==0.2.0
+    # via ansible-builder
+rich==7.1.0
+    # via ansible-lint
+rq==1.5.2
+    # via pulpcore
+ruamel.yaml.clib==0.2.2
+    # via ruamel.yaml
+ruamel.yaml==0.16.12
+    # via ansible-lint
+semantic-version==2.8.5
+    # via galaxy-importer, pulp-ansible
+six==1.15.0
+    # via bleach, cryptography, jsonschema, packaging
+sqlparse==0.3.1
+    # via django
+tablib[html,ods,xls,xlsx,yaml]==2.0.0
+    # via django-import-export
+typing-extensions==3.7.4.3
+    # via aiohttp, ansible-lint, rich, yarl
+typing==3.7.4.3
+    # via aiodns
+uritemplate==3.0.1
+    # via drf-spectacular
+urllib3==1.25.10
+    # via requests
+urlman==1.3.0
+    # via django-lifecycle
+webencodings==0.5.1
+    # via bleach
+whitenoise==5.2.0
+    # via pulpcore
+xlrd==1.2.0
+    # via tablib
+xlwt==1.3.0
+    # via tablib
+yarl==1.6.0
+    # via aiohttp
+zipp==3.2.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -17,11 +17,16 @@ ansible-builder==0.2.2
 ansible-lint==4.3.5
     # via galaxy-importer
 ansible==2.10.0
-    # via ansible-lint, galaxy-importer
+    # via
+    #   ansible-lint
+    #   galaxy-importer
 async-timeout==3.0.1
     # via aiohttp
 attrs==20.2.0
-    # via aiohttp, galaxy-importer, jsonschema
+    # via
+    #   aiohttp
+    #   galaxy-importer
+    #   jsonschema
 backoff==1.10.0
     # via pulpcore
 bleach-whitelist==0.0.11
@@ -31,9 +36,13 @@ bleach==3.2.1
 certifi==2020.6.20
     # via requests
 cffi==1.14.3
-    # via cryptography, pycares
+    # via
+    #   cryptography
+    #   pycares
 chardet==3.0.4
-    # via aiohttp, requests
+    # via
+    #   aiohttp
+    #   requests
 click==7.1.2
     # via rq
 colorama==0.4.3
@@ -42,8 +51,6 @@ commonmark==0.9.1
     # via rich
 cryptography==3.1.1
     # via ansible-base
-dataclasses==0.7
-    # via rich
 defusedxml==0.6.0
     # via odfpy
 diff-match-patch==20200713
@@ -63,17 +70,32 @@ django-lifecycle==0.7.7
 django-prometheus==2.1.0
     # via galaxy-ng (setup.py)
 django==2.2.16
-    # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+    # via
+    #   django-currentuser
+    #   django-filter
+    #   django-guardian
+    #   django-import-export
+    #   django-lifecycle
+    #   djangorestframework
+    #   drf-nested-routers
+    #   drf-spectacular
+    #   galaxy-ng (setup.py)
+    #   pulpcore
 djangorestframework-queryfields==1.0.0
     # via pulpcore
 djangorestframework==3.11.2
-    # via drf-nested-routers, drf-spectacular, pulpcore
+    # via
+    #   drf-nested-routers
+    #   drf-spectacular
+    #   pulpcore
 drf-access-policy==0.7.0
     # via pulpcore
 drf-nested-routers==0.91
     # via pulpcore
 drf-spectacular==0.9.13
-    # via galaxy-ng (setup.py), pulpcore
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulpcore
 dynaconf==3.1.1
     # via pulpcore
 et-xmlfile==1.0.1
@@ -81,23 +103,27 @@ et-xmlfile==1.0.1
 flake8==3.8.3
     # via galaxy-importer
 galaxy-importer==0.2.14
-    # via galaxy-ng (setup.py), pulp-ansible
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulp-ansible
 gunicorn==20.0.4
     # via pulpcore
-idna-ssl==1.1.0
-    # via aiohttp
 idna==2.10
-    # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0
-    # via flake8, jsonschema, markdown
+    # via
+    #   requests
+    #   yarl
 inflection==0.5.1
     # via drf-spectacular
 jdcal==1.4.1
     # via openpyxl
 jinja2==2.11.2
-    # via ansible-base, pulpcore
+    # via
+    #   ansible-base
+    #   pulpcore
 jsonschema==3.2.0
-    # via drf-spectacular, pulp-ansible
+    # via
+    #   drf-spectacular
+    #   pulp-ansible
 markdown==3.2.2
     # via galaxy-importer
 markuppy==1.14
@@ -107,13 +133,18 @@ markupsafe==1.1.1
 mccabe==0.6.1
     # via flake8
 multidict==4.7.6
-    # via aiohttp, yarl
+    # via
+    #   aiohttp
+    #   yarl
 odfpy==1.4.1
     # via tablib
 openpyxl==3.0.5
     # via tablib
 packaging==20.4
-    # via ansible-base, bleach, pulp-ansible
+    # via
+    #   ansible-base
+    #   bleach
+    #   pulp-ansible
 prometheus-client==0.8.0
     # via django-prometheus
 psycopg2==2.8.6
@@ -121,7 +152,9 @@ psycopg2==2.8.6
 pulp-ansible==0.5.5
     # via galaxy-ng (setup.py)
 pulpcore==3.7.1
-    # via galaxy-ng (setup.py), pulp-ansible
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulp-ansible
 pycares==3.1.1
     # via aiodns
 pycodestyle==2.6.0
@@ -143,9 +176,19 @@ python-gnupg==0.4.6
 pytz==2020.1
     # via django
 pyyaml==5.3.1
-    # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+    # via
+    #   ansible-base
+    #   ansible-builder
+    #   ansible-lint
+    #   drf-spectacular
+    #   galaxy-importer
+    #   pulp-ansible
+    #   pulpcore
+    #   tablib
 redis==3.5.3
-    # via pulpcore, rq
+    # via
+    #   pulpcore
+    #   rq
 requests==2.24.0
     # via galaxy-importer
 requirements-parser==0.2.0
@@ -154,22 +197,24 @@ rich==7.1.0
     # via ansible-lint
 rq==1.5.2
     # via pulpcore
-ruamel.yaml.clib==0.2.2
-    # via ruamel.yaml
 ruamel.yaml==0.16.12
     # via ansible-lint
 semantic-version==2.8.5
-    # via galaxy-importer, pulp-ansible
+    # via
+    #   galaxy-importer
+    #   pulp-ansible
 six==1.15.0
-    # via bleach, cryptography, jsonschema, packaging
+    # via
+    #   bleach
+    #   cryptography
+    #   jsonschema
+    #   packaging
 sqlparse==0.3.1
     # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0
     # via django-import-export
 typing-extensions==3.7.4.3
-    # via aiohttp, ansible-lint, rich, yarl
-typing==3.7.4.3
-    # via aiodns
+    # via rich
 uritemplate==3.0.1
     # via drf-spectacular
 urllib3==1.25.10
@@ -186,8 +231,6 @@ xlwt==1.3.0
     # via tablib
 yarl==1.6.0
     # via aiohttp
-zipp==3.2.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -4,106 +4,206 @@
 #
 #    pip-compile --output-file=requirements/requirements.insights.txt requirements/requirements.insights.in setup.py
 #
-aiodns==2.0.0             # via pulpcore
-aiofiles==0.5.0           # via pulpcore
-aiohttp==3.6.2            # via pulpcore
-ansible-base==2.10.1      # via ansible
-ansible-builder==0.2.2    # via galaxy-importer
-ansible-lint==4.3.5       # via galaxy-importer
-ansible==2.10.0           # via ansible-lint, galaxy-importer
-async-timeout==3.0.1      # via aiohttp
-attrs==20.2.0             # via aiohttp, galaxy-importer, jsonschema
-backoff==1.10.0           # via pulpcore
-bleach-whitelist==0.0.11  # via galaxy-importer
-bleach==3.2.1             # via galaxy-importer
-boto3==1.15.9             # via -r requirements/requirements.insights.in, django-storages, watchtower
-botocore==1.18.9          # via boto3, s3transfer
-certifi==2020.6.20        # via requests
-cffi==1.14.3              # via cryptography, pycares
-chardet==3.0.4            # via aiohttp, requests
-click==7.1.2              # via rq
-colorama==0.4.3           # via rich
-commonmark==0.9.1         # via rich
-cryptography==3.1.1       # via ansible-base
-dataclasses==0.7          # via rich
-defusedxml==0.6.0         # via odfpy
-diff-match-patch==20200713  # via django-import-export
-django-cleanup==5.1.0     # via pulpcore
-django-currentuser==0.5.1  # via pulpcore
-django-filter==2.3.0      # via pulpcore
-django-guardian==2.3.0    # via pulpcore
-django-import-export==2.3.0  # via pulpcore
-django-lifecycle==0.7.7   # via pulpcore
-django-prometheus==2.1.0  # via galaxy-ng (setup.py)
-django-storages[boto3]==1.10.1  # via -r requirements/requirements.insights.in
-django==2.2.16            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, django-storages, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
-djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.11.2  # via drf-nested-routers, drf-spectacular, pulpcore
-drf-access-policy==0.7.0  # via pulpcore
-drf-nested-routers==0.91  # via pulpcore
-drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.1.1           # via pulpcore
-et-xmlfile==1.0.1         # via openpyxl
-flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.14   # via galaxy-ng (setup.py), pulp-ansible
-gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via flake8, jsonschema, markdown
-inflection==0.5.1         # via drf-spectacular
-jdcal==1.4.1              # via openpyxl
-jinja2==2.11.2            # via ansible-base, pulpcore
-jmespath==0.10.0          # via boto3, botocore
-jsonschema==3.2.0         # via drf-spectacular, pulp-ansible
-logstash-formatter==0.5.17  # via -r requirements/requirements.insights.in
-markdown==3.2.2           # via galaxy-importer
-markuppy==1.14            # via tablib
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8
-multidict==4.7.6          # via aiohttp, yarl
-odfpy==1.4.1              # via tablib
-openpyxl==3.0.5           # via tablib
-packaging==20.4           # via ansible-base, bleach, pulp-ansible
-prometheus-client==0.8.0  # via django-prometheus
-psycopg2==2.8.6           # via pulpcore
-pulp-ansible==0.5.5       # via galaxy-ng (setup.py)
-pulpcore==3.7.1           # via galaxy-ng (setup.py), pulp-ansible
-pycares==3.1.1            # via aiodns
-pycodestyle==2.6.0        # via flake8
-pycparser==2.20           # via cffi
-pyflakes==2.2.0           # via flake8
-pygments==2.7.1           # via rich
-pygtrie==2.3.3            # via pulpcore
-pyparsing==2.4.7          # via packaging
-pyrsistent==0.17.3        # via jsonschema
-python-dateutil==2.8.1    # via botocore
-python-gnupg==0.4.6       # via pulpcore
-pytz==2020.1              # via django
-pyyaml==5.3.1             # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
-redis==3.5.3              # via pulpcore, rq
-requests==2.24.0          # via galaxy-importer
-requirements-parser==0.2.0  # via ansible-builder
-rich==7.1.0               # via ansible-lint
-rq==1.5.2                 # via pulpcore
-ruamel.yaml.clib==0.2.2   # via ruamel.yaml
-ruamel.yaml==0.16.12      # via ansible-lint
-s3transfer==0.3.3         # via boto3
-semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via bleach, cryptography, jsonschema, packaging, python-dateutil
-sqlparse==0.3.1           # via django
-tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.3  # via aiohttp, ansible-lint, rich, yarl
-typing==3.7.4.3           # via aiodns
-uritemplate==3.0.1        # via drf-spectacular
-urllib3==1.25.10          # via botocore, requests
-urlman==1.3.0             # via django-lifecycle
-watchtower==0.8.0         # via -r requirements/requirements.insights.in
-webencodings==0.5.1       # via bleach
-whitenoise==5.2.0         # via pulpcore
-xlrd==1.2.0               # via tablib
-xlwt==1.3.0               # via tablib
-yarl==1.6.0               # via aiohttp
-zipp==3.2.0               # via importlib-metadata
+aiodns==2.0.0
+    # via pulpcore
+aiofiles==0.5.0
+    # via pulpcore
+aiohttp==3.6.2
+    # via pulpcore
+ansible-base==2.10.1
+    # via ansible
+ansible-builder==0.2.2
+    # via galaxy-importer
+ansible-lint==4.3.5
+    # via galaxy-importer
+ansible==2.10.0
+    # via ansible-lint, galaxy-importer
+async-timeout==3.0.1
+    # via aiohttp
+attrs==20.2.0
+    # via aiohttp, galaxy-importer, jsonschema
+backoff==1.10.0
+    # via pulpcore
+bleach-whitelist==0.0.11
+    # via galaxy-importer
+bleach==3.2.1
+    # via galaxy-importer
+boto3==1.15.9
+    # via -r requirements/requirements.insights.in, django-storages, watchtower
+botocore==1.18.9
+    # via boto3, s3transfer
+certifi==2020.6.20
+    # via requests
+cffi==1.14.3
+    # via cryptography, pycares
+chardet==3.0.4
+    # via aiohttp, requests
+click==7.1.2
+    # via rq
+colorama==0.4.3
+    # via rich
+commonmark==0.9.1
+    # via rich
+cryptography==3.1.1
+    # via ansible-base
+dataclasses==0.7
+    # via rich
+defusedxml==0.6.0
+    # via odfpy
+diff-match-patch==20200713
+    # via django-import-export
+django-cleanup==5.1.0
+    # via pulpcore
+django-currentuser==0.5.1
+    # via pulpcore
+django-filter==2.3.0
+    # via pulpcore
+django-guardian==2.3.0
+    # via pulpcore
+django-import-export==2.3.0
+    # via pulpcore
+django-lifecycle==0.7.7
+    # via pulpcore
+django-prometheus==2.1.0
+    # via galaxy-ng (setup.py)
+django-storages[boto3]==1.10.1
+    # via -r requirements/requirements.insights.in
+django==2.2.16
+    # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, django-storages, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+djangorestframework-queryfields==1.0.0
+    # via pulpcore
+djangorestframework==3.11.2
+    # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.7.0
+    # via pulpcore
+drf-nested-routers==0.91
+    # via pulpcore
+drf-spectacular==0.9.13
+    # via galaxy-ng (setup.py), pulpcore
+dynaconf==3.1.1
+    # via pulpcore
+et-xmlfile==1.0.1
+    # via openpyxl
+flake8==3.8.3
+    # via galaxy-importer
+galaxy-importer==0.2.14
+    # via galaxy-ng (setup.py), pulp-ansible
+gunicorn==20.0.4
+    # via pulpcore
+idna-ssl==1.1.0
+    # via aiohttp
+idna==2.10
+    # via idna-ssl, requests, yarl
+importlib-metadata==2.0.0
+    # via flake8, jsonschema, markdown
+inflection==0.5.1
+    # via drf-spectacular
+jdcal==1.4.1
+    # via openpyxl
+jinja2==2.11.2
+    # via ansible-base, pulpcore
+jmespath==0.10.0
+    # via boto3, botocore
+jsonschema==3.2.0
+    # via drf-spectacular, pulp-ansible
+logstash-formatter==0.5.17
+    # via -r requirements/requirements.insights.in
+markdown==3.2.2
+    # via galaxy-importer
+markuppy==1.14
+    # via tablib
+markupsafe==1.1.1
+    # via jinja2
+mccabe==0.6.1
+    # via flake8
+multidict==4.7.6
+    # via aiohttp, yarl
+odfpy==1.4.1
+    # via tablib
+openpyxl==3.0.5
+    # via tablib
+packaging==20.4
+    # via ansible-base, bleach, pulp-ansible
+prometheus-client==0.8.0
+    # via django-prometheus
+psycopg2==2.8.6
+    # via pulpcore
+pulp-ansible==0.5.5
+    # via galaxy-ng (setup.py)
+pulpcore==3.7.1
+    # via galaxy-ng (setup.py), pulp-ansible
+pycares==3.1.1
+    # via aiodns
+pycodestyle==2.6.0
+    # via flake8
+pycparser==2.20
+    # via cffi
+pyflakes==2.2.0
+    # via flake8
+pygments==2.7.1
+    # via rich
+pygtrie==2.3.3
+    # via pulpcore
+pyparsing==2.4.7
+    # via packaging
+pyrsistent==0.17.3
+    # via jsonschema
+python-dateutil==2.8.1
+    # via botocore
+python-gnupg==0.4.6
+    # via pulpcore
+pytz==2020.1
+    # via django
+pyyaml==5.3.1
+    # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+redis==3.5.3
+    # via pulpcore, rq
+requests==2.24.0
+    # via galaxy-importer
+requirements-parser==0.2.0
+    # via ansible-builder
+rich==7.1.0
+    # via ansible-lint
+rq==1.5.2
+    # via pulpcore
+ruamel.yaml.clib==0.2.2
+    # via ruamel.yaml
+ruamel.yaml==0.16.12
+    # via ansible-lint
+s3transfer==0.3.3
+    # via boto3
+semantic-version==2.8.5
+    # via galaxy-importer, pulp-ansible
+six==1.15.0
+    # via bleach, cryptography, jsonschema, packaging, python-dateutil
+sqlparse==0.3.1
+    # via django
+tablib[html,ods,xls,xlsx,yaml]==2.0.0
+    # via django-import-export
+typing-extensions==3.7.4.3
+    # via aiohttp, ansible-lint, rich, yarl
+typing==3.7.4.3
+    # via aiodns
+uritemplate==3.0.1
+    # via drf-spectacular
+urllib3==1.25.10
+    # via botocore, requests
+urlman==1.3.0
+    # via django-lifecycle
+watchtower==0.8.0
+    # via -r requirements/requirements.insights.in
+webencodings==0.5.1
+    # via bleach
+whitenoise==5.2.0
+    # via pulpcore
+xlrd==1.2.0
+    # via tablib
+xlwt==1.3.0
+    # via tablib
+yarl==1.6.0
+    # via aiohttp
+zipp==3.2.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -17,11 +17,16 @@ ansible-builder==0.2.2
 ansible-lint==4.3.5
     # via galaxy-importer
 ansible==2.10.0
-    # via ansible-lint, galaxy-importer
+    # via
+    #   ansible-lint
+    #   galaxy-importer
 async-timeout==3.0.1
     # via aiohttp
 attrs==20.2.0
-    # via aiohttp, galaxy-importer, jsonschema
+    # via
+    #   aiohttp
+    #   galaxy-importer
+    #   jsonschema
 backoff==1.10.0
     # via pulpcore
 bleach-whitelist==0.0.11
@@ -29,15 +34,24 @@ bleach-whitelist==0.0.11
 bleach==3.2.1
     # via galaxy-importer
 boto3==1.15.9
-    # via -r requirements/requirements.insights.in, django-storages, watchtower
+    # via
+    #   -r requirements/requirements.insights.in
+    #   django-storages
+    #   watchtower
 botocore==1.18.9
-    # via boto3, s3transfer
+    # via
+    #   boto3
+    #   s3transfer
 certifi==2020.6.20
     # via requests
 cffi==1.14.3
-    # via cryptography, pycares
+    # via
+    #   cryptography
+    #   pycares
 chardet==3.0.4
-    # via aiohttp, requests
+    # via
+    #   aiohttp
+    #   requests
 click==7.1.2
     # via rq
 colorama==0.4.3
@@ -46,8 +60,6 @@ commonmark==0.9.1
     # via rich
 cryptography==3.1.1
     # via ansible-base
-dataclasses==0.7
-    # via rich
 defusedxml==0.6.0
     # via odfpy
 diff-match-patch==20200713
@@ -69,17 +81,33 @@ django-prometheus==2.1.0
 django-storages[boto3]==1.10.1
     # via -r requirements/requirements.insights.in
 django==2.2.16
-    # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, django-storages, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+    # via
+    #   django-currentuser
+    #   django-filter
+    #   django-guardian
+    #   django-import-export
+    #   django-lifecycle
+    #   django-storages
+    #   djangorestframework
+    #   drf-nested-routers
+    #   drf-spectacular
+    #   galaxy-ng (setup.py)
+    #   pulpcore
 djangorestframework-queryfields==1.0.0
     # via pulpcore
 djangorestframework==3.11.2
-    # via drf-nested-routers, drf-spectacular, pulpcore
+    # via
+    #   drf-nested-routers
+    #   drf-spectacular
+    #   pulpcore
 drf-access-policy==0.7.0
     # via pulpcore
 drf-nested-routers==0.91
     # via pulpcore
 drf-spectacular==0.9.13
-    # via galaxy-ng (setup.py), pulpcore
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulpcore
 dynaconf==3.1.1
     # via pulpcore
 et-xmlfile==1.0.1
@@ -87,25 +115,31 @@ et-xmlfile==1.0.1
 flake8==3.8.3
     # via galaxy-importer
 galaxy-importer==0.2.14
-    # via galaxy-ng (setup.py), pulp-ansible
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulp-ansible
 gunicorn==20.0.4
     # via pulpcore
-idna-ssl==1.1.0
-    # via aiohttp
 idna==2.10
-    # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0
-    # via flake8, jsonschema, markdown
+    # via
+    #   requests
+    #   yarl
 inflection==0.5.1
     # via drf-spectacular
 jdcal==1.4.1
     # via openpyxl
 jinja2==2.11.2
-    # via ansible-base, pulpcore
+    # via
+    #   ansible-base
+    #   pulpcore
 jmespath==0.10.0
-    # via boto3, botocore
+    # via
+    #   boto3
+    #   botocore
 jsonschema==3.2.0
-    # via drf-spectacular, pulp-ansible
+    # via
+    #   drf-spectacular
+    #   pulp-ansible
 logstash-formatter==0.5.17
     # via -r requirements/requirements.insights.in
 markdown==3.2.2
@@ -117,13 +151,18 @@ markupsafe==1.1.1
 mccabe==0.6.1
     # via flake8
 multidict==4.7.6
-    # via aiohttp, yarl
+    # via
+    #   aiohttp
+    #   yarl
 odfpy==1.4.1
     # via tablib
 openpyxl==3.0.5
     # via tablib
 packaging==20.4
-    # via ansible-base, bleach, pulp-ansible
+    # via
+    #   ansible-base
+    #   bleach
+    #   pulp-ansible
 prometheus-client==0.8.0
     # via django-prometheus
 psycopg2==2.8.6
@@ -131,7 +170,9 @@ psycopg2==2.8.6
 pulp-ansible==0.5.5
     # via galaxy-ng (setup.py)
 pulpcore==3.7.1
-    # via galaxy-ng (setup.py), pulp-ansible
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulp-ansible
 pycares==3.1.1
     # via aiodns
 pycodestyle==2.6.0
@@ -155,9 +196,19 @@ python-gnupg==0.4.6
 pytz==2020.1
     # via django
 pyyaml==5.3.1
-    # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+    # via
+    #   ansible-base
+    #   ansible-builder
+    #   ansible-lint
+    #   drf-spectacular
+    #   galaxy-importer
+    #   pulp-ansible
+    #   pulpcore
+    #   tablib
 redis==3.5.3
-    # via pulpcore, rq
+    # via
+    #   pulpcore
+    #   rq
 requests==2.24.0
     # via galaxy-importer
 requirements-parser==0.2.0
@@ -166,28 +217,33 @@ rich==7.1.0
     # via ansible-lint
 rq==1.5.2
     # via pulpcore
-ruamel.yaml.clib==0.2.2
-    # via ruamel.yaml
 ruamel.yaml==0.16.12
     # via ansible-lint
 s3transfer==0.3.3
     # via boto3
 semantic-version==2.8.5
-    # via galaxy-importer, pulp-ansible
+    # via
+    #   galaxy-importer
+    #   pulp-ansible
 six==1.15.0
-    # via bleach, cryptography, jsonschema, packaging, python-dateutil
+    # via
+    #   bleach
+    #   cryptography
+    #   jsonschema
+    #   packaging
+    #   python-dateutil
 sqlparse==0.3.1
     # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0
     # via django-import-export
 typing-extensions==3.7.4.3
-    # via aiohttp, ansible-lint, rich, yarl
-typing==3.7.4.3
-    # via aiodns
+    # via rich
 uritemplate==3.0.1
     # via drf-spectacular
 urllib3==1.25.10
-    # via botocore, requests
+    # via
+    #   botocore
+    #   requests
 urlman==1.3.0
     # via django-lifecycle
 watchtower==0.8.0
@@ -202,8 +258,6 @@ xlwt==1.3.0
     # via tablib
 yarl==1.6.0
     # via aiohttp
-zipp==3.2.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -4,105 +4,204 @@
 #
 #    pip-compile --output-file=requirements/requirements.standalone.txt requirements/requirements.standalone.in setup.py
 #
-aiodns==2.0.0             # via pulpcore
-aiofiles==0.5.0           # via pulpcore
-aiohttp==3.6.2            # via pulpcore
-ansible-base==2.10.1      # via ansible
-ansible-builder==0.2.2    # via galaxy-importer
-ansible-lint==4.3.5       # via galaxy-importer
-ansible==2.10.0           # via ansible-lint, galaxy-importer
-async-timeout==3.0.1      # via aiohttp
-attrs==20.2.0             # via aiohttp, galaxy-importer, jsonschema
-backoff==1.10.0           # via pulpcore
-bleach-whitelist==0.0.11  # via galaxy-importer
-bleach==3.2.1             # via galaxy-importer
-certifi==2020.6.20        # via requests
-cffi==1.14.3              # via cryptography, pycares
-chardet==3.0.4            # via aiohttp, requests
-click==7.1.2              # via rq
-colorama==0.4.3           # via rich
-commonmark==0.9.1         # via rich
-cryptography==3.1.1       # via ansible-base, pyjwt
-dataclasses==0.7          # via rich
-defusedxml==0.6.0         # via odfpy
-diff-match-patch==20200713  # via django-import-export
-django-cleanup==5.1.0     # via pulpcore
-django-currentuser==0.5.1  # via pulpcore
-django-filter==2.3.0      # via pulpcore
-django-guardian==2.3.0    # via pulpcore
-django-import-export==2.3.0  # via pulpcore
-django-lifecycle==0.7.7   # via pulpcore
-django-prometheus==2.1.0  # via galaxy-ng (setup.py)
-django==2.2.16            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
-djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.11.2  # via drf-nested-routers, drf-spectacular, pulpcore
-drf-access-policy==0.7.0  # via pulpcore
-drf-nested-routers==0.91  # via pulpcore
-drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.1.1           # via pulpcore
-ecdsa==0.13.3             # via pulp-container
-et-xmlfile==1.0.1         # via openpyxl
-flake8==3.8.3             # via galaxy-importer
-future==0.18.2            # via pyjwkest
-galaxy-importer==0.2.14   # via galaxy-ng (setup.py), pulp-ansible
-gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via flake8, jsonschema, markdown
-inflection==0.5.1         # via drf-spectacular
-jdcal==1.4.1              # via openpyxl
-jinja2==2.11.2            # via ansible-base, pulpcore
-jsonschema==3.2.0         # via drf-spectacular, pulp-ansible
-markdown==3.2.2           # via galaxy-importer
-markuppy==1.14            # via tablib
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8
-multidict==4.7.6          # via aiohttp, yarl
-odfpy==1.4.1              # via tablib
-openpyxl==3.0.5           # via tablib
-packaging==20.4           # via ansible-base, bleach, pulp-ansible
-prometheus-client==0.8.0  # via django-prometheus
-psycopg2==2.8.6           # via pulpcore
-pulp-ansible==0.5.5       # via galaxy-ng (setup.py)
-pulp-container==2.1.0     # via -r requirements/requirements.standalone.in
-pulpcore==3.7.1           # via galaxy-ng (setup.py), pulp-ansible, pulp-container
-pycares==3.1.1            # via aiodns
-pycodestyle==2.6.0        # via flake8
-pycparser==2.20           # via cffi
-pycryptodomex==3.9.8      # via pyjwkest
-pyflakes==2.2.0           # via flake8
-pygments==2.7.1           # via rich
-pygtrie==2.3.3            # via pulpcore
-pyjwkest==1.4.2           # via pulp-container
-pyjwt[crypto]==1.7.1      # via pulp-container
-pyparsing==2.4.7          # via packaging
-pyrsistent==0.17.3        # via jsonschema
-python-gnupg==0.4.6       # via pulpcore
-pytz==2020.1              # via django
-pyyaml==5.3.1             # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
-redis==3.5.3              # via pulpcore, rq
-requests==2.24.0          # via galaxy-importer, pyjwkest
-requirements-parser==0.2.0  # via ansible-builder
-rich==7.1.0               # via ansible-lint
-rq==1.5.2                 # via pulpcore
-ruamel.yaml.clib==0.2.2   # via ruamel.yaml
-ruamel.yaml==0.16.12      # via ansible-lint
-semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via bleach, cryptography, jsonschema, packaging, pyjwkest, url-normalize
-sqlparse==0.3.1           # via django
-tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.3  # via aiohttp, ansible-lint, rich, yarl
-typing==3.7.4.3           # via aiodns
-uritemplate==3.0.1        # via drf-spectacular
-url-normalize==1.4.2      # via pulp-container
-urllib3==1.25.10          # via requests
-urlman==1.3.0             # via django-lifecycle
-webencodings==0.5.1       # via bleach
-whitenoise==5.2.0         # via pulpcore
-xlrd==1.2.0               # via tablib
-xlwt==1.3.0               # via tablib
-yarl==1.6.0               # via aiohttp
-zipp==3.2.0               # via importlib-metadata
+aiodns==2.0.0
+    # via pulpcore
+aiofiles==0.5.0
+    # via pulpcore
+aiohttp==3.6.2
+    # via pulpcore
+ansible-base==2.10.1
+    # via ansible
+ansible-builder==0.2.2
+    # via galaxy-importer
+ansible-lint==4.3.5
+    # via galaxy-importer
+ansible==2.10.0
+    # via ansible-lint, galaxy-importer
+async-timeout==3.0.1
+    # via aiohttp
+attrs==20.2.0
+    # via aiohttp, galaxy-importer, jsonschema
+backoff==1.10.0
+    # via pulpcore
+bleach-whitelist==0.0.11
+    # via galaxy-importer
+bleach==3.2.1
+    # via galaxy-importer
+certifi==2020.6.20
+    # via requests
+cffi==1.14.3
+    # via cryptography, pycares
+chardet==3.0.4
+    # via aiohttp, requests
+click==7.1.2
+    # via rq
+colorama==0.4.3
+    # via rich
+commonmark==0.9.1
+    # via rich
+cryptography==3.1.1
+    # via ansible-base, pyjwt
+dataclasses==0.7
+    # via rich
+defusedxml==0.6.0
+    # via odfpy
+diff-match-patch==20200713
+    # via django-import-export
+django-cleanup==5.1.0
+    # via pulpcore
+django-currentuser==0.5.1
+    # via pulpcore
+django-filter==2.3.0
+    # via pulpcore
+django-guardian==2.3.0
+    # via pulpcore
+django-import-export==2.3.0
+    # via pulpcore
+django-lifecycle==0.7.7
+    # via pulpcore
+django-prometheus==2.1.0
+    # via galaxy-ng (setup.py)
+django==2.2.16
+    # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+djangorestframework-queryfields==1.0.0
+    # via pulpcore
+djangorestframework==3.11.2
+    # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.7.0
+    # via pulpcore
+drf-nested-routers==0.91
+    # via pulpcore
+drf-spectacular==0.9.13
+    # via galaxy-ng (setup.py), pulpcore
+dynaconf==3.1.1
+    # via pulpcore
+ecdsa==0.13.3
+    # via pulp-container
+et-xmlfile==1.0.1
+    # via openpyxl
+flake8==3.8.3
+    # via galaxy-importer
+future==0.18.2
+    # via pyjwkest
+galaxy-importer==0.2.14
+    # via galaxy-ng (setup.py), pulp-ansible
+gunicorn==20.0.4
+    # via pulpcore
+idna-ssl==1.1.0
+    # via aiohttp
+idna==2.10
+    # via idna-ssl, requests, yarl
+importlib-metadata==2.0.0
+    # via flake8, jsonschema, markdown
+inflection==0.5.1
+    # via drf-spectacular
+jdcal==1.4.1
+    # via openpyxl
+jinja2==2.11.2
+    # via ansible-base, pulpcore
+jsonschema==3.2.0
+    # via drf-spectacular, pulp-ansible
+markdown==3.2.2
+    # via galaxy-importer
+markuppy==1.14
+    # via tablib
+markupsafe==1.1.1
+    # via jinja2
+mccabe==0.6.1
+    # via flake8
+multidict==4.7.6
+    # via aiohttp, yarl
+odfpy==1.4.1
+    # via tablib
+openpyxl==3.0.5
+    # via tablib
+packaging==20.4
+    # via ansible-base, bleach, pulp-ansible
+prometheus-client==0.8.0
+    # via django-prometheus
+psycopg2==2.8.6
+    # via pulpcore
+pulp-ansible==0.5.5
+    # via galaxy-ng (setup.py)
+pulp-container==2.1.0
+    # via -r requirements/requirements.standalone.in
+pulpcore==3.7.1
+    # via galaxy-ng (setup.py), pulp-ansible, pulp-container
+pycares==3.1.1
+    # via aiodns
+pycodestyle==2.6.0
+    # via flake8
+pycparser==2.20
+    # via cffi
+pycryptodomex==3.9.8
+    # via pyjwkest
+pyflakes==2.2.0
+    # via flake8
+pygments==2.7.1
+    # via rich
+pygtrie==2.3.3
+    # via pulpcore
+pyjwkest==1.4.2
+    # via pulp-container
+pyjwt[crypto]==1.7.1
+    # via pulp-container
+pyparsing==2.4.7
+    # via packaging
+pyrsistent==0.17.3
+    # via jsonschema
+python-gnupg==0.4.6
+    # via pulpcore
+pytz==2020.1
+    # via django
+pyyaml==5.3.1
+    # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+redis==3.5.3
+    # via pulpcore, rq
+requests==2.24.0
+    # via galaxy-importer, pyjwkest
+requirements-parser==0.2.0
+    # via ansible-builder
+rich==7.1.0
+    # via ansible-lint
+rq==1.5.2
+    # via pulpcore
+ruamel.yaml.clib==0.2.2
+    # via ruamel.yaml
+ruamel.yaml==0.16.12
+    # via ansible-lint
+semantic-version==2.8.5
+    # via galaxy-importer, pulp-ansible
+six==1.15.0
+    # via bleach, cryptography, jsonschema, packaging, pyjwkest, url-normalize
+sqlparse==0.3.1
+    # via django
+tablib[html,ods,xls,xlsx,yaml]==2.0.0
+    # via django-import-export
+typing-extensions==3.7.4.3
+    # via aiohttp, ansible-lint, rich, yarl
+typing==3.7.4.3
+    # via aiodns
+uritemplate==3.0.1
+    # via drf-spectacular
+url-normalize==1.4.2
+    # via pulp-container
+urllib3==1.25.10
+    # via requests
+urlman==1.3.0
+    # via django-lifecycle
+webencodings==0.5.1
+    # via bleach
+whitenoise==5.2.0
+    # via pulpcore
+xlrd==1.2.0
+    # via tablib
+xlwt==1.3.0
+    # via tablib
+yarl==1.6.0
+    # via aiohttp
+zipp==3.2.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -17,11 +17,16 @@ ansible-builder==0.2.2
 ansible-lint==4.3.5
     # via galaxy-importer
 ansible==2.10.0
-    # via ansible-lint, galaxy-importer
+    # via
+    #   ansible-lint
+    #   galaxy-importer
 async-timeout==3.0.1
     # via aiohttp
 attrs==20.2.0
-    # via aiohttp, galaxy-importer, jsonschema
+    # via
+    #   aiohttp
+    #   galaxy-importer
+    #   jsonschema
 backoff==1.10.0
     # via pulpcore
 bleach-whitelist==0.0.11
@@ -31,9 +36,13 @@ bleach==3.2.1
 certifi==2020.6.20
     # via requests
 cffi==1.14.3
-    # via cryptography, pycares
+    # via
+    #   cryptography
+    #   pycares
 chardet==3.0.4
-    # via aiohttp, requests
+    # via
+    #   aiohttp
+    #   requests
 click==7.1.2
     # via rq
 colorama==0.4.3
@@ -41,9 +50,9 @@ colorama==0.4.3
 commonmark==0.9.1
     # via rich
 cryptography==3.1.1
-    # via ansible-base, pyjwt
-dataclasses==0.7
-    # via rich
+    # via
+    #   ansible-base
+    #   pyjwt
 defusedxml==0.6.0
     # via odfpy
 diff-match-patch==20200713
@@ -63,17 +72,32 @@ django-lifecycle==0.7.7
 django-prometheus==2.1.0
     # via galaxy-ng (setup.py)
 django==2.2.16
-    # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+    # via
+    #   django-currentuser
+    #   django-filter
+    #   django-guardian
+    #   django-import-export
+    #   django-lifecycle
+    #   djangorestframework
+    #   drf-nested-routers
+    #   drf-spectacular
+    #   galaxy-ng (setup.py)
+    #   pulpcore
 djangorestframework-queryfields==1.0.0
     # via pulpcore
 djangorestframework==3.11.2
-    # via drf-nested-routers, drf-spectacular, pulpcore
+    # via
+    #   drf-nested-routers
+    #   drf-spectacular
+    #   pulpcore
 drf-access-policy==0.7.0
     # via pulpcore
 drf-nested-routers==0.91
     # via pulpcore
 drf-spectacular==0.9.13
-    # via galaxy-ng (setup.py), pulpcore
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulpcore
 dynaconf==3.1.1
     # via pulpcore
 ecdsa==0.13.3
@@ -85,23 +109,27 @@ flake8==3.8.3
 future==0.18.2
     # via pyjwkest
 galaxy-importer==0.2.14
-    # via galaxy-ng (setup.py), pulp-ansible
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulp-ansible
 gunicorn==20.0.4
     # via pulpcore
-idna-ssl==1.1.0
-    # via aiohttp
 idna==2.10
-    # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0
-    # via flake8, jsonschema, markdown
+    # via
+    #   requests
+    #   yarl
 inflection==0.5.1
     # via drf-spectacular
 jdcal==1.4.1
     # via openpyxl
 jinja2==2.11.2
-    # via ansible-base, pulpcore
+    # via
+    #   ansible-base
+    #   pulpcore
 jsonschema==3.2.0
-    # via drf-spectacular, pulp-ansible
+    # via
+    #   drf-spectacular
+    #   pulp-ansible
 markdown==3.2.2
     # via galaxy-importer
 markuppy==1.14
@@ -111,13 +139,18 @@ markupsafe==1.1.1
 mccabe==0.6.1
     # via flake8
 multidict==4.7.6
-    # via aiohttp, yarl
+    # via
+    #   aiohttp
+    #   yarl
 odfpy==1.4.1
     # via tablib
 openpyxl==3.0.5
     # via tablib
 packaging==20.4
-    # via ansible-base, bleach, pulp-ansible
+    # via
+    #   ansible-base
+    #   bleach
+    #   pulp-ansible
 prometheus-client==0.8.0
     # via django-prometheus
 psycopg2==2.8.6
@@ -127,7 +160,10 @@ pulp-ansible==0.5.5
 pulp-container==2.1.0
     # via -r requirements/requirements.standalone.in
 pulpcore==3.7.1
-    # via galaxy-ng (setup.py), pulp-ansible, pulp-container
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulp-ansible
+    #   pulp-container
 pycares==3.1.1
     # via aiodns
 pycodestyle==2.6.0
@@ -155,33 +191,49 @@ python-gnupg==0.4.6
 pytz==2020.1
     # via django
 pyyaml==5.3.1
-    # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+    # via
+    #   ansible-base
+    #   ansible-builder
+    #   ansible-lint
+    #   drf-spectacular
+    #   galaxy-importer
+    #   pulp-ansible
+    #   pulpcore
+    #   tablib
 redis==3.5.3
-    # via pulpcore, rq
+    # via
+    #   pulpcore
+    #   rq
 requests==2.24.0
-    # via galaxy-importer, pyjwkest
+    # via
+    #   galaxy-importer
+    #   pyjwkest
 requirements-parser==0.2.0
     # via ansible-builder
 rich==7.1.0
     # via ansible-lint
 rq==1.5.2
     # via pulpcore
-ruamel.yaml.clib==0.2.2
-    # via ruamel.yaml
 ruamel.yaml==0.16.12
     # via ansible-lint
 semantic-version==2.8.5
-    # via galaxy-importer, pulp-ansible
+    # via
+    #   galaxy-importer
+    #   pulp-ansible
 six==1.15.0
-    # via bleach, cryptography, jsonschema, packaging, pyjwkest, url-normalize
+    # via
+    #   bleach
+    #   cryptography
+    #   jsonschema
+    #   packaging
+    #   pyjwkest
+    #   url-normalize
 sqlparse==0.3.1
     # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0
     # via django-import-export
 typing-extensions==3.7.4.3
-    # via aiohttp, ansible-lint, rich, yarl
-typing==3.7.4.3
-    # via aiodns
+    # via rich
 uritemplate==3.0.1
     # via drf-spectacular
 url-normalize==1.4.2
@@ -200,8 +252,6 @@ xlwt==1.3.0
     # via tablib
 yarl==1.6.0
     # via aiohttp
-zipp==3.2.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,11 +15,16 @@ ansible-builder==0.2.2
 ansible-lint==4.2.0
     # via galaxy-importer
 ansible==2.9.9
-    # via ansible-lint, galaxy-importer
+    # via
+    #   ansible-lint
+    #   galaxy-importer
 async-timeout==3.0.1
     # via aiohttp
 attrs==19.3.0
-    # via aiohttp, galaxy-importer, jsonschema
+    # via
+    #   aiohttp
+    #   galaxy-importer
+    #   jsonschema
 backoff==1.10.0
     # via pulpcore
 bleach-whitelist==0.0.10
@@ -29,9 +34,13 @@ bleach==3.1.5
 certifi==2020.4.5.1
     # via requests
 cffi==1.14.0
-    # via cryptography, pycares
+    # via
+    #   cryptography
+    #   pycares
 chardet==3.0.4
-    # via aiohttp, requests
+    # via
+    #   aiohttp
+    #   requests
 click==7.1.2
     # via rq
 cryptography==2.9.2
@@ -53,17 +62,32 @@ django-lifecycle==0.8.0
 django-prometheus==2.0.0
     # via galaxy-ng (setup.py)
 django==2.2.16
-    # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+    # via
+    #   django-currentuser
+    #   django-filter
+    #   django-guardian
+    #   django-import-export
+    #   django-lifecycle
+    #   djangorestframework
+    #   drf-nested-routers
+    #   drf-spectacular
+    #   galaxy-ng (setup.py)
+    #   pulpcore
 djangorestframework-queryfields==1.0.0
     # via pulpcore
 djangorestframework==3.12.2
-    # via drf-nested-routers, drf-spectacular, pulpcore
+    # via
+    #   drf-nested-routers
+    #   drf-spectacular
+    #   pulpcore
 drf-access-policy==0.8.1
     # via pulpcore
 drf-nested-routers==0.92.1
     # via pulpcore
 drf-spectacular==0.9.14
-    # via galaxy-ng (setup.py), pulpcore
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulpcore
 dynaconf==3.1.2
     # via pulpcore
 et-xmlfile==1.0.1
@@ -71,21 +95,27 @@ et-xmlfile==1.0.1
 flake8==3.8.2
     # via galaxy-importer
 galaxy-importer==0.2.14
-    # via galaxy-ng (setup.py), pulp-ansible
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulp-ansible
 gunicorn==20.0.4
     # via pulpcore
 idna==2.9
-    # via requests, yarl
-importlib-metadata==1.6.0
-    # via flake8, jsonschema, markdown
+    # via
+    #   requests
+    #   yarl
 inflection==0.4.0
     # via drf-spectacular
 jdcal==1.4.1
     # via openpyxl
 jinja2==2.11.2
-    # via ansible, pulpcore
+    # via
+    #   ansible
+    #   pulpcore
 jsonschema==3.2.0
-    # via drf-spectacular, pulp-ansible
+    # via
+    #   drf-spectacular
+    #   pulp-ansible
 markdown==3.2.2
     # via galaxy-importer
 markuppy==1.14
@@ -95,21 +125,27 @@ markupsafe==1.1.1
 mccabe==0.6.1
     # via flake8
 multidict==4.7.6
-    # via aiohttp, yarl
+    # via
+    #   aiohttp
+    #   yarl
 odfpy==1.4.1
     # via tablib
 openpyxl==3.0.3
     # via tablib
 packaging==20.4
-    # via bleach, pulp-ansible
+    # via
+    #   bleach
+    #   pulp-ansible
 prometheus-client==0.8.0
     # via django-prometheus
 psycopg2==2.8.5
     # via pulpcore
-pulp-ansible==0.5.0
+pulp-ansible==0.5.5
     # via galaxy-ng (setup.py)
 pulpcore==3.8.1
-    # via galaxy-ng (setup.py), pulp-ansible
+    # via
+    #   galaxy-ng (setup.py)
+    #   pulp-ansible
 pycares==3.1.1
     # via aiodns
 pycodestyle==2.6.0
@@ -129,23 +165,39 @@ python-gnupg==0.4.6
 pytz==2020.1
     # via django
 pyyaml==5.3.1
-    # via ansible, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+    # via
+    #   ansible
+    #   ansible-builder
+    #   ansible-lint
+    #   drf-spectacular
+    #   galaxy-importer
+    #   pulp-ansible
+    #   pulpcore
+    #   tablib
 redis==3.5.3
-    # via pulpcore, rq
+    # via
+    #   pulpcore
+    #   rq
 requests==2.23.0
     # via galaxy-importer
 requirements-parser==0.2.0
     # via ansible-builder
 rq==1.4.2
     # via pulpcore
-ruamel.yaml.clib==0.2.0
-    # via ruamel.yaml
 ruamel.yaml==0.16.10
     # via ansible-lint
 semantic-version==2.8.5
-    # via galaxy-importer, pulp-ansible
+    # via
+    #   galaxy-importer
+    #   pulp-ansible
 six==1.15.0
-    # via ansible-lint, bleach, cryptography, jsonschema, packaging, pyrsistent
+    # via
+    #   ansible-lint
+    #   bleach
+    #   cryptography
+    #   jsonschema
+    #   packaging
+    #   pyrsistent
 sqlparse==0.3.1
     # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0
@@ -166,8 +218,6 @@ xlwt==1.3.0
     # via tablib
 yarl==1.4.2
     # via aiohttp
-zipp==3.1.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,88 +4,170 @@
 #
 #    pip-compile --output-file=requirements/requirements.txt setup.py
 #
-aiodns==2.0.0             # via pulpcore
-aiofiles==0.5.0           # via pulpcore
-aiohttp==3.6.2            # via pulpcore
-ansible-builder==0.2.2    # via galaxy-importer
-ansible-lint==4.2.0       # via galaxy-importer
-ansible==2.9.9            # via ansible-lint, galaxy-importer
-async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via aiohttp, galaxy-importer, jsonschema
-backoff==1.10.0           # via pulpcore
-bleach-whitelist==0.0.10  # via galaxy-importer
-bleach==3.1.5             # via galaxy-importer
-certifi==2020.4.5.1       # via requests
-cffi==1.14.0              # via cryptography, pycares
-chardet==3.0.4            # via aiohttp, requests
-click==7.1.2              # via rq
-cryptography==2.9.2       # via ansible
-defusedxml==0.6.0         # via odfpy
-diff-match-patch==20181111  # via django-import-export
-django-currentuser==0.5.1  # via pulpcore
-django-filter==2.4.0      # via pulpcore
-django-guardian==2.3.0    # via pulpcore
-django-import-export==2.4.0  # via pulpcore
-django-lifecycle==0.8.0   # via pulpcore
-django-prometheus==2.0.0  # via galaxy-ng (setup.py)
-django==2.2.16            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
-djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.12.2  # via drf-nested-routers, drf-spectacular, pulpcore
-drf-access-policy==0.8.1  # via pulpcore
-drf-nested-routers==0.92.1  # via pulpcore
-drf-spectacular==0.9.14   # via galaxy-ng (setup.py), pulpcore
-dynaconf==3.1.2           # via pulpcore
-et-xmlfile==1.0.1         # via openpyxl
-flake8==3.8.2             # via galaxy-importer
-galaxy-importer==0.2.14   # via galaxy-ng (setup.py), pulp-ansible
-gunicorn==20.0.4          # via pulpcore
-idna==2.9                 # via requests, yarl
-importlib-metadata==1.6.0  # via flake8, jsonschema, markdown
-inflection==0.4.0         # via drf-spectacular
-jdcal==1.4.1              # via openpyxl
-jinja2==2.11.2            # via ansible, pulpcore
-jsonschema==3.2.0         # via drf-spectacular, pulp-ansible
-markdown==3.2.2           # via galaxy-importer
-markuppy==1.14            # via tablib
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8
-multidict==4.7.6          # via aiohttp, yarl
-odfpy==1.4.1              # via tablib
-openpyxl==3.0.3           # via tablib
-packaging==20.4           # via bleach, pulp-ansible
-prometheus-client==0.8.0  # via django-prometheus
-psycopg2==2.8.5           # via pulpcore
-pulp-ansible==0.5.0       # via galaxy-ng (setup.py)
-pulpcore==3.8.1           # via galaxy-ng (setup.py), pulp-ansible
-pycares==3.1.1            # via aiodns
-pycodestyle==2.6.0        # via flake8
-pycparser==2.20           # via cffi
-pyflakes==2.2.0           # via flake8
-pygtrie==2.3.3            # via pulpcore
-pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via jsonschema
-python-gnupg==0.4.6       # via pulpcore
-pytz==2020.1              # via django
-pyyaml==5.3.1             # via ansible, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
-redis==3.5.3              # via pulpcore, rq
-requests==2.23.0          # via galaxy-importer
-requirements-parser==0.2.0  # via ansible-builder
-rq==1.4.2                 # via pulpcore
-ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml==0.16.10      # via ansible-lint
-semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via ansible-lint, bleach, cryptography, jsonschema, packaging, pyrsistent
-sqlparse==0.3.1           # via django
-tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-uritemplate==3.0.1        # via drf-spectacular
-urllib3==1.25.9           # via requests
-urlman==1.3.0             # via django-lifecycle
-webencodings==0.5.1       # via bleach
-whitenoise==5.1.0         # via pulpcore
-xlrd==1.2.0               # via tablib
-xlwt==1.3.0               # via tablib
-yarl==1.4.2               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
+aiodns==2.0.0
+    # via pulpcore
+aiofiles==0.5.0
+    # via pulpcore
+aiohttp==3.6.2
+    # via pulpcore
+ansible-builder==0.2.2
+    # via galaxy-importer
+ansible-lint==4.2.0
+    # via galaxy-importer
+ansible==2.9.9
+    # via ansible-lint, galaxy-importer
+async-timeout==3.0.1
+    # via aiohttp
+attrs==19.3.0
+    # via aiohttp, galaxy-importer, jsonschema
+backoff==1.10.0
+    # via pulpcore
+bleach-whitelist==0.0.10
+    # via galaxy-importer
+bleach==3.1.5
+    # via galaxy-importer
+certifi==2020.4.5.1
+    # via requests
+cffi==1.14.0
+    # via cryptography, pycares
+chardet==3.0.4
+    # via aiohttp, requests
+click==7.1.2
+    # via rq
+cryptography==2.9.2
+    # via ansible
+defusedxml==0.6.0
+    # via odfpy
+diff-match-patch==20181111
+    # via django-import-export
+django-currentuser==0.5.1
+    # via pulpcore
+django-filter==2.4.0
+    # via pulpcore
+django-guardian==2.3.0
+    # via pulpcore
+django-import-export==2.4.0
+    # via pulpcore
+django-lifecycle==0.8.0
+    # via pulpcore
+django-prometheus==2.0.0
+    # via galaxy-ng (setup.py)
+django==2.2.16
+    # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+djangorestframework-queryfields==1.0.0
+    # via pulpcore
+djangorestframework==3.12.2
+    # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.8.1
+    # via pulpcore
+drf-nested-routers==0.92.1
+    # via pulpcore
+drf-spectacular==0.9.14
+    # via galaxy-ng (setup.py), pulpcore
+dynaconf==3.1.2
+    # via pulpcore
+et-xmlfile==1.0.1
+    # via openpyxl
+flake8==3.8.2
+    # via galaxy-importer
+galaxy-importer==0.2.14
+    # via galaxy-ng (setup.py), pulp-ansible
+gunicorn==20.0.4
+    # via pulpcore
+idna==2.9
+    # via requests, yarl
+importlib-metadata==1.6.0
+    # via flake8, jsonschema, markdown
+inflection==0.4.0
+    # via drf-spectacular
+jdcal==1.4.1
+    # via openpyxl
+jinja2==2.11.2
+    # via ansible, pulpcore
+jsonschema==3.2.0
+    # via drf-spectacular, pulp-ansible
+markdown==3.2.2
+    # via galaxy-importer
+markuppy==1.14
+    # via tablib
+markupsafe==1.1.1
+    # via jinja2
+mccabe==0.6.1
+    # via flake8
+multidict==4.7.6
+    # via aiohttp, yarl
+odfpy==1.4.1
+    # via tablib
+openpyxl==3.0.3
+    # via tablib
+packaging==20.4
+    # via bleach, pulp-ansible
+prometheus-client==0.8.0
+    # via django-prometheus
+psycopg2==2.8.5
+    # via pulpcore
+pulp-ansible==0.5.0
+    # via galaxy-ng (setup.py)
+pulpcore==3.8.1
+    # via galaxy-ng (setup.py), pulp-ansible
+pycares==3.1.1
+    # via aiodns
+pycodestyle==2.6.0
+    # via flake8
+pycparser==2.20
+    # via cffi
+pyflakes==2.2.0
+    # via flake8
+pygtrie==2.3.3
+    # via pulpcore
+pyparsing==2.4.7
+    # via packaging
+pyrsistent==0.16.0
+    # via jsonschema
+python-gnupg==0.4.6
+    # via pulpcore
+pytz==2020.1
+    # via django
+pyyaml==5.3.1
+    # via ansible, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+redis==3.5.3
+    # via pulpcore, rq
+requests==2.23.0
+    # via galaxy-importer
+requirements-parser==0.2.0
+    # via ansible-builder
+rq==1.4.2
+    # via pulpcore
+ruamel.yaml.clib==0.2.0
+    # via ruamel.yaml
+ruamel.yaml==0.16.10
+    # via ansible-lint
+semantic-version==2.8.5
+    # via galaxy-importer, pulp-ansible
+six==1.15.0
+    # via ansible-lint, bleach, cryptography, jsonschema, packaging, pyrsistent
+sqlparse==0.3.1
+    # via django
+tablib[html,ods,xls,xlsx,yaml]==2.0.0
+    # via django-import-export
+uritemplate==3.0.1
+    # via drf-spectacular
+urllib3==1.25.9
+    # via requests
+urlman==1.3.0
+    # via django-lifecycle
+webencodings==0.5.1
+    # via bleach
+whitenoise==5.1.0
+    # via pulpcore
+xlrd==1.2.0
+    # via tablib
+xlwt==1.3.0
+    # via tablib
+yarl==1.4.2
+    # via aiohttp
+zipp==3.1.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Update `requirements/` requirement files to use new pip-tools format while keeping requirement changes to a minimum