### PR TITLE
Reduce excessive number of spawned synclist tasks

### DIFF
--- a/CHANGES/50.bugfix
+++ b/CHANGES/50.bugfix
@@ -1,0 +1,3 @@
+Fixed synclist curation creating 2 * N tasks, where N is number of synclists.
+Now synclist curation is executed in batches. Number of batches is configured in project settings.
+By default it is set to 200 synclists per task.

--- a/galaxy_ng/app/api/ui/viewsets/my_synclist.py
+++ b/galaxy_ng/app/api/ui/viewsets/my_synclist.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.shortcuts import get_object_or_404
 from guardian.shortcuts import get_objects_for_user
 
 from rest_framework.decorators import action
@@ -35,13 +36,12 @@ class MySyncListViewSet(SyncListViewSet):
         )
 
     @action(detail=True, methods=["post"])
-    def curate(self, request, pk=None):
-        locks = [pk]
-        task_args = (pk,)
-        task_kwargs = {}
-
+    def curate(self, request, pk):
+        synclist = get_object_or_404(models.SyncList, pk)
         synclist_task = enqueue_with_reservation(
-            curate_synclist_repository, locks, args=task_args, kwargs=task_kwargs
+            curate_synclist_repository,
+            resources=[synclist.repository],
+            args=(pk, )
         )
 
         log.debug("synclist_task: %s", synclist_task)

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -43,6 +43,9 @@ GALAXY_API_SYNCLIST_NAME_FORMAT = "{account_name}-synclist"
 # Require approval for incoming content, which uses a staging repository
 GALAXY_REQUIRE_CONTENT_APPROVAL = True
 
+# Number of synclist to be processed in single task
+SYNCLIST_BATCH_SIZE = 200
+
 # Local rest framework settings
 # -----------------------------
 


### PR DESCRIPTION
Fix large number of enqueued synclist related tasks by doing the
following changes:
  * Call `add_and_remove` tasks directly.
  * Call `curate_synclist_repository` task in batches.
  * Batch size is set to 200.