### PR TITLE
Add endpoint for returning images in a container repo.

### DIFF
--- a/CHANGES/277.feature
+++ b/CHANGES/277.feature
@@ -1,0 +1,1 @@
+Add api to return images in a container repo.

--- a/galaxy_ng/app/api/ui/serializers/__init__.py
+++ b/galaxy_ng/app/api/ui/serializers/__init__.py
@@ -28,7 +28,8 @@ from .distribution import (
 )
 
 from .execution_environment import (
-    ContainerRepositorySerializer
+    ContainerRepositorySerializer,
+    ContainerRepositoryImageSerializer
 )
 
 __all__ = (
@@ -53,5 +54,6 @@ __all__ = (
     # distribution
     'DistributionSerializer',
     # container
-    'ContainerRepositorySerializer'
+    'ContainerRepositorySerializer',
+    'ContainerRepositoryImageSerializer'
 )

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -89,9 +89,11 @@ class ContainerRepositoryImageSerializer(serializers.ModelSerializer):
 
     def get_layers(self, obj):
         layers = []
-        blobs = container_models.BlobManifest.objects.filter(manifest=obj)
-        for blob in blobs:
-            layers.append(blob.manifest_blob.digest)
+        for blob in obj.blobs.all():
+            layers.append({
+                'digest': blob.digest,
+                'size': blob._artifacts.first().size
+            })
         return layers
 
     def get_config_blob(self, obj):

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -103,14 +103,15 @@ class ContainerRepositoryImageSerializer(serializers.ModelSerializer):
         }
 
     def get_tags(self, obj):
-        tags = []
+        # tags = []
 
         # tagget_manifests returns all tags on the manifest, not just the ones
         # that are in the latest version of the repo.
-        repo_content = self.context['view'].repository_version.content.all()
-        tag_qs = obj.tagged_manifests.filter(pk__in=repo_content)
+        # repo_content = self.context['view'].repository_version.content.all()
+        # tag_qs = obj.tagged_manifests.filter(pk__in=repo_content)
 
-        for tag in tag_qs:
-            tags.append(tag.name)
+        # for tag in obj.tagged_manifest:
+        #     tags.append(tag.name)
+        # return tags
 
-        return tags
+        return obj.tags

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -72,6 +72,7 @@ class ContainerRepositorySerializer(serializers.ModelSerializer):
 class ContainerRepositoryImageSerializer(serializers.ModelSerializer):
     config_blob = serializers.SerializerMethodField()
     tags = serializers.SerializerMethodField()
+    layers = serializers.SerializerMethodField()
 
     class Meta:
         model = container_models.Manifest
@@ -82,11 +83,22 @@ class ContainerRepositoryImageSerializer(serializers.ModelSerializer):
             'media_type',
             'config_blob',
             'tags',
-            'pulp_created'
+            'pulp_created',
+            'layers'
         )
 
+    def get_layers(self, obj):
+        layers = []
+        blobs = container_models.BlobManifest.objects.filter(manifest=obj)
+        for blob in blobs:
+            layers.append(blob.manifest_blob.digest)
+        return layers
+
     def get_config_blob(self, obj):
-        return obj.config_blob.digest
+        return {
+            'digest': obj.config_blob.digest,
+            'media_type': obj.config_blob.media_type
+        }
 
     def get_tags(self, obj):
         tags = []

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -37,6 +37,14 @@ container_paths = [
         viewsets.ContainerRepositoryViewSet.as_view({'get': 'list'}),
         name='container-repository-detail'),
     path(
+        "repositories/<str:name>/images/",
+        viewsets.CotainerRepositoryManifestViewSet.as_view({'get': 'list'}),
+        name='container-repository-images'),
+    path(
+        "repositories/<str:namespace>/<str:name>/images/",
+        viewsets.CotainerRepositoryManifestViewSet.as_view({'get': 'list'}),
+        name='container-repository-images'),
+    path(
         "repositories/<str:name>/",
         viewsets.ContainerRepositoryViewSet.as_view({'get': 'retrieve'}),
         name='container-repository-detail'),

--- a/galaxy_ng/app/api/ui/viewsets/__init__.py
+++ b/galaxy_ng/app/api/ui/viewsets/__init__.py
@@ -16,7 +16,10 @@ from .synclist import SyncListViewSet
 from .root import APIRootView
 from .group import GroupViewSet, GroupModelPermissionViewSet, GroupUserViewSet
 from .distribution import DistributionViewSet, MyDistributionViewSet
