### PR TITLE
Backport: Add field detailing if a write only value is set or not. (#626)

### DIFF
--- a/CHANGES/120.misc
+++ b/CHANGES/120.misc
@@ -1,0 +1,1 @@
+Adds write_only_fields to remote API to inform clients if a write only field is set or not.

--- a/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
@@ -174,6 +174,48 @@ class TestUiSyncConfigViewSet(BaseTestCase):
         self.assertNotIn('token', response.data)
         self.assertNotIn('proxy_password', response.data)
 
+    def test_write_only_fields(self):
+        self.client.force_authenticate(user=self.admin_user)
+        api_url = self.build_config_url(self.certified_remote.name)
+        write_only_fields = ['client_key', 'token', 'password', 'proxy_password']
+
+        # note, proxy url and user have to be set in order to be able to set a
+        # proxy password
+        request_data = {
+            "url": self.certified_remote.url,
+            "proxy_url": "https://example.com",
+            "proxy_username": "bob"}
+
+        for field in write_only_fields:
+            request_data[field] = "value_is_set"
+
+        self.client.put(api_url, request_data, format='json')
+
+        write_only = self.client.get(api_url).data['write_only_fields']
+        response_names = set()
+        # Check that all write only fields are set
+        for field in write_only:
+            self.assertEqual(field['is_set'], True)
+
+            # unset all write only fields
+            request_data[field['name']] = None
+            response_names.add(field['name'])
+
+        self.assertEqual(set(write_only_fields), response_names)
+        self.client.put(api_url, request_data, format='json')
+
+        # Check that all write only fields are unset
+        write_only = self.client.get(api_url).data['write_only_fields']
+        for field in write_only:
+            self.assertEqual(field['is_set'], False)
+            request_data[field['name']] = ""
+
+        self.client.put(api_url, request_data, format='json')
+
+        write_only = self.client.get(api_url).data['write_only_fields']
+        for field in write_only:
+            self.assertEqual(field['is_set'], False)
+
     def test_split_proxy_url_field(self):
         self.client.force_authenticate(user=self.admin_user)
 


### PR DESCRIPTION
Backport: #626 

* Add field detailing if a write only value is set or not.

Issue: AAH-120
(cherry picked from commit c3e24a4ca79a5081e952774c1ae79b9e2a9b332c)