### PR TITLE
Fix pr_check.sh script

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-# TODO(cutwater): This is dummy script to be called by Jenkins CI. 
+# TODO(cutwater): This is dummy script to be called by Jenkins CI.
 # 		  To be implemented.
 
 
-exit 0
+# Need to make a dummy results file to make tests pass
+mkdir -p artifacts
+cat << EOF > artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>


### PR DESCRIPTION
Because pr-check Jenkins job got switched from `gh-pr-check` to
`insights-gh-pr-check`, it is expected to have JUnit report file
as a result of the script.
Normally it is generated when bonfire is called.
This patch creates a dummy report file to make CI pass.

No-Issue