### PR TITLE
Add requires_ansible to the collection api endpoints

### DIFF
--- a/CHANGES/409.feature
+++ b/CHANGES/409.feature
@@ -1,0 +1,1 @@
+Add requires_ansible to the collection api endpoints

--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -69,6 +69,7 @@ class CollectionVersionBaseSerializer(Serializer):
     namespace = serializers.CharField()
     name = serializers.CharField()
     version = serializers.CharField()
+    requires_ansible = serializers.CharField()
     created_at = serializers.DateTimeField(source='pulp_created')
     metadata = CollectionMetadataSerializer(source='*')
     contents = serializers.ListField(ContentSerializer())


### PR DESCRIPTION
Field `requires_ansible` is available in the following endpoints:
* /_ui/v1/repo/published/<namespace>/<collection_name>/
* /_ui/v1/repo/published/<namespace>/<collection_name>/?version=<#.#.#>
* /v3/collections/<namespace>/<collection_name>/versions/
* /v3/collections/<namespace>/<collection_name>/versions/<#.#.#>/

Issue: AAH-409