### PR TITLE
urls: allow dashes in container names

### DIFF
--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -60,12 +60,12 @@ container_paths = [
     # under _content prevents cases where an image could be named foo/images
     # and conflict with our URL paths.
     re_path(
-        r'repositories/(?P<base_path>\w+\/{0,1}\w+)/_content/',
+        r'repositories/(?P<base_path>[-\w]+\/{0,1}[-\w]+)/_content/',
         include(container_repo_paths)),
 
     # This regex can capture "namespace/name" and "name"
     re_path(
-        r'repositories/(?P<base_path>\w+\/{0,1}\w+)/',
+        r'repositories/(?P<base_path>[-\w]+\/{0,1}[-\w]+)/',
         viewsets.ContainerRepositoryViewSet.as_view({'get': 'retrieve', 'put': 'update'}),
         name='container-repository-detail'),
 ]


### PR DESCRIPTION
When a container contains a dash...

    docker pull hello-world
    docker image tag hello-world localhost:5001/hello-world
    docker push localhost:5001/hello-world
    docker image tag hello-world localhost:5001/whatever/hello-world
    docker push localhost:5001/whatever/hello-world

the api request for `GET /api/automation-hub/_ui/v1/execution-environments/repositories/whatever/hello-world/` (or just `...repositories/hello-world/`)
returns a 404, because no route matches

Changing `\w+` to `[-\w]+` to allow dashes.

No-Issue

Cc @newswangerd , @ZitaNemeckova 

This is a follow-up to https://github.com/ansible/galaxy_ng/pull/658, to allow for dashes in container names. (Such as https://hub.docker.com/_/hello-world ).

(Docker allows to push to `hello-world/hello-world` as well, so added the dash to both the namespace and the name, but maybe that's not desired?)

(Also noticed a separate issue, if I already have an arista container, pushing to arista/whatever returns a Bad Request, and docker push just keeps retrying.)