### PR TITLE
Fix groups endpoint viewable only by admin

### DIFF
--- a/CHANGES/453.bugfix
+++ b/CHANGES/453.bugfix
@@ -1,0 +1,1 @@
+Fix groups endpoint viewable only by admin

--- a/galaxy_ng/app/api/ui/viewsets/group.py
+++ b/galaxy_ng/app/api/ui/viewsets/group.py
@@ -29,6 +29,12 @@ class GroupViewSet(LocalSettingsMixin, viewsets.GroupViewSet):
     filterset_class = GroupFilter
     permission_classes = [access_policy.GroupAccessPolicy]
 
+    # TODO(awcrosby): replace this by setting attribute to None
+    # after https://pulp.plan.io/issues/8438 is resolved
+    def _remove_attr(self):
+        raise AttributeError
+    queryset_filtering_required_permission = property(_remove_attr)
+
     @transaction.atomic
     def create(self, request, *args, **kwargs):
         name = request.data['name']


### PR DESCRIPTION
pulpcore 3.10.0 introduced [queryset_filtering_required_permission](https://github.com/pulp/pulpcore/blob/master/pulpcore/app/viewsets/user.py#L109)
attribute to GroupViewSet with a permission not used by galaxy_ng.

Currently it can not be overridden simply by setting to None,
so the attribute is removed from the subclass.

Issue: AAH-453