### PR TITLE
Expose /pulp/api/v3/status in openapi as used by pulp squeezer

### DIFF
--- a/CHANGES/482.bugfix
+++ b/CHANGES/482.bugfix
@@ -1,0 +1,1 @@
+Expose pulp API in generated openapi spec.

--- a/galaxy_ng/app/common/openapi.py
+++ b/galaxy_ng/app/common/openapi.py
@@ -24,10 +24,10 @@ def preprocess_debug_logger(endpoints, **kwargs):
 def preprocess_exclude_endpoints(endpoints, **kwargs):
     """Return an iterable of (path, path_regex, method, callback) with some endpoints removed
 
-    For example, the default is to to remove '/pulp' and '/_ui/' api endpoints.
+    For example, the default is to to remove '/pulp' and '/_ui/' api endpoints, while
+    allowing /pulp/api/v3/status endpoint and all automation-hub v3 endpoints.
     """
-
     return [
         (path, path_regex, method, callback) for path, path_regex, method, callback in endpoints
-        if not path.startswith('/pulp') and '/_ui/' not in path
+        if path == '/pulp/api/v3/status/' or (not path.startswith('/pulp') and '/_ui/' not in path)
     ]

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -95,8 +95,6 @@ SPECTACULAR_SETTINGS = {
         "name": "GPLv2+",
         "url": "https://raw.githubusercontent.com/ansible/galaxy_ng/master/LICENSE",
     },
-    'PREPROCESSING_HOOKS': ['galaxy_ng.app.common.openapi.preprocess_exclude_endpoints',
-                            'galaxy_ng.app.common.openapi.preprocess_debug_logger'],
     "COMPONENT_SPLIT_REQUEST": True,
     "dynaconf_merge": True,
 }


### PR DESCRIPTION
Without it, some of the playbooks that depend on the
https://github.com/ansible/galaxy_collection
collection will fail.

Issue: AAH-482