### PR TITLE
Container access policies 278

### DIFF
--- a/CHANGES/278.feature
+++ b/CHANGES/278.feature
@@ -1,0 +1,1 @@
+Add galaxy style access_policy for pulp_container

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -222,6 +222,9 @@ class CollectionAccessPolicy(AccessPolicyBase):
         namespace = models.Namespace.objects.get(name=collection.namespace)
         return request.user.has_perm('galaxy.upload_to_namespace', namespace)
 
+class CollectionUploadAccessPolicy(AccessPolicyBase):
+    NAME = 'CollectionUploadViewSet'
+
     def can_create_collection(self, request, view, permission):
         data = view._get_data(request)
         try:

--- a/galaxy_ng/app/access_control/plugins/pulp_container/pulp_container_namespaces_viewset.json
+++ b/galaxy_ng/app/access_control/plugins/pulp_container/pulp_container_namespaces_viewset.json
@@ -1,0 +1,117 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "pulp_href": "/pulp/api/v3/access_policies/564614bf-14e0-4464-a062-2a050100ce56/",
+      "pulp_created": "2021-02-16T17:49:06.887164Z",
+      "permissions_assignment": [
+        {
+          "function": "create_namespace_group",
+          "parameters": {
+            "group_type": "owners",
+            "add_user_to_group": true
+          },
+          "permissions": [
+            "container.view_containernamespace",
+            "container.delete_containernamespace",
+            "container.namespace_add_containerdistribution",
+            "container.namespace_delete_containerdistribution",
+            "container.namespace_view_containerdistribution",
+            "container.namespace_pull_containerdistribution",
+            "container.namespace_push_containerdistribution",
+            "container.namespace_change_containerdistribution",
+            "container.namespace_view_containerpushrepository",
+            "container.namespace_modify_content_containerpushrepository"
+          ]
+        },
+        {
+          "function": "create_namespace_group",
+          "parameters": {
+            "group_type": "collaborators",
+            "add_user_to_group": false
+          },
+          "permissions": [
+            "container.view_containernamespace",
+            "container.namespace_add_containerdistribution",
+            "container.namespace_delete_containerdistribution",
+            "container.namespace_view_containerdistribution",
+            "container.namespace_pull_containerdistribution",
+            "container.namespace_push_containerdistribution",
+            "container.namespace_change_containerdistribution",
+            "container.namespace_view_containerpushrepository",
+            "container.namespace_modify_content_containerpushrepository"
+          ]
+        },
+        {
+          "function": "create_namespace_group",
+          "parameters": {
+            "group_type": "consumers",
+            "add_user_to_group": false
+          },
+          "permissions": [
+            "container.view_containernamespace",
+            "container.namespace_view_containerdistribution",
+            "container.namespace_pull_containerdistribution",
+            "container.namespace_view_containerpushrepository"
+          ]
+        }
+      ],
+      "statements": [
+        {
+          "action": [
+            "list"
+          ],
+          "effect": "allow",
+          "principal": "authenticated"
+        },
+        {
+          "action": [
+            "create"
+          ],
+          "effect": "allow",
+          "condition": "has_model_perms:container.add_containernamespace",
+          "principal": "authenticated"
+        },
+        {
+          "action": [
+            "retrieve"
+          ],
+          "effect": "allow",
+          "condition": "has_model_or_obj_perms:container.view_containernamespace",
+          "principal": "authenticated"
+        },
+        {
+          "action": [
+            "destroy"
+          ],
+          "effect": "allow",
+          "condition": [
+            "has_model_or_obj_perms:container.delete_containernamespace",
+            "has_model_or_obj_perms:container.view_containernamespace"
+          ],
+          "principal": "authenticated"
+        },
+        {
+          "action": [
+            "create_distribution"
+          ],
+          "effect": "allow",
+          "condition": "has_model_or_obj_perms:container.namespace_add_containerdistribution",
+          "principal": "authenticated"
+        },
+        {
+          "action": [
+            "view_distribution"
+          ],
+          "effect": "allow",
+          "condition": "has_model_or_obj_perms:container.namespace_view_containerdistribution",
+          "principal": "authenticated"
+        }
+      ],
+      "viewset_name": "pulp_container/namespaces",
+      "customized": false
+    }
+  ]
+}

