### PR TITLE
compose: print INFO messages to stderr, not stdout

### DIFF
--- a/compose
+++ b/compose
@@ -26,10 +26,10 @@ EOF
   exit 1
 fi
 
-echo "INFO: Using compose profile ${COMPOSE_PROFILE}"
-echo "INFO: ${DEV_SOURCE_PATH:-No} packages installed from source"
-echo "INFO: Image suffix ${DEV_IMAGE_SUFFIX:-is unset}"
-echo "INFO: Volume suffix ${DEV_VOLUME_SUFFIX:-${DEV_IMAGE_SUFFIX:-is unset}}"
+echo "INFO: Using compose profile ${COMPOSE_PROFILE}" >&2
+echo "INFO: ${DEV_SOURCE_PATH:-No} packages installed from source" >&2
+echo "INFO: Image suffix ${DEV_IMAGE_SUFFIX:-is unset}" >&2
+echo "INFO: Volume suffix ${DEV_VOLUME_SUFFIX:-${DEV_IMAGE_SUFFIX:-is unset}}" >&2
 
 compose_args=(
   -f 'dev/docker-compose.yml'


### PR DESCRIPTION
Figured out how to dump the database from a running container...

    ./compose exec postgres pg_dump -U galaxy_ng galaxy_ng -Fc > pg.dump

Except that dump is invalid because it starts with the 4 INFO lines compose outputs.

Since the 5th line is only going to stderr, adding >&2 to the other INFO outputs as well.

Cc @rochacbruno 