-from .execution_environment import ContainerRepositoryViewSet
+from .execution_environment import (
+    ContainerRepositoryViewSet,
+    CotainerRepositoryManifestViewSet
+)
 
 __all__ = (
     'NamespaceViewSet',
@@ -36,5 +39,6 @@ __all__ = (
     'GroupUserViewSet',
     'DistributionViewSet',
     'MyDistributionViewSet',
-    'ContainerRepositoryViewSet'
+    'ContainerRepositoryViewSet',
+    'CotainerRepositoryManifestViewSet'
 )

--- a/galaxy_ng/app/api/ui/viewsets/__init__.py
+++ b/galaxy_ng/app/api/ui/viewsets/__init__.py
@@ -18,7 +18,7 @@ from .group import GroupViewSet, GroupModelPermissionViewSet, GroupUserViewSet
 from .distribution import DistributionViewSet, MyDistributionViewSet
 from .execution_environment import (
     ContainerRepositoryViewSet,
-    CotainerRepositoryManifestViewSet
+    ContainerRepositoryManifestViewSet
 )
 
 __all__ = (
@@ -40,5 +40,5 @@ __all__ = (
     'DistributionViewSet',
     'MyDistributionViewSet',
     'ContainerRepositoryViewSet',
-    'CotainerRepositoryManifestViewSet'
+    'ContainerRepositoryManifestViewSet'
 )

--- a/galaxy_ng/app/api/ui/viewsets/execution_environment.py
+++ b/galaxy_ng/app/api/ui/viewsets/execution_environment.py
@@ -38,25 +38,16 @@ class ContainerRepositoryViewSet(api_base.ModelViewSet):
     filter_backends = (DjangoFilterBackend,)
     filterset_class = RepositoryFilter
     permission_classes = [access_policy.ContainerRepositoryAccessPolicy]
-
-    def get_object(self):
-        base_path = self.kwargs["name"]
-        if self.kwargs.get("namespace"):
-            base_path = "{}/{}".format(self.kwargs["namespace"], self.kwargs["name"])
-
-        return get_object_or_404(self.queryset, base_path=base_path)
+    lookup_field = "base_path"
 
 
-class CotainerRepositoryManifestViewSet(api_base.ModelViewSet):
+class ContainerRepositoryManifestViewSet(api_base.ModelViewSet):
     serializer_class = serializers.ContainerRepositoryImageSerializer
 
     permission_classes = [access_policy.ContainerRepositoryAccessPolicy]
 
     def get_queryset(self):
-        base_path = self.kwargs["name"]
-        if self.kwargs.get("namespace"):
-            base_path = "{}/{}".format(self.kwargs["namespace"], self.kwargs["name"])
-
+        base_path = self.kwargs["base_path"]
         repo = get_object_or_404(models.ContainerDistribution, base_path=base_path).repository
         repo_version = repo.latest_version()
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ requirements = [
     "pulp-ansible==0.7.0",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
-    "pulp-container==2.3.1"
+    "pulp-container>=2.3.1"
 ]
 
 package_name = os.environ.get("GALAXY_NG_ALTERNATE_NAME", "galaxy-ng")


### PR DESCRIPTION
- Refactors container repo api paths to use more streamlined regex paths
- Add new api at `_ui/v1/execution-environments/repositories/{repo_path}/_content/images/` that returns a list of images in a repo.
- Add ability to filter images by tag and digest
- Add ability to sort images by `created`

API response
```
{
    "meta": {
        "count": 3
    },
    "links": {
        "first": "/api/automation-hub/_ui/v1/execution-environments/repositories/ubuntu/_content/images/?limit=10&offset=0",
        "previous": null,
        "next": null,
        "last": "/api/automation-hub/_ui/v1/execution-environments/repositories/ubuntu/_content/images/?limit=10&offset=0"
    },
    "data": [
        {
            "pulp_id": "fb1fe61c-434f-4d4d-8c64-12d33d08258b",
            "digest": "sha256:7d945d49c683b8ec367e86b010ab224199317d3fbf6461c448917a3fda17303d",
            "schema_version": 2,
            "media_type": "application/vnd.docker.distribution.manifest.v2+json",
            "config_blob": {
                "digest": "sha256:1f0815c1cb6e74ede323d39ded15fa90182a9ad5c64a3eb405c3f4297e9390e7",
                "media_type": "application/vnd.docker.image.rootfs.diff.tar.gzip"
            },
            "tags": [
                "postgres"
            ],
            "pulp_created": "2021-02-18T18:12:47.892024Z",
            "layers": [
                {
                    "digest": "sha256:29be22cb3acc5ee06240b3a727fa9dbbbe3b492f8c71d09fd57e84b6eeb83c00",
                    "size": 130
                },
                {
                    "digest": "sha256:c8752d5b785c50549f9d1ae2b6a004258c6ceb925a852bd5c9f30acf09f3892e",
                    "size": 121
                },
                {
                    "digest": "sha256:390c1c9a5ae4cb5301a81835bf1670a6114751ef4d07a7349c8b1413291746d7",
                    "size": 3050
                },
                {
                    "digest": "sha256:d736e67e6ac366e5f1209a1500726480888e4d78469d8e7dcadb5e6a47bbd178",
                    "size": 115
                },
                {
                    "digest": "sha256:5044045cf6f211ae92b3cf444652785a22d45d61057ac2c280d4028009dbea60",
                    "size": 391060
                },
                {
                    "digest": "sha256:564b77596399c4678ea0968348cf4d52e02e9669209e4de9de0eb1cf48749778",
                    "size": 7964523
                },
                {
                    "digest": "sha256:2696974e2815b47f62f4bb06900e7fa75b75a3c0874a9786e0dda00d6467d7c3",
                    "size": 1419383
                },
                {
                    "digest": "sha256:b4c431d00c785ececae7cb8dfa48d970c552f3dbf319a4bde1f12d1930cc237d",
                    "size": 1770
                },
                {
                    "digest": "sha256:f63c47038e663f46e2c1191c0bfe018c039361ee8bd7ffc3352a9692cc91e1e3",
                    "size": 169
                },
                {
                    "digest": "sha256:ebcdc659c5bf4b2ba68155c624968151cbfa99508dba74257051245d4e1fa5e0",
                    "size": 9337
                },
                {
                    "digest": "sha256:77a0c198cde5ca80ffba1a109ebc345a72b15847a58f310929c7c28f5c6cc67e",
                    "size": 4399
                },
                {
                    "digest": "sha256:40adec129f1a1bfc5a08b13816eef32abde7672f1bd4c56ad6741529728c8ac5",
                    "size": 4178277
                },
                {
                    "digest": "sha256:45b42c59be334ecda0daaa139b2f7d310e45c564c5f12263b1b8e68ec9e810ed",
                    "size": 27095142
                },
                {
                    "digest": "sha256:c0e62f172284d5acbd13ade8030dc1e703663d26d795ae4d19d8c66b3a5499b0",
                    "size": 73713565
                }
            ]
        },
        {
            "pulp_id": "0977085d-0296-4075-8682-baa64b64c720",
            "digest": "sha256:13ad29357a71f0906e85c9743261c1b72bf2ddeb24ddc2575f7c95519a5160ab",
            "schema_version": 2,
            "media_type": "application/vnd.docker.distribution.manifest.v2+json",
            "config_blob": {
                "digest": "sha256:f643c72bc25212974c16f3348b3a898b1ec1eb13ec1539e10a103e6e217eb2f1",
                "media_type": "application/vnd.docker.image.rootfs.diff.tar.gzip"
            },
            "tags": [],
            "pulp_created": "2021-02-12T20:10:54.207555Z",
            "layers": [
                {
                    "digest": "sha256:2c2d948710f21ad82dce71743b1654b45acb5c059cf5c19da491582cef6f2601",
                    "size": 162
                },
                {
                    "digest": "sha256:14428a6d4bcdba49a64127900a0691fb00a3f329aced25eb77e3b65646638f8d",
                    "size": 847
                },
                {
                    "digest": "sha256:da7391352a9bb76b292a568c066aa4c3cbae8d494e6a3c68e3c596d34f7c75f8",
                    "size": 28563271
                }
            ]
        },
        {
            "pulp_id": "b9f29d73-e53a-4ded-a6e5-f9184b023dde",
            "digest": "sha256:4e4bc990609ed865e07afc8427c30ffdddca5153fd4e82c20d8f0783a291e241",
            "schema_version": 2,
            "media_type": "application/vnd.docker.distribution.manifest.v2+json",
            "config_blob": {
                "digest": "sha256:f643c72bc25212974c16f3348b3a898b1ec1eb13ec1539e10a103e6e217eb2f1",
                "media_type": "application/vnd.docker.image.rootfs.diff.tar.gzip"
            },
            "tags": [
                "latest"
            ],
            "pulp_created": "2021-02-15T18:41:24.260782Z",
            "layers": [
                {
                    "digest": "sha256:2c2d948710f21ad82dce71743b1654b45acb5c059cf5c19da491582cef6f2601",
                    "size": 162
                },
                {
                    "digest": "sha256:14428a6d4bcdba49a64127900a0691fb00a3f329aced25eb77e3b65646638f8d",
                    "size": 847
                },
                {
                    "digest": "sha256:da7391352a9bb76b292a568c066aa4c3cbae8d494e6a3c68e3c596d34f7c75f8",
                    "size": 28563271
                }
            ]
        }
    ]
}
```