### PR TITLE
Update stable-4.2 dependencies

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -14,16 +14,15 @@ ansible==2.10.0           # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
 attrs==20.2.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
-bleach-whitelist==0.0.11  # via galaxy-importer
-bleach==3.2.1             # via galaxy-importer
+bleach-allowlist==1.0.3   # via galaxy-importer
+bleach==3.3.0             # via galaxy-importer
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
 colorama==0.4.3           # via rich
 commonmark==0.9.1         # via rich
-cryptography==3.1.1       # via ansible-base
-dataclasses==0.7          # via rich
+cryptography==3.4.3       # via ansible-base
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
 django-cleanup==5.1.0     # via pulpcore
@@ -42,11 +41,9 @@ drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
 dynaconf==3.1.1           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.14   # via galaxy-ng (setup.py), pulp-ansible
+galaxy-importer==0.2.15   # via galaxy-ng (setup.py), pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via flake8, jsonschema, markdown
+idna==2.10                # via requests, yarl
 inflection==0.5.1         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via ansible-base, pulpcore
@@ -67,7 +64,7 @@ pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
 pyflakes==2.2.0           # via flake8
-pygments==2.7.1           # via rich
+pygments==2.7.4           # via rich
 pygtrie==2.3.3            # via pulpcore
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
@@ -79,14 +76,12 @@ requests==2.24.0          # via galaxy-importer
 requirements-parser==0.2.0  # via ansible-builder
 rich==7.1.0               # via ansible-lint
 rq==1.5.2                 # via pulpcore
-ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via ansible-lint
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via bleach, cryptography, jsonschema, packaging
+six==1.15.0               # via bleach, jsonschema, packaging
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.3  # via aiohttp, ansible-lint, rich, yarl
-typing==3.7.4.3           # via aiodns
+typing-extensions==3.7.4.3  # via rich
 uritemplate==3.0.1        # via drf-spectacular
 urllib3==1.25.10          # via requests
 urlman==1.3.0             # via django-lifecycle
@@ -95,7 +90,6 @@ whitenoise==5.2.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 yarl==1.6.0               # via aiohttp
-zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -14,8 +14,8 @@ ansible==2.10.0           # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
 attrs==20.2.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
-bleach-whitelist==0.0.11  # via galaxy-importer
-bleach==3.2.1             # via galaxy-importer
+bleach-allowlist==1.0.3   # via galaxy-importer
+bleach==3.3.0             # via galaxy-importer
 boto3==1.15.9             # via -r requirements/requirements.insights.in, django-storages, watchtower
 botocore==1.18.9          # via boto3, s3transfer
 certifi==2020.6.20        # via requests
@@ -24,8 +24,7 @@ chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
 colorama==0.4.3           # via rich
 commonmark==0.9.1         # via rich
-cryptography==3.1.1       # via ansible-base
-dataclasses==0.7          # via rich
+cryptography==3.4.3       # via ansible-base
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
 django-cleanup==5.1.0     # via pulpcore
@@ -45,11 +44,9 @@ drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
 dynaconf==3.1.1           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
-galaxy-importer==0.2.14   # via galaxy-ng (setup.py), pulp-ansible
+galaxy-importer==0.2.15   # via galaxy-ng (setup.py), pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via flake8, jsonschema, markdown
+idna==2.10                # via requests, yarl
 inflection==0.5.1         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via ansible-base, pulpcore
@@ -72,7 +69,7 @@ pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
 pyflakes==2.2.0           # via flake8
-pygments==2.7.1           # via rich
+pygments==2.7.4           # via rich
 pygtrie==2.3.3            # via pulpcore
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
@@ -85,15 +82,13 @@ requests==2.24.0          # via galaxy-importer
 requirements-parser==0.2.0  # via ansible-builder
 rich==7.1.0               # via ansible-lint
 rq==1.5.2                 # via pulpcore
-ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via ansible-lint
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via bleach, cryptography, jsonschema, packaging, python-dateutil
+six==1.15.0               # via bleach, jsonschema, packaging, python-dateutil
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.3  # via aiohttp, ansible-lint, rich, yarl
-typing==3.7.4.3           # via aiodns
+typing-extensions==3.7.4.3  # via rich
 uritemplate==3.0.1        # via drf-spectacular
 urllib3==1.25.10          # via botocore, requests
 urlman==1.3.0             # via django-lifecycle
@@ -103,7 +98,6 @@ whitenoise==5.2.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 yarl==1.6.0               # via aiohttp
-zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -14,16 +14,15 @@ ansible==2.10.0           # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
 attrs==20.2.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
-bleach-whitelist==0.0.11  # via galaxy-importer
-bleach==3.2.1             # via galaxy-importer
+bleach-allowlist==1.0.3   # via galaxy-importer
+bleach==3.3.0             # via galaxy-importer
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
 colorama==0.4.3           # via rich
 commonmark==0.9.1         # via rich
-cryptography==3.1.1       # via ansible-base, pyjwt
-dataclasses==0.7          # via rich
+cryptography==3.4.3       # via ansible-base, pyjwt
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20200713  # via django-import-export
 django-cleanup==5.1.0     # via pulpcore
@@ -44,11 +43,9 @@ ecdsa==0.13.3             # via pulp-container
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.3             # via galaxy-importer
 future==0.18.2            # via pyjwkest
-galaxy-importer==0.2.14   # via galaxy-ng (setup.py), pulp-ansible
+galaxy-importer==0.2.15   # via galaxy-ng (setup.py), pulp-ansible
 gunicorn==20.0.4          # via pulpcore
-idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via flake8, jsonschema, markdown
+idna==2.10                # via requests, yarl
 inflection==0.5.1         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via ansible-base, pulpcore
@@ -71,7 +68,7 @@ pycodestyle==2.6.0        # via flake8
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pyflakes==2.2.0           # via flake8
-pygments==2.7.1           # via rich
+pygments==2.7.4           # via rich
 pygtrie==2.3.3            # via pulpcore
 pyjwkest==1.4.2           # via pulp-container
 pyjwt[crypto]==1.7.1      # via pulp-container
@@ -85,14 +82,12 @@ requests==2.24.0          # via galaxy-importer, pyjwkest
 requirements-parser==0.2.0  # via ansible-builder
 rich==7.1.0               # via ansible-lint
 rq==1.5.2                 # via pulpcore
-ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via ansible-lint
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via bleach, cryptography, jsonschema, packaging, pyjwkest, url-normalize
+six==1.15.0               # via bleach, jsonschema, packaging, pyjwkest, url-normalize
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
-typing-extensions==3.7.4.3  # via aiohttp, ansible-lint, rich, yarl
-typing==3.7.4.3           # via aiodns
+typing-extensions==3.7.4.3  # via rich
 uritemplate==3.0.1        # via drf-spectacular
 url-normalize==1.4.2      # via pulp-container
 urllib3==1.25.10          # via requests
@@ -102,7 +97,6 @@ whitenoise==5.2.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 yarl==1.6.0               # via aiohttp
-zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -13,13 +13,13 @@ ansible==2.9.9            # via ansible-lint, galaxy-importer
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
-bleach-whitelist==0.0.10  # via galaxy-importer
-bleach==3.1.5             # via galaxy-importer
+bleach-allowlist==1.0.3   # via galaxy-importer
+bleach==3.3.0             # via galaxy-importer
 certifi==2020.4.5.1       # via requests
 cffi==1.14.0              # via cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via rq
-cryptography==2.9.2       # via ansible
+cryptography==3.4.3       # via ansible
 defusedxml==0.6.0         # via odfpy
 diff-match-patch==20181111  # via django-import-export
 django-currentuser==0.5.1  # via pulpcore
@@ -28,7 +28,7 @@ django-guardian==2.3.0    # via pulpcore
 django-import-export==2.4.0  # via pulpcore
 django-lifecycle==0.8.0   # via pulpcore
 django-prometheus==2.0.0  # via galaxy-ng (setup.py)
-django==2.2.16            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django==2.2.18            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
 djangorestframework==3.12.2  # via drf-nested-routers, drf-spectacular, pulpcore
 drf-access-policy==0.8.1  # via pulpcore
@@ -37,10 +37,9 @@ drf-spectacular==0.9.14   # via galaxy-ng (setup.py), pulpcore
 dynaconf==3.1.2           # via pulpcore
 et-xmlfile==1.0.1         # via openpyxl
 flake8==3.8.2             # via galaxy-importer
-galaxy-importer==0.2.14   # via galaxy-ng (setup.py), pulp-ansible
+galaxy-importer==0.2.15   # via galaxy-ng (setup.py), pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna==2.9                 # via requests, yarl
-importlib-metadata==1.6.0  # via flake8, jsonschema, markdown
 inflection==0.4.0         # via drf-spectacular
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via ansible, pulpcore
@@ -55,7 +54,7 @@ openpyxl==3.0.3           # via tablib
 packaging==20.4           # via bleach, pulp-ansible
 prometheus-client==0.8.0  # via django-prometheus
 psycopg2==2.8.5           # via pulpcore
-pulp-ansible==0.5.0       # via galaxy-ng (setup.py)
+pulp-ansible==0.5.6       # via galaxy-ng (setup.py)
 pulpcore==3.8.1           # via galaxy-ng (setup.py), pulp-ansible
 pycares==3.1.1            # via aiodns
 pycodestyle==2.6.0        # via flake8
@@ -71,10 +70,9 @@ redis==3.5.3              # via pulpcore, rq
 requests==2.23.0          # via galaxy-importer
 requirements-parser==0.2.0  # via ansible-builder
 rq==1.4.2                 # via pulpcore
-ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via ansible-lint
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.15.0               # via ansible-lint, bleach, cryptography, jsonschema, packaging, pyrsistent
+six==1.15.0               # via ansible-lint, bleach, jsonschema, packaging, pyrsistent
 sqlparse==0.3.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==2.0.0  # via django-import-export
 uritemplate==3.0.1        # via drf-spectacular
@@ -85,7 +83,6 @@ whitenoise==5.1.0         # via pulpcore
 xlrd==1.2.0               # via tablib
 xlwt==1.3.0               # via tablib
 yarl==1.4.2               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class BuildPyCommand(_BuildPyCommand):
 
 requirements = [
     "Django~=2.2.18",
-    "galaxy-importer==0.2.14",
+    "galaxy-importer==0.2.15",
     "pulpcore>=3.7,<3.9",
     "pulp-ansible==0.5.6",
     "django-prometheus>=2.0.0",


### PR DESCRIPTION
Run pip-compile --upgrade for packages: `cryptography`, `pygments`, and
`galaxy-importer` (which has `bleach` dependency)

Used `pip-tools==5.4.0` to generate deps to keep same format for stable-4.2 branch.

Related:
* pygments dep issue: https://bugzilla.redhat.com/show_bug.cgi?id=1922136
* cryptography dep issue: https://bugzilla.redhat.com/show_bug.cgi?id=1926226 AAH-331
* bleach issue https://bugzilla.redhat.com/show_bug.cgi?id=1827491 AAH-327 AAH-328