### PR TITLE
Update to pulp_container 2.3.1

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -12,11 +12,11 @@ aiohttp==3.7.3
     # via pulpcore
 ansible-base==2.10.5
     # via ansible
-ansible-builder==0.5.1
+ansible-builder==0.6.0
     # via galaxy-importer
 ansible-lint==4.3.7
     # via galaxy-importer
-ansible==2.10.6
+ansible==2.10.7
     # via
     #   ansible-lint
     #   galaxy-importer
@@ -39,7 +39,7 @@ bleach==3.3.0
     # via galaxy-importer
 certifi==2020.12.5
     # via requests
-cffi==1.14.4
+cffi==1.14.5
     # via
     #   cryptography
     #   pycares
@@ -53,7 +53,7 @@ colorama==0.4.4
     # via rich
 commonmark==0.9.1
     # via rich
-cryptography==3.4.3
+cryptography==3.4.5
     # via ansible-base
 defusedxml==0.6.0
     # via odfpy
@@ -93,7 +93,7 @@ djangorestframework==3.12.2
     #   drf-nested-routers
     #   drf-spectacular
     #   pulpcore
-drf-access-policy==0.8.6
+drf-access-policy==0.8.7
     # via pulpcore
 drf-nested-routers==0.92.1
     # via pulpcore
@@ -168,7 +168,7 @@ pycparser==2.20
     # via cffi
 pyflakes==2.2.0
     # via flake8
-pygments==2.7.4
+pygments==2.8.0
     # via rich
 pygtrie==2.3.3
     # via pulpcore

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -12,11 +12,11 @@ aiohttp==3.7.3
     # via pulpcore
 ansible-base==2.10.5
     # via ansible
-ansible-builder==0.5.1
+ansible-builder==0.6.0
     # via galaxy-importer
 ansible-lint==4.3.7
     # via galaxy-importer
-ansible==2.10.6
+ansible==2.10.7
     # via
     #   ansible-lint
     #   galaxy-importer
@@ -37,18 +37,18 @@ bleach-allowlist==1.0.3
     # via galaxy-importer
 bleach==3.3.0
     # via galaxy-importer
-boto3==1.17.4
+boto3==1.17.7
     # via
     #   -r requirements/requirements.insights.in
     #   django-storages
     #   watchtower
-botocore==1.20.4
+botocore==1.20.7
     # via
     #   boto3
     #   s3transfer
 certifi==2020.12.5
     # via requests
-cffi==1.14.4
+cffi==1.14.5
     # via
     #   cryptography
     #   pycares
@@ -62,7 +62,7 @@ colorama==0.4.4
     # via rich
 commonmark==0.9.1
     # via rich
-cryptography==3.4.3
+cryptography==3.4.5
     # via ansible-base
 defusedxml==0.6.0
     # via odfpy
@@ -105,7 +105,7 @@ djangorestframework==3.12.2
     #   drf-nested-routers
     #   drf-spectacular
     #   pulpcore
-drf-access-policy==0.8.6
+drf-access-policy==0.8.7
     # via pulpcore
 drf-nested-routers==0.92.1
     # via pulpcore
@@ -186,7 +186,7 @@ pycparser==2.20
     # via cffi
 pyflakes==2.2.0
     # via flake8
-pygments==2.7.4
+pygments==2.8.0
     # via rich
 pygtrie==2.3.3
     # via pulpcore

--- a/requirements/requirements.standalone.in
+++ b/requirements/requirements.standalone.in
@@ -1,1 +1,1 @@
-pulp-container~=2.3.0
+pulp-container~=2.3.1

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -12,11 +12,11 @@ aiohttp==3.7.3
     # via pulpcore
 ansible-base==2.10.5
     # via ansible
-ansible-builder==0.5.1
+ansible-builder==0.6.0
     # via galaxy-importer
 ansible-lint==4.3.7
     # via galaxy-importer
-ansible==2.10.6
+ansible==2.10.7
     # via
     #   ansible-lint
     #   galaxy-importer
@@ -39,7 +39,7 @@ bleach==3.3.0
     # via galaxy-importer
 certifi==2020.12.5
     # via requests
-cffi==1.14.4
+cffi==1.14.5
     # via
     #   cryptography
     #   pycares
@@ -53,7 +53,7 @@ colorama==0.4.4
     # via rich
 commonmark==0.9.1
     # via rich
-cryptography==3.4.3
+cryptography==3.4.5
     # via
     #   ansible-base
     #   pyjwt
@@ -95,7 +95,7 @@ djangorestframework==3.12.2
     #   drf-nested-routers
     #   drf-spectacular
     #   pulpcore
-drf-access-policy==0.8.6
+drf-access-policy==0.8.7
     # via pulpcore
 drf-nested-routers==0.92.1
     # via pulpcore
@@ -162,7 +162,7 @@ psycopg2==2.8.6
     # via pulpcore
 pulp-ansible==0.7.0
     # via galaxy-ng (setup.py)
-pulp-container==2.3.0
+pulp-container==2.3.1
     # via -r requirements/requirements.standalone.in
 pulpcore==3.10.0
     # via
@@ -179,7 +179,7 @@ pycryptodomex==3.10.1
     # via pyjwkest
 pyflakes==2.2.0
     # via flake8
-pygments==2.7.4
+pygments==2.8.0
     # via rich
 pygtrie==2.3.3
     # via pulpcore


### PR DESCRIPTION
2.3.1 includes this fix: https://github.com/pulp/pulp_container/pull/236 which was preventing us from using the pulp_container registry alongside galaxy_ng