### PR TITLE
Hotfix for compose.env load on bash <3 and on a Mac

### DIFF
--- a/compose
+++ b/compose
@@ -4,10 +4,16 @@ set -o nounset
 set -o errexit
 
 if [[ -f '.compose.env' ]]; then
-  set -o allexport
-  # avoid override already set variables
-  source <(grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$|: ${\1=\2}; export \1|g')
-  set +o allexport
+  # export variables from .compose.env but only if the var is not already set.
+
+  # -- The below solution using `source` is good, but is not valid for `source`
+  #    on bash <3 on a Mac.
+  # set -o allexport
+  #source <(grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$|: ${\1=\2}; export \1|g')
+  # set +o allexport
+
+  # This solution using `eval` works on bash <3, >3 and also zsh on Mac and Linux
+  eval "$(grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$| export \1=${\1:-\2} |g' | xargs -L 1)"
 fi
 
 if [[ -z "${COMPOSE_PROFILE:-}" ]]; then


### PR DESCRIPTION
`source` accepts only filenames on bash <3 and on Mac
So this new solution uses `eval` to evaluate the
result of grep and export only env vars from `.compose.env`
that was not already defined on the shell.

This works only on bash >3 and zsh **But doesn't work on a mac, because `source` and `sed` are different on mac bash**

```bash
# avoid override already set variables
source <(grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$|: ${\1=\2}; export \1|g')
```

This works on bash<3 >3, bash and zsh  
```bash
# export vars from .compose.env but only if those vars are not already exported.
eval "$(grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$| export \1=${\1:-\2} |g' | xargs -L 1)"
```

Explained:

- grep `.compose.env` without comment lines
    * `grep -v '^#' .compose.env`
- pass each grepped line to sed
- sed splits KEY=value in two groups `\1 and \2`
   * `| sed -E 's|^(.+)=(.*)$|`
- we use that to build `export KEY=${KEY:-value}`
  * `export \1=${\1:-\2} |g'`
- As sed can't evaluate `${KEY-:default}` we need to pass it to `eval`


ShellChecked

![Screenshot_2021-03-15_19-22-49](https://user-images.githubusercontent.com/458654/111228886-bc590680-85c3-11eb-86da-5bf530d5387d.png)



This is to allow

```bash
./compose   # using vars from .compose.env

DEV_IMAGE_SUFFIX=foo ./compose   # using everything from .compose.env except DEV_IMAGE_SUFFIX
```


No-Issue