### PR TITLE
Update stable-4.2 branch to use Django 2.2.20  (AAH-489)

### DIFF
--- a/CHANGES/489.bugfix
+++ b/CHANGES/489.bugfix
@@ -1,0 +1,1 @@
+Update Django to 2.2.20

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -32,7 +32,7 @@ django-guardian==2.3.0    # via pulpcore
 django-import-export==2.3.0  # via pulpcore
 django-lifecycle==0.7.7   # via pulpcore
 django-prometheus==2.1.0  # via galaxy-ng (setup.py)
-django==2.2.18            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django==2.2.20            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
 djangorestframework==3.11.2  # via drf-nested-routers, drf-spectacular, pulpcore
 drf-access-policy==0.7.0  # via pulpcore

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -35,7 +35,7 @@ django-import-export==2.3.0  # via pulpcore
 django-lifecycle==0.7.7   # via pulpcore
 django-prometheus==2.1.0  # via galaxy-ng (setup.py)
 django-storages[boto3]==1.10.1  # via -r requirements/requirements.insights.in
-django==2.2.18            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, django-storages, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django==2.2.20            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, django-storages, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
 djangorestframework==3.11.2  # via drf-nested-routers, drf-spectacular, pulpcore
 drf-access-policy==0.7.0  # via pulpcore

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -32,7 +32,7 @@ django-guardian==2.3.0    # via pulpcore
 django-import-export==2.3.0  # via pulpcore
 django-lifecycle==0.7.7   # via pulpcore
 django-prometheus==2.1.0  # via galaxy-ng (setup.py)
-django==2.2.18            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
+django==2.2.20            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
 djangorestframework==3.11.2  # via drf-nested-routers, drf-spectacular, pulpcore
 drf-access-policy==0.7.0  # via pulpcore

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ class BuildPyCommand(_BuildPyCommand):
 
 
 requirements = [
-    "Django~=2.2.18",
+    "Django~=2.2.20",
     "galaxy-importer==0.2.15",
     "pulpcore>=3.7,<3.9",
     "pulp-ansible==0.5.8",


### PR DESCRIPTION
Issue: AAH-489

But only Django, and not any deps updated by pip-compile.
Opening as new PR to compare CI results.

See https://github.com/ansible/galaxy_ng/pull/713  for full 'make requirements' diff.