### PR TITLE
[hotfix][dev-env] Extra space inside `sed` avoids new line creation.

### DIFF
--- a/compose
+++ b/compose
@@ -5,15 +5,7 @@ set -o errexit
 
 if [[ -f '.compose.env' ]]; then
   # export variables from .compose.env but only if the var is not already set.
-
-  # -- The below solution using `source` is good, but is not valid for `source`
-  #    on bash <3 on a Mac.
-  # set -o allexport
-  #source <(grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$|: ${\1=\2}; export \1|g')
-  # set +o allexport
-
-  # This solution using `eval` works on bash <3, >3 and also zsh on Mac and Linux
-  eval "$(grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$| export \1=${\1:-\2} |g' | xargs -L 1)"
+  eval "$(grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$|export \1=${\1:-\2}|g' | xargs -L 1)"
 fi
 
 if [[ -z "${COMPOSE_PROFILE:-}" ]]; then


### PR DESCRIPTION
reported by @himdel

```diff
- sed -E 's|^(.+)=(.*)$| export \1=${\1:-\2} |g'
+ sed -E 's|^(.+)=(.*)$|export \1=${\1:-\2}|g'
```

```bash
$ grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$| export \1=${\1:-\2} |g' | xargs -L 1
export COMPOSE_PROFILE=${COMPOSE_PROFILE:-standalone} export DEV_SOURCE_PATH=${DEV_SOURCE_PATH:-galaxy_ng} export LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS:-1} export ANSIBLE_HUB_UI_PATH=${ANSIBLE_HUB_UI_PATH:-/home/himdel/ansible-hub-ui}
```
then

```bash
$ grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$|export \1=${\1:-\2}|g' | xargs -L 1 
export COMPOSE_PROFILE=${COMPOSE_PROFILE:-standalone}
export DEV_SOURCE_PATH=${DEV_SOURCE_PATH:-galaxy_ng}
export ANSIBLE_HUB_UI_PATH=${ANSIBLE_HUB_UI_PATH:-/home/rochacbruno/Projects/ansible-hub-ui}
```

No white space inside sed directive to create new lines.

No-Issue