### PR TITLE
Add container repository history api.

### DIFF
--- a/CHANGES/276.feature
+++ b/CHANGES/276.feature
@@ -1,0 +1,1 @@
+Add the ability to view the changes that have been made to a container repo.

--- a/galaxy_ng/app/api/ui/serializers/__init__.py
+++ b/galaxy_ng/app/api/ui/serializers/__init__.py
@@ -29,7 +29,8 @@ from .distribution import (
 
 from .execution_environment import (
     ContainerRepositorySerializer,
-    ContainerRepositoryImageSerializer
+    ContainerRepositoryImageSerializer,
+    ContainerRepositoryHistorySerializer
 )
 
 __all__ = (
@@ -55,5 +56,6 @@ __all__ = (
     'DistributionSerializer',
     # container
     'ContainerRepositorySerializer',
-    'ContainerRepositoryImageSerializer'
+    'ContainerRepositoryImageSerializer',
+    'ContainerRepositoryHistorySerializer'
 )

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -132,18 +132,14 @@ class ContainerRepositoryHistorySerializer(serializers.ModelSerializer):
         )
 
     def get_added(self, obj):
-        added = []
-        for content in obj.added_memberships.all():
-            added.append(self._content_info(content.content))
-
-        return added
+        return [
+            self._content_info(content.content) for content in obj.added_memberships.all()
+        ]
 
     def get_removed(self, obj):
-        removed = []
-        for content in obj.removed_memberships.all():
-            removed.append(self._content_info(content.content))
-
-        return removed
+        return [
+            self._content_info(content.content) for content in obj.removed_memberships.all()
+        ]
 
     def _content_info(self, content):
         return_data = {

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -1,5 +1,8 @@
 from rest_framework import serializers
+from django.db.models import Q
+
 from pulp_container.app import models as container_models
+from pulpcore.plugin import models as core_models
 
 from galaxy_ng.app import models
 from galaxy_ng.app.access_control.fields import GroupPermissionField
@@ -113,3 +116,52 @@ class ContainerRepositoryImageSerializer(serializers.ModelSerializer):
             tags.append(tag.name)
 
         return tags
+
+
+class ContainerRepositoryHistorySerializer(serializers.ModelSerializer):
+    added = serializers.SerializerMethodField()
+    removed = serializers.SerializerMethodField()
+
+    class Meta:
+        model = core_models.RepositoryVersion
+        fields = (
+            'pulp_id',
+            'added',
+            'removed',
+            'pulp_created',
+            'number'
+        )
+
+    def get_added(self, obj):
+        added = []
+        for content in obj.added_memberships.all():
+            added.append(self._content_info(content.content))
+
+        return added
+
+    def get_removed(self, obj):
+        removed = []
+        for content in obj.removed_memberships.all():
+            removed.append(self._content_info(content.content))
+
+        return removed
+
+    def _content_info(self, content):
+        return_data = {
+            "pulp_id": content.pulp_id,
+            "pulp_type": content.pulp_type,
+            "manifest_digest": None,
+            "tag_name": None,
+        }
+
+        # TODO: Figure out if there is a way to prefetch Manifest and Tag objects
+        if content.pulp_type == 'container.manifest':
+            manifest = container_models.Manifest.objects.get(pk=content.pulp_id)
+            return_data['manifest_digest'] = manifest.digest
+        elif content.pulp_type == 'container.tag':
+            tag = container_models.Tag.objects.select_related('tagged_manifest')\
+                .get(pk=content.pulp_id)
+            return_data['manifest_digest'] = tag.tagged_manifest.digest
+            return_data['tag_name'] = tag.name
+
+        return return_data

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -1,5 +1,4 @@
 from rest_framework import serializers
-from django.db.models import Q
 
 from pulp_container.app import models as container_models
 from pulpcore.plugin import models as core_models

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -32,10 +32,13 @@ auth_views = [
 ]
 
 container_repo_paths = [
-
-    re_path(
-        r'images/',
+    path(
+        'images/',
         viewsets.ContainerRepositoryManifestViewSet.as_view({'get': 'list'}),
+        name='container-repository-images'),
+    path(
+        'history/',
+        viewsets.ContainerRepositoryHistoryViewSet.as_view({'get': 'list'}),
         name='container-repository-images'),
 ]
 
@@ -46,7 +49,7 @@ container_paths = [
         name='container-repository-list'),
 
     # image names can't start with _, so namespacing all the nested views
-    # under _detail prevents cases where an image could be named foo/images
+    # under _content prevents cases where an image could be named foo/images
     # and conflict with our URL paths.
     re_path(
         r'repositories/(?P<base_path>\w+\/{0,1}\w+)/_content/',

--- a/galaxy_ng/app/api/ui/viewsets/__init__.py
+++ b/galaxy_ng/app/api/ui/viewsets/__init__.py
@@ -18,7 +18,8 @@ from .group import GroupViewSet, GroupModelPermissionViewSet, GroupUserViewSet
 from .distribution import DistributionViewSet, MyDistributionViewSet
 from .execution_environment import (
     ContainerRepositoryViewSet,
-    ContainerRepositoryManifestViewSet
+    ContainerRepositoryManifestViewSet,
+    ContainerRepositoryHistoryViewSet
 )
 
 __all__ = (
@@ -40,5 +41,6 @@ __all__ = (
     'DistributionViewSet',
     'MyDistributionViewSet',
     'ContainerRepositoryViewSet',
-    'ContainerRepositoryManifestViewSet'
+    'ContainerRepositoryManifestViewSet',
+    'ContainerRepositoryHistoryViewSet'
 )

--- a/galaxy_ng/app/api/ui/viewsets/execution_environment.py
+++ b/galaxy_ng/app/api/ui/viewsets/execution_environment.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db.models import Prefetch, Count, Subquery, OuterRef, Q
+from django.db.models import Prefetch, Count, Q
 
 from pulpcore.plugin import models as core_models
 from pulp_container.app import models as container_models


### PR DESCRIPTION
Adds `_ui/v1/execution-environments/repositories/<container>/_content/history/` endpoint which returns a list of repository versions that have Tags or Manifests that has been added or removed from the registry.

```
{
    "meta": {
        "count": 1
    },
    "links": {
        "first": "/api/automation-hub/_ui/v1/execution-environments/repositories/postgres/_content/history/?limit=10&offset=0",
        "previous": null,
        "next": null,
        "last": "/api/automation-hub/_ui/v1/execution-environments/repositories/postgres/_content/history/?limit=10&offset=0"
    },
    "data": [
        {
            "pulp_id": "41c336a1-bd53-478a-ad8a-e322bbed8794",
            "added": [
                {
                    "pulp_id": "12d401ca-0f4d-44cb-9230-2becdaf61348",
                    "pulp_type": "container.manifest",
                    "manifest_digest": "sha256:be73fdba6d4e542e5fd10abb5aef072cf2c52547ebd3e39dd72e6ca3f98c8233",
                    "tag_name": null
                },
                {
                    "pulp_id": "efe9988b-2d6c-4a6b-9bab-fbb3580e7a59",
                    "pulp_type": "container.tag",
                    "manifest_digest": "sha256:be73fdba6d4e542e5fd10abb5aef072cf2c52547ebd3e39dd72e6ca3f98c8233",
                    "tag_name": "latest"
                }
            ],
            "removed": [],
            "pulp_created": "2021-02-22T20:41:57.415284Z",
            "number": 16
        }
    ]
}
```