### PR TITLE
Fix wrong get_object_or_404 call in synclist curate

### DIFF
--- a/galaxy_ng/app/api/ui/viewsets/my_synclist.py
+++ b/galaxy_ng/app/api/ui/viewsets/my_synclist.py
@@ -37,7 +37,7 @@ class MySyncListViewSet(SyncListViewSet):
 
     @action(detail=True, methods=["post"])
     def curate(self, request, pk):
-        synclist = get_object_or_404(models.SyncList, pk)
+        synclist = get_object_or_404(models.SyncList, pk=pk)
         synclist_task = enqueue_with_reservation(
             curate_synclist_repository,
             resources=[synclist.repository],


### PR DESCRIPTION
Related-Issue: AAH-50