### PR TITLE
Replace PULP_REDIS* env variables with PULP_REDIS_URL env variable

### DIFF
--- a/CHANGES/486.bugfix
+++ b/CHANGES/486.bugfix
@@ -1,0 +1,1 @@
+Replace current PULP_REDIS* env variables with PULP_REDIS_URL env variable to accommodate PULP_REDIS_SSL.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -97,7 +97,19 @@ run_manage() {
 
 
 redis_connection_hack() {
-    PULP_REDIS_URL="rediss://${PULP_REDIS_PASSWORD}@${PULP_REDIS_HOST:-localhost}:${PULP_REDIS_PORT:-6379}/0"
+    if [[ "$PULP_REDIS_SSL" == "true" ]]; then
+        protocol="rediss://"
+    else
+        protocol="redis://"
+    fi
+
+    if [[ -z "$PULP_REDIS_PASSWORD" ]]; then
+        password=""
+    else
+        password=":${PULP_REDIS_PASSWORD}@"
+    fi
+
+    PULP_REDIS_URL="${protocol}${password}${PULP_REDIS_HOST:-localhost}:${PULP_REDIS_PORT:-6379}/0"
     unset PULP_REDIS_HOST PULP_REDIS_PORT PULP_REDIS_PASSWORD
     export PULP_REDIS_URL
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -96,10 +96,19 @@ run_manage() {
 }
 
 
+redis_connection_hack() {
+    PULP_REDIS_URL="rediss://${PULP_REDIS_PASSWORD}@${PULP_REDIS_HOST:-localhost}:${PULP_REDIS_PORT:-6379}/0"
+    unset PULP_REDIS_HOST PULP_REDIS_PORT PULP_REDIS_PASSWORD
+    export PULP_REDIS_URL
+}
+
 main() {
     if [[ "$#" -eq 0 ]]; then
         exec "/bin/bash"
     fi
+
+    # TODO: remove once Pulp recognizes REDIS_SSL parameter when building settings for RQ in pulpcore/rqconfig.py
+    redis_connection_hack
 
     case "$1" in
         'run')


### PR DESCRIPTION
This change should be removed once Pulp recognizes REDIS_SSL parameter when building settings for RQ in `pulpcore/rqconfig.py`

Issue: AAH-486