### PR TITLE
Deactivate Unpaginated Sync Endpoints

### DIFF
--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -31,17 +31,22 @@ sync_urls = [
 ]
 
 urlpatterns = [
-    path("", viewsets.RepoMetadataViewSet.as_view({"get": "retrieve"}), name="repo-metadata"),
-    path(
-        'collections/all/',
-        viewsets.UnpaginatedCollectionViewSet.as_view({'get': 'list'}),
-        name='all-collections-list'
-    ),
-    path(
-        'collection_versions/all/',
-        viewsets.UnpaginatedCollectionVersionViewSet.as_view({"get": "list"}),
-        name="all-collection-versions-list"
-    ),
+
+    # The following endpoints are related to issue https://issues.redhat.com/browse/AAH-224
+    # For now endpoints are temporary deactivated until the issue is resolved.
+    #
+    # path("", viewsets.RepoMetadataViewSet.as_view({"get": "retrieve"}), name="repo-metadata"),
+    # path(
+    #     'collections/all/',
+    #     viewsets.UnpaginatedCollectionViewSet.as_view({'get': 'list'}),
+    #     name='all-collections-list'
+    # ),
+    # path(
+    #     'collection_versions/all/',
+    #     viewsets.UnpaginatedCollectionVersionViewSet.as_view({"get": "list"}),
+    #     name="all-collection-versions-list"
+    # ),
+
     path(
         'collections/',
         viewsets.CollectionViewSet.as_view({'get': 'list'}),

--- a/galaxy_ng/tests/unit/api/test_api_v3_collections.py
+++ b/galaxy_ng/tests/unit/api/test_api_v3_collections.py
@@ -1,3 +1,4 @@
+from unittest.case import skip
 from django.urls.base import reverse
 from galaxy_ng.app.constants import DeploymentMode
 from django.test.utils import override_settings
@@ -100,27 +101,28 @@ class TestCollectionViewsets(BaseTestCase):
             }
         )
 
+        # The following URLS are temporary deatived due to https://issues.redhat.com/browse/AAH-224
         # metadata urls
-        self.all_collections_url = reverse(
-            'galaxy:api:content:v3:all-collections-list',
-            kwargs={
-                'path': self.repo.name,
-            }
-        )
+        # self.all_collections_url = reverse(
+        #     'galaxy:api:content:v3:all-collections-list',
+        #     kwargs={
+        #         'path': self.repo.name,
+        #     }
+        # )
 
-        self.all_versions_url = reverse(
-            'galaxy:api:content:v3:all-collection-versions-list',
-            kwargs={
-                'path': self.repo.name,
-            }
-        )
+        # self.all_versions_url = reverse(
+        #     'galaxy:api:content:v3:all-collection-versions-list',
+        #     kwargs={
+        #         'path': self.repo.name,
+        #     }
+        # )
 
-        self.metadata_url = reverse(
-            'galaxy:api:content:v3:repo-metadata',
-            kwargs={
-                'path': self.repo.name,
-            }
-        )
+        # self.metadata_url = reverse(
+        #     'galaxy:api:content:v3:repo-metadata',
+        #     kwargs={
+        #         'path': self.repo.name,
+        #     }
+        # )
 
         # used for href tests
         self.pulp_href_fragment = "pulp_ansible/galaxy"
@@ -144,6 +146,7 @@ class TestCollectionViewsets(BaseTestCase):
             self.pulp_href_fragment, response.data["data"][0]["highest_version"]["href"]
         )
 
+    @skip("https://issues.redhat.com/browse/AAH-224")
     def test_unpaginated_collections_list(self):
         """Assert the call to v3/collections/all returns correct
         collections and versions


### PR DESCRIPTION
Endpoints are deactivated temporaty until
https://issues.redhat.com/browse/AAH-224 is resolved.

No-Issue