--- a/galaxy_ng/app/access_control/plugins/pulp_container/pulp_container_namespaces_viewset.json
+++ b/galaxy_ng/app/access_control/plugins/pulp_container/pulp_container_namespaces_viewset.json
@@ -1,117 +1,106 @@
 {
-  "count": 1,
-  "next": null,
-  "previous": null,
-  "results": [
+  "permissions_assignment": [
     {
-      "pulp_href": "/pulp/api/v3/access_policies/564614bf-14e0-4464-a062-2a050100ce56/",
-      "pulp_created": "2021-02-16T17:49:06.887164Z",
-      "permissions_assignment": [
-        {
-          "function": "create_namespace_group",
-          "parameters": {
-            "group_type": "owners",
-            "add_user_to_group": true
-          },
-          "permissions": [
-            "container.view_containernamespace",
-            "container.delete_containernamespace",
-            "container.namespace_add_containerdistribution",
-            "container.namespace_delete_containerdistribution",
-            "container.namespace_view_containerdistribution",
-            "container.namespace_pull_containerdistribution",
-            "container.namespace_push_containerdistribution",
-            "container.namespace_change_containerdistribution",
-            "container.namespace_view_containerpushrepository",
-            "container.namespace_modify_content_containerpushrepository"
-          ]
-        },
-        {
-          "function": "create_namespace_group",
-          "parameters": {
-            "group_type": "collaborators",
-            "add_user_to_group": false
-          },
-          "permissions": [
-            "container.view_containernamespace",
-            "container.namespace_add_containerdistribution",
-            "container.namespace_delete_containerdistribution",
-            "container.namespace_view_containerdistribution",
-            "container.namespace_pull_containerdistribution",
-            "container.namespace_push_containerdistribution",
-            "container.namespace_change_containerdistribution",
-            "container.namespace_view_containerpushrepository",
-            "container.namespace_modify_content_containerpushrepository"
-          ]
-        },
-        {
-          "function": "create_namespace_group",
-          "parameters": {
-            "group_type": "consumers",
-            "add_user_to_group": false
-          },
-          "permissions": [
-            "container.view_containernamespace",
-            "container.namespace_view_containerdistribution",
-            "container.namespace_pull_containerdistribution",
-            "container.namespace_view_containerpushrepository"
-          ]
-        }
+      "function": "create_namespace_group",
+      "parameters": {
+        "group_type": "owners",
+        "add_user_to_group": true
+      },
+      "permissions": [
+        "container.view_containernamespace",
+        "container.delete_containernamespace",
+        "container.namespace_add_containerdistribution",
+        "container.namespace_delete_containerdistribution",
+        "container.namespace_view_containerdistribution",
+        "container.namespace_pull_containerdistribution",
+        "container.namespace_push_containerdistribution",
+        "container.namespace_change_containerdistribution",
+        "container.namespace_view_containerpushrepository",
+        "container.namespace_modify_content_containerpushrepository"
+      ]
+    },
+    {
+      "function": "create_namespace_group",
+      "parameters": {
+        "group_type": "collaborators",
+        "add_user_to_group": false
+      },
+      "permissions": [
+        "container.view_containernamespace",
+        "container.namespace_add_containerdistribution",
+        "container.namespace_delete_containerdistribution",
+        "container.namespace_view_containerdistribution",
+        "container.namespace_pull_containerdistribution",
+        "container.namespace_push_containerdistribution",
+        "container.namespace_change_containerdistribution",
+        "container.namespace_view_containerpushrepository",
+        "container.namespace_modify_content_containerpushrepository"
+      ]
+    },
+    {
+      "function": "create_namespace_group",
+      "parameters": {
+        "group_type": "consumers",
+        "add_user_to_group": false
+      },
+      "permissions": [
+        "container.view_containernamespace",
+        "container.namespace_view_containerdistribution",
+        "container.namespace_pull_containerdistribution",
+        "container.namespace_view_containerpushrepository"
+      ]
+    }
+  ],
+  "statements": [
+    {
+      "action": [
+        "list"
       ],
-      "statements": [
-        {
-          "action": [
-            "list"
-          ],
-          "effect": "allow",
-          "principal": "authenticated"
-        },
-        {
-          "action": [
-            "create"
-          ],
-          "effect": "allow",
-          "condition": "has_model_perms:container.add_containernamespace",
-          "principal": "authenticated"
-        },
-        {
-          "action": [
-            "retrieve"
-          ],
-          "effect": "allow",
-          "condition": "has_model_or_obj_perms:container.view_containernamespace",
-          "principal": "authenticated"
-        },
-        {
-          "action": [
-            "destroy"
-          ],
-          "effect": "allow",
-          "condition": [
-            "has_model_or_obj_perms:container.delete_containernamespace",
-            "has_model_or_obj_perms:container.view_containernamespace"
-          ],
-          "principal": "authenticated"
-        },
-        {
-          "action": [
-            "create_distribution"
-          ],
-          "effect": "allow",
-          "condition": "has_model_or_obj_perms:container.namespace_add_containerdistribution",
-          "principal": "authenticated"
-        },
-        {
-          "action": [
-            "view_distribution"
-          ],
-          "effect": "allow",
-          "condition": "has_model_or_obj_perms:container.namespace_view_containerdistribution",
-          "principal": "authenticated"
-        }
+      "effect": "allow",
+      "principal": "authenticated"
+    },
+    {
+      "action": [
+        "create"
       ],
-      "viewset_name": "pulp_container/namespaces",
-      "customized": false
+      "effect": "allow",
+      "condition": "has_model_perms:container.add_containernamespace",
+      "principal": "authenticated"
+    },
+    {
+      "action": [
+        "retrieve"
+      ],
+      "effect": "allow",
+      "condition": "has_model_or_obj_perms:container.view_containernamespace",
+      "principal": "authenticated"
+    },
+    {
+      "action": [
+        "destroy"
+      ],
+      "effect": "allow",
+      "condition": [
+        "has_model_or_obj_perms:container.delete_containernamespace",
+        "has_model_or_obj_perms:container.view_containernamespace"
+      ],
+      "principal": "authenticated"
+    },
+    {
+      "action": [
+        "create_distribution"
+      ],
+      "effect": "allow",
+      "condition": "has_model_or_obj_perms:container.namespace_add_containerdistribution",
+      "principal": "authenticated"
+    },
+    {
+      "action": [
+        "view_distribution"
+      ],
+      "effect": "allow",
+      "condition": "has_model_or_obj_perms:container.namespace_view_containerdistribution",
+      "principal": "authenticated"
     }
   ]
 }

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -35,12 +35,6 @@ STANDALONE_STATEMENTS = {
             "effect": "deny",
         },
         {
-            "action": "create",
-            "principal": "authenticated",
-            "effect": "allow",
-            "condition": "can_create_collection"
-        },
-        {
             "action": "update",
             "principal": "authenticated",
             "effect": "allow",
@@ -52,6 +46,14 @@ STANDALONE_STATEMENTS = {
             "effect": "allow",
             "condition": "has_model_perms:ansible.modify_ansible_repo_content"
         }
+    ],
+    'CollectionUploadViewSet': [
+        {
+            "action": "create",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "can_create_collection"
+        },
     ],
     'CollectionRemoteViewSet': [
         {

--- a/galaxy_ng/app/management/commands/access-policy-show.py
+++ b/galaxy_ng/app/management/commands/access-policy-show.py
@@ -38,18 +38,18 @@ class Command(BaseCommand):
     #             "permission in the form 'app_label.codename'".format(
     #                 permission))
 
-    # def add_arguments(self, parser):
+    def add_arguments(self, parser):
     #     parser.add_argument('group', type=self.valid_group)
-    #     parser.add_argument(
-    #         'permissions',
-    #         nargs='+',
-    #         type=self.valid_permission
-    #     )
+        parser.add_argument(
+            '--deployment-mode',
+            dest='deployment_mode',
+            default=settings.GALAXY_DEPLOYMENT_MODE,
+            help="The deployment mode to use the access_policy of. Choices: insights, standalone"
+        )
 
     def handle(self, *args, **options):
         ap = access_control.access_policy.AccessPolicyBase()
-        deployment_mode = settings.GALAXY_DEPLOYMENT_MODE
-        deployment_mode = 'insights'
+        deployment_mode = options['deployment_mode']
         statements_map = ap._get_statements(deployment_mode)
         statement_template = \
             "\taction: {action}\n\t\tprincipal: {principal}\n\t\teffect: {effect}\n\t\tconditions:\n{conditions}\n"

--- a/galaxy_ng/app/management/commands/access-policy-show.py
+++ b/galaxy_ng/app/management/commands/access-policy-show.py
@@ -1,0 +1,82 @@
+from django.conf import settings
+
+from django.core.management import BaseCommand, CommandError
+from django.core.exceptions import ObjectDoesNotExist
+
+from galaxy_ng.app import access_control
+
+class Command(BaseCommand):
+    """
+    Django management command to show access_policy statements
+    """
+
+    help = 'Show access_policy statements'
+
+    # def valid_group(self, group):
+    #     try:
+    #         return Group.objects.get(name=group)
+    #     except ObjectDoesNotExist:
+    #         raise CommandError(
+    #             'Group {} does not exist. Please provide a valid '
+    #             'group name.'.format(group))
+
+    # def valid_permission(self, permission):
+    #     try:
+    #         app_label, codename = permission.split('.', 1)
+    #     except ValueError:
+    #         raise CommandError(
+    #             "Invalid permission format for {}. "
+    #             "Expecting 'app_label.codename'.".format(permission)
+    #         )
+    #     try:
+    #         return Permission.objects.get(
+    #             content_type__app_label=app_label,
+    #             codename=codename)
+    #     except ObjectDoesNotExist:
+    #         raise CommandError(
+    #             "Permission {} not found. Please provide a valid "
+    #             "permission in the form 'app_label.codename'".format(
+    #                 permission))
+
+    # def add_arguments(self, parser):
+    #     parser.add_argument('group', type=self.valid_group)
+    #     parser.add_argument(
+    #         'permissions',
+    #         nargs='+',
+    #         type=self.valid_permission
+    #     )
+
+    def handle(self, *args, **options):
+        ap = access_control.access_policy.AccessPolicyBase()
+        deployment_mode = settings.GALAXY_DEPLOYMENT_MODE
+        deployment_mode = 'insights'
+        statements_map = ap._get_statements(deployment_mode)
+        statement_template = \
+            "\taction: {action}\n\t\tprincipal: {principal}\n\t\teffect: {effect}\n\t\tconditions:\n{conditions}\n"
+
+        self.stdout.write(f"deployment_mode: {deployment_mode}\n")
+        for view, statements in statements_map.items():
+            self.stdout.write("%s\n" % view)
+            for statement in statements:
+                actions = statement['action']
+                if isinstance(actions, str):
+                    actions = [actions]
+                conditions = statement.get('condition', [])
+                if isinstance(conditions, str):
+                    conditions = [conditions]
+                condition_lines = []
+                for cond in conditions:
+                    condition_line = f'\t\t\t{cond}\n'
+                    condition_lines.append(condition_line)
+                conditions_buf = ''.join(condition_lines)
+                for action in actions:
+                    self.stdout.write(statement_template.format(action=action,
+                                                                principal=statement['principal'],
+                                                                effect=statement['effect'],
+                                                                conditions=conditions_buf))
+                # self.stdout.write("\t%s\n" % statement)
+        # group = options['group']
+        # for perm in options['permissions']:
+        #     group.permissions.add(perm.id)
+        # self.stdout.write("Assigned requested permission to "
+        #                   "group '{}'".format(group.name))

--- a/galaxy_ng/app/management/commands/access-policy-views.py
+++ b/galaxy_ng/app/management/commands/access-policy-views.py
@@ -80,6 +80,12 @@ class Command(show_urls.Command):
             dest='user_id',
             help="The user to test with"
         )
+        parser.add_argument(
+            '--url',
+            dest='url',
+            default=None,
+            help="The url to show access policy for"
+        )
         super().add_arguments(parser)
 
     def _get_user(self, user_id):
@@ -144,6 +150,9 @@ class Command(show_urls.Command):
             url = simplify_regex(regex)
             decorator = ', '.join(decorators)
 
+            url_filter = options['url']
+            if url_filter and url_filter != url:
+                continue
             if module.startswith('admin'):
                 continue
             if module.startswith('django'):
@@ -154,6 +163,7 @@ class Command(show_urls.Command):
                 continue
             if module.startswith('drf_spectacular'):
                 continue
+
 
             perms = []
 

--- a/galaxy_ng/app/management/commands/access-policy-views.py
+++ b/galaxy_ng/app/management/commands/access-policy-views.py
@@ -1,0 +1,175 @@
+import functools
+import json
+import logging
+import pprint
+import re
+
+from django.conf import settings
+
+from django.contrib.admindocs.views import simplify_regex
+from django.core.management import BaseCommand, CommandError
+from django.core.exceptions import ObjectDoesNotExist
+
+from django_extensions.management.commands import show_urls
+from galaxy_ng.app import access_control
+
+log = logging.getLogger(__name__)
+pp = pprint.pformat
+
+class Command(show_urls.Command):
+    """
+    Django management command to show access_policy statements
+    """
+
+    help = 'Show access_policy viewsets'
+
+    # def valid_group(self, group):
+    #     try:
+    #         return Group.objects.get(name=group)
+    #     except ObjectDoesNotExist:
+    #         raise CommandError(
+    #             'Group {} does not exist. Please provide a valid '
+    #             'group name.'.format(group))
+
+    # def valid_permission(self, permission):
+    #     try:
+    #         app_label, codename = permission.split('.', 1)
+    #     except ValueError:
+    #         raise CommandError(
+    #             "Invalid permission format for {}. "
+    #             "Expecting 'app_label.codename'.".format(permission)
+    #         )
+    #     try:
+    #         return Permission.objects.get(
+    #             content_type__app_label=app_label,
+    #             codename=codename)
+    #     except ObjectDoesNotExist:
+    #         raise CommandError(
+    #             "Permission {} not found. Please provide a valid "
+    #             "permission in the form 'app_label.codename'".format(
+    #                 permission))
+
+    # def add_arguments(self, parser):
+    # #     parser.add_argument('group', type=self.valid_group)
+    #     parser.add_argument(
+    #         '--deployment-mode',
+    #         dest='deployment_mode',
+    #         default=settings.GALAXY_DEPLOYMENT_MODE,
+    #         help="The deployment mode to use the access_policy of. Choices: insights, standalone"
+    #     )
+
+    def handle(self, *args, **options):
+        decorator = options['decorator']
+        if not decorator:
+            decorator = ['login_required']
+
+        urlconf = options['urlconf']
+
+        views = []
+        if not hasattr(settings, urlconf):
+            raise CommandError("Settings module {} does not have the attribute {}.".format(settings, urlconf))
+
+        try:
+            urlconf = __import__(getattr(settings, urlconf), {}, {}, [''])
+        except Exception as e:
+            if options['traceback']:
+                import traceback
+                traceback.print_exc()
+            raise CommandError("Error occurred while trying to load %s: %s" % (getattr(settings, urlconf), str(e)))
+
+        view_functions = self.extract_views_from_urlpatterns(urlconf.urlpatterns)
+        log.debug('view_functions:\n%s', pp(view_functions))
+
+        for (func, regex, url_name) in view_functions:
+            if hasattr(func, '__globals__'):
+                func_globals = func.__globals__
+            elif hasattr(func, 'func_globals'):
+                func_globals = func.func_globals
+            else:
+                func_globals = {}
+
+            decorators = [d for d in decorator if d in func_globals]
+
+            if isinstance(func, functools.partial):
+                func = func.func
+                decorators.insert(0, 'functools.partial')
+
+            permission_classes = []
+            if hasattr(func, '__name__'):
+                func_name = func.__name__
+            elif hasattr(func, '__class__'):
+                func_name = '%s()' % func.__class__.__name__
+                permission_classes = func.permission_classes
+            else:
+                func_name = re.sub(r' at 0x[0-9a-f]+', '', repr(func))
+                permission_classes = func.permission_classes
+
+            module = '{0}.{1}'.format(func.__module__, func_name)
+            url_name = url_name or ''
+            url = simplify_regex(regex)
+            decorator = ', '.join(decorators)
+
+            if module.startswith('admin'):
+                continue
+            if module.startswith('django'):
+                continue
+            if module.startswith('rest_framework'):
+                continue
+            if module.startswith('pulp'):
+                continue
+            if module.startswith('drf_spectacular'):
+                continue
+
+            format_style = 'json'
+            if format_style == 'json':
+                views.append({"url": url,
+                              "module": module,
+                              "name": url_name,
+                              "permission_classes": permission_classes,
+                              "path_regex": regex,
+
+                              "decorators": decorator})
+            else:
+                views.append(fmtr.format(
+                    module='{0}.{1}'.format(style.MODULE(func.__module__), style.MODULE_NAME(func_name)),
+                    url_name=style.URL_NAME(url_name),
+                    url=style.URL(url),
+                    decorator=decorator,
+                ).strip())
+
+        log.debug('views:\n%s', pp(views))
+
+
+    def not_handle(self, *args, **options):
+        ap = access_control.access_policy.AccessPolicyBase()
+        deployment_mode = options['deployment_mode']
+        statements_map = ap._get_statements(deployment_mode)
+        statement_template = \
+            "\taction: {action}\n\t\tprincipal: {principal}\n\t\teffect: {effect}\n\t\tconditions:\n{conditions}\n"
+
+        self.stdout.write(f"deployment_mode: {deployment_mode}\n")
+        for view, statements in statements_map.items():
+            self.stdout.write("%s\n" % view)
+            for statement in statements:
+                actions = statement['action']
+                if isinstance(actions, str):
+                    actions = [actions]
+                conditions = statement.get('condition', [])
+                if isinstance(conditions, str):
+                    conditions = [conditions]
+                condition_lines = []
+                for cond in conditions:
+                    condition_line = f'\t\t\t{cond}\n'
+                    condition_lines.append(condition_line)
+                conditions_buf = ''.join(condition_lines)
+                for action in actions:
+                    self.stdout.write(statement_template.format(action=action,
+                                                                principal=statement['principal'],
+                                                                effect=statement['effect'],
+                                                                conditions=conditions_buf))
+                # self.stdout.write("\t%s\n" % statement)
+        # group = options['group']
+        # for perm in options['permissions']:
+        #     group.permissions.add(perm.id)
+        # self.stdout.write("Assigned requested permission to "
+        #                   "group '{}'".format(group.name))

--- a/galaxy_ng/app/management/commands/access-policy-views.py
+++ b/galaxy_ng/app/management/commands/access-policy-views.py
@@ -262,7 +262,7 @@ class Command(show_urls.Command):
         # statements_map = access_perm._get_statements(deployment_mode)
         statements= access_perm.get_policy_statements(None, access_policy_viewset)
         statement_template = \
-            "\taction: {action}\n\t\tprincipal: {principal}\n\t\teffect: {effect}\n\t\tconditions:\n{conditions}\n"
+            "\taction: {action}\n\t\tprincipal: {principal}\n\t\teffect: {effect}\n\t\tconditions:\n{conditions}"
 
         # self.stdout.write(f"deployment_mode: {deployment_mode}\n")
 
@@ -285,18 +285,20 @@ class Command(show_urls.Command):
                 conditions = [conditions]
             condition_lines = []
             for cond in conditions:
-                condition_line = f'\t\t\t{cond}\n'
+                condition_line = f'\t\t\t{cond}'
                 condition_lines.append(condition_line)
-            conditions_buf = ''.join(condition_lines)
+            conditions_buf = '\n'.join(condition_lines) or '\t\t\t[]'
             for action in actions:
                 self.stdout.write(statement_template.format(action=action,
                                                             principal=statement['principal'],
                                                             effect=statement['effect'],
                                                             conditions=conditions_buf))
                 # self.stdout.write("\t%s\n" % statement)
+                result = False
                 if user and action not in ('*', 'update', 'destroy'):
                     result = self._has_permission(viewset_info, user, action, viewset_info['url'])
-                    self.stdout.write(f'\t\tresult: {result}\n')
+                self.stdout.write(f'\t\tresult: {result}\n')
+                self.stdout.write('\n')
 
         # group = options['group']
         # for perm in options['permissions']:

--- a/galaxy_ng/app/management/commands/access-policy-views.py
+++ b/galaxy_ng/app/management/commands/access-policy-views.py
@@ -47,34 +47,7 @@ class Command(show_urls.Command):
 
     help = 'Show access_policy viewsets'
 
-    # def valid_group(self, group):
-    #     try:
-    #         return Group.objects.get(name=group)
-    #     except ObjectDoesNotExist:
-    #         raise CommandError(
-    #             'Group {} does not exist. Please provide a valid '
-    #             'group name.'.format(group))
-
-    # def valid_permission(self, permission):
-    #     try:
-    #         app_label, codename = permission.split('.', 1)
-    #     except ValueError:
-    #         raise CommandError(
-    #             "Invalid permission format for {}. "
-    #             "Expecting 'app_label.codename'.".format(permission)
-    #         )
-    #     try:
-    #         return Permission.objects.get(
-    #             content_type__app_label=app_label,
-    #             codename=codename)
-    #     except ObjectDoesNotExist:
-    #         raise CommandError(
-    #             "Permission {} not found. Please provide a valid "
-    #             "permission in the form 'app_label.codename'".format(
-    #                 permission))
-
     def add_arguments(self, parser):
-    #     parser.add_argument('group', type=self.valid_group)
         parser.add_argument(
             '--userid',
             dest='user_id',
@@ -96,7 +69,6 @@ class Command(show_urls.Command):
 
     def _get_user(self, user_id):
         backends = get_backends()
-        # backend = load_backend(backend_path)
         backend = backends[0]
         if isinstance(backend, ModelBackend):
             user = backend.get_user(user_id=user_id)
@@ -126,23 +98,9 @@ class Command(show_urls.Command):
         url_patterns = urlconf.urlpatterns
 
         url_filter = options['url']
-        # if url_filter:
-        #     resolve_match = resolve(url_filter)
-        #     log.debug('rm: %s', resolve_match)
-        #     log.debug('rm.args: %s', resolve_match.args)
-        #     log.debug('matched %s', url_filter)
-        #     urlpat = path(route=resolve_match.route,
-        #                   view=resolve_match.func,
-        #                   kwargs=resolve_match.kwargs,
-        #                   name=resolve_match.url_name)
-        #     url_patterns = [urlpat]
 
-        # log.debug('urlconf:\n%s', pp(urlconf.urlpatterns))
         view_functions = self.extract_views_from_urlpatterns(url_patterns, url_filter=url_filter)
-
         # log.debug('view_functions:\n%s', pp(view_functions))
-
-
 
         for (func, regex, url_name, p, resolved_match) in view_functions:
             if hasattr(func, '__globals__'):
@@ -173,16 +131,8 @@ class Command(show_urls.Command):
             url = simplify_regex(regex)
             decorator = ', '.join(decorators)
 
-            log.debug('p: %s', p)
-            log.debug('resolved_match: %s', resolved_match)
-
             url_filter = options['url']
             url_name_filter = options['urlname']
-            # if url_filter:
-            #     resolve_match = resolve(url_filter)
-            #     log.debug('rm: %s', resolve_match)
-            #     log.debug('rm.args: %s', resolve_match.args)
-            #     log.debug('matched %s', url_filter)
 
             if url_name_filter and url_name_filter != url_name:
                 continue
@@ -216,6 +166,7 @@ class Command(show_urls.Command):
                                   "path_regex": regex,
                                   "decorators": decorator,
                                   "view": func.cls,
+                                  "resolved_match": resolved_match,
                                   "p": p})
 
             # format_style = 'json'
@@ -249,8 +200,7 @@ class Command(show_urls.Command):
         views = []
         if url_filter:
             resolve_match = resolve(url_filter)
-            # log.debug('rm: %s', resolve_match)
-            log.debug('url_filter %s matched resolve_match: %s', url_filter, resolve_match)
+            # log.debug('url_filter %s matched resolve_match: %s', url_filter, resolve_match)
             urlpat = path(route=url_filter,
                           # route=resolve_match.route,
                           view=resolve_match.func,
@@ -258,7 +208,6 @@ class Command(show_urls.Command):
                           name=resolve_match.url_name)
             urlpatterns = [urlpat]
         for p in urlpatterns:
-            # log.debug('PATTERN p: %s type: %s', p, type(p))
             if isinstance(p, (URLPattern, show_urls.RegexURLPattern)):
                 try:
                     if not p.name:
@@ -268,18 +217,11 @@ class Command(show_urls.Command):
                     else:
                         name = p.name
                     pattern = show_urls.describe_pattern(p)
-                    log.debug('PATTERN p: %s', p)
-                    log.debug('p.callback: %s', p.callback)
-                    log.debug('base: %s', base)
-                    log.debug('pattern: %s', pattern)
-                    log.debug('base+pattern: %s', base + pattern)
-                    log.debug('name: %s', name)
+                    # log.debug('PATTERN p: %s', p)
+                    # log.debug('pattern: %s', pattern)
 
                     resolved_match = p.resolve(base + pattern)
                     log.debug('resolved_match: %s', resolved_match)
-
-                    rev_url = reverse(name, kwargs=resolved_match.kwargs)
-                    log.debug('rev_url: %s', rev_url)
 
                     views.append((p.callback, base + pattern, name, p, resolved_match))
                 except ViewDoesNotExist:

--- a/galaxy_ng/app/management/commands/access-policy-views.py
+++ b/galaxy_ng/app/management/commands/access-policy-views.py
@@ -83,11 +83,10 @@ class Command(show_urls.Command):
                 traceback.print_exc()
             raise CommandError("Error occurred while trying to load %s: %s" % (getattr(settings, urlconf), str(e)))
 
-        log.debug('urlconf:\n%s', pp(urlconf.urlpatterns))
+        # log.debug('urlconf:\n%s', pp(urlconf.urlpatterns))
         view_functions = self.extract_views_from_urlpatterns(urlconf.urlpatterns)
-        log.debug('view_functions:\n%s', pp(view_functions))
 
-        access_policy_viewsets = []
+        # log.debug('view_functions:\n%s', pp(view_functions))
 
         for (func, regex, url_name, p) in view_functions:
             if hasattr(func, '__globals__'):
@@ -124,19 +123,17 @@ class Command(show_urls.Command):
                 continue
             if module.startswith('rest_framework'):
                 continue
-            if module.startswith('pulp'):
-                continue
+            # if module.startswith('pulp'):
+            #    continue
             if module.startswith('drf_spectacular'):
                 continue
 
             perms = []
-            # log.debug('func: %s', func)
+
             if hasattr(func, 'cls'):
-                log.debug('dir(%s):\n%s', func.cls, pp(dir(func.cls)))
                 permission_classes = func.cls.permission_classes
                 perms = func.cls.get_permissions(func.cls)
-                if isinstance(perms[0], AccessPolicy):
-                    access_policy_viewsets.append(func.cls)
+                if perms and isinstance(perms[0], AccessPolicy):
                     views.append({"url": url,
                                   "module": module,
                                   "name": url_name,
@@ -164,7 +161,7 @@ class Command(show_urls.Command):
             #         decorator=decorator,
             #     ).strip())
 
-        log.debug('views:\n%s', pp(views))
+        # log.debug('views:\n%s', pp(views))
         for view in views:
             self.show_access_policy(view)
 

--- a/galaxy_ng/app/management/commands/access-policy-views.py
+++ b/galaxy_ng/app/management/commands/access-policy-views.py
@@ -22,7 +22,7 @@ from rest_access_policy import AccessPolicy
 from galaxy_ng.app import access_control
 
 log = logging.getLogger(__name__)
-pp = pprint.pformat
+pf = pprint.pformat
 
 class FauxInnerRequest:
     def __init__(self, user, method, path, *args, **kwargs):
@@ -278,7 +278,9 @@ class Command(show_urls.Command):
         view = access_policy_viewset
         self.stdout.write("%s\n\tviewset: %s\n\turl_name: %s\n" % (viewset_info['url'], viewset_info['module'],
                                                                    viewset_info['name']))
-        self.stdout.write("\taccess_policy: %s\n\n" % (viewset_info['access_policy'],))
+        self.stdout.write("\taccess_policy: %s\n" % (viewset_info['access_policy'],))
+        self.stdout.write("\tkwargs: %s\n" % (viewset_info['resolved_match'].kwargs,))
+        self.stdout.write("\n")
 
         user_id = options['user_id']
         user = self._get_user(user_id)


### PR DESCRIPTION
Very much work in progress.

Currently, mainly adding some management commands for introspect access_policy  ('access-policy-views')
and bits and pieces of sample access policy statements to use  (currently, more or less just the default perms, but
you can:

`http --auth admin:admin GET http://localhost:5001/pulp/api/v3/access_policies/?viewset_name=pulp_container/namespaces`

to get the AccessPolicy for pulp_container/namespaces viewset and it's pulp_href

`http -v --auth admin:admin PATCH http://localhost:5001${ACCESS_POLICY_PULP_HREF}/ @galaxy_ng/app/access_control/plugins/pulp_container/pulp_container_namespaces_viewset.json`

To patch existing policy with the locally store version.

Some related pulpcore / pulpcontainer issues  (not really blockers, but kind of annoying):
- https://pulp.plan.io/issues/8408
- https://pulp.plan.io/issues/8405