### PR TITLE
Fixing pulpcore 3.10+ breaking changes and renamings

### DIFF
--- a/CHANGES/393.misc
+++ b/CHANGES/393.misc
@@ -1,0 +1,1 @@
+Fixing some incompatibilities and renamings introduced by pulpcore 3.10

--- a/galaxy_ng/app/api/v3/serializers/collection.py
+++ b/galaxy_ng/app/api/v3/serializers/collection.py
@@ -53,15 +53,15 @@ class CollectionSerializer(_CollectionSerializer, HrefNamespaceMixin):
 
     def get_highest_version(self, obj):
         """Get a highest version and its link."""
-        collection = self.context["highest_versions"][obj.pk]
+        data = super().get_highest_version(obj)
         kwargs = {
             "path": self.context["path"],
-            "namespace": collection.namespace,
-            "name": collection.name,
-            "version": collection.version,
+            "namespace": obj.namespace,
+            "name": obj.name,
+            "version": data['version'],
         }
-        href = self._get_href("collection-versions-detail", **kwargs)
-        return {"href": href, "version": str(collection.version)}
+        data['href'] = self._get_href("collection-versions-detail", **kwargs)
+        return data
 
 
 class CollectionRefSerializer(_CollectionRefSerializer, HrefNamespaceMixin):
@@ -106,11 +106,7 @@ class CollectionVersionSerializer(_CollectionVersionSerializer, HrefNamespaceMix
         host = settings.CONTENT_ORIGIN.strip("/")
         prefix = settings.CONTENT_PATH_PREFIX.strip("/")
         distro_base_path = self.context["path"]
-        filename_path = self.context["content_artifact"].relative_path.lstrip("/")
-
-        download_url = f"{host}/{prefix}/{distro_base_path}/{filename_path}"
-
-        return download_url
+        return f"{host}/{prefix}/{distro_base_path}/{obj.relative_path}"
 
     def get_href(self, obj):
         """Get href."""

--- a/galaxy_ng/app/api/v3/views/sync.py
+++ b/galaxy_ng/app/api/v3/views/sync.py
@@ -47,7 +47,8 @@ class SyncRemoteView(api_base.APIView):
             kwargs={
                 "remote_pk": remote.pk,
                 "repository_pk": distro.repository.pk,
-                "mirror": True
+                "mirror": True,
+                "optimize": True,
             },
         )
 


### PR DESCRIPTION
Pulpcore 3.10 introduced some breaking changes

- On serializers `highest_versions` has been removed out of the context
- On download_url `content_artifact` has been also moved out of context
- Sync now requires `optimize=True` attribute

And also some non-breaking changes

- Viewsets `retrieve` is not needed because distro_path is now part of pulp-ansible and can be removed from our side
- `self._deprecation` is not necessary (included by mistake on a
  previous PR)

Issue: AAH-393