### PR TITLE
Content Sync Performance changed to /metadata/ endpoint

### DIFF
--- a/CHANGES/224.feature
+++ b/CHANGES/224.feature
@@ -1,1 +1,0 @@
-Add unpaginated collections, collectionversions and metadata endopints for better sync performance.

--- a/CHANGES/224.misc
+++ b/CHANGES/224.misc
@@ -1,0 +1,1 @@
+Replaced Unpaginated endpoints with higher pagination limit

--- a/galaxy_ng/app/api/v3/serializers/__init__.py
+++ b/galaxy_ng/app/api/v3/serializers/__init__.py
@@ -3,7 +3,7 @@ from .collection import (
     CollectionVersionSerializer,
     CollectionVersionListSerializer,
     CollectionUploadSerializer,
-    UnpaginatedCollectionVersionSerializer,
+    MetadataCollectionSerializer,
 )
 
 from .namespace import (
@@ -31,5 +31,5 @@ __all__ = (
     'NamespaceSummarySerializer',
     'TaskSerializer',
     'TaskSummarySerializer',
-    'UnpaginatedCollectionVersionSerializer',
+    'MetadataCollectionSerializer',
 )

--- a/galaxy_ng/app/api/v3/serializers/collection.py
+++ b/galaxy_ng/app/api/v3/serializers/collection.py
@@ -86,6 +86,8 @@ class CollectionVersionListSerializer(_CollectionVersionListSerializer, HrefName
 class MetadataCollectionVersionSerializer(_MetadataCollectionVersionSerializer,
                                           HrefNamespaceMixin):
 
+    collection = CollectionRefSerializer(read_only=True)
+
     class Meta(_MetadataCollectionVersionSerializer.Meta):
         ref_name = "MetadataCollectionVersionWithFixedHrefsSerializer"
 
@@ -131,6 +133,7 @@ class CollectionVersionSerializer(_CollectionVersionSerializer, HrefNamespaceMix
 
     class Meta(_CollectionVersionSerializer.Meta):
         ref_name = "CollectionVersionWithDownloadUrlSerializer"
+        fields = _CollectionVersionSerializer.Meta.fields + ("collection",)
 
     def get_download_url(self, obj):
         """

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -35,7 +35,7 @@ urlpatterns = [
     path(
         'collections/metadata/',
         viewsets.MetadataCollectionViewSet.as_view({'get': 'list'}),
-        name='metadata-collections-list'
+        name='metadata-collection-list'
     ),
     path(
         'collections/',

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -31,22 +31,12 @@ sync_urls = [
 ]
 
 urlpatterns = [
-
-    # The following endpoints are related to issue https://issues.redhat.com/browse/AAH-224
-    # For now endpoints are temporary deactivated until the issue is resolved.
-    #
-    # path("", viewsets.RepoMetadataViewSet.as_view({"get": "retrieve"}), name="repo-metadata"),
-    # path(
-    #     'collections/all/',
-    #     viewsets.UnpaginatedCollectionViewSet.as_view({'get': 'list'}),
-    #     name='all-collections-list'
-    # ),
-    # path(
-    #     'collection_versions/all/',
-    #     viewsets.UnpaginatedCollectionVersionViewSet.as_view({"get": "list"}),
-    #     name="all-collection-versions-list"
-    # ),
-
+    path("", viewsets.RepoMetadataViewSet.as_view({"get": "retrieve"}), name="repo-metadata"),
+    path(
+        'collections/metadata/',
+        viewsets.MetadataCollectionViewSet.as_view({'get': 'list'}),
+        name='metadata-collections-list'
+    ),
     path(
         'collections/',
         viewsets.CollectionViewSet.as_view({'get': 'list'}),

--- a/galaxy_ng/app/api/v3/viewsets/__init__.py
+++ b/galaxy_ng/app/api/v3/viewsets/__init__.py
@@ -6,8 +6,7 @@ from .collection import (
     CollectionVersionViewSet,
     CollectionVersionDocsViewSet,
     CollectionVersionMoveViewSet,
-    UnpaginatedCollectionViewSet,
-    UnpaginatedCollectionVersionViewSet,
+    MetadataCollectionViewSet,
     RepoMetadataViewSet,
 )
 
@@ -33,7 +32,6 @@ __all__ = (
     'NamespaceViewSet',
     'SyncConfigViewSet',
     'TaskViewSet',
-    'UnpaginatedCollectionViewSet',
-    'UnpaginatedCollectionVersionViewSet',
+    'MetadataCollectionViewSet',
     'RepoMetadataViewSet',
 )

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -27,7 +27,7 @@ from galaxy_ng.app.access_control import access_policy
 from galaxy_ng.app.api.v3.serializers import (
     CollectionSerializer,
     CollectionVersionSerializer,
-    UnpaginatedCollectionVersionSerializer,
+    MetadataCollectionSerializer,
     CollectionVersionListSerializer,
     CollectionUploadSerializer,
 )
@@ -72,12 +72,11 @@ class RepoMetadataViewSet(api_base.LocalSettingsMixin,
     permission_classes = [access_policy.CollectionAccessPolicy]
 
 
-class UnpaginatedCollectionViewSet(api_base.LocalSettingsMixin,
-                                   ViewNamespaceSerializerContextMixin,
-                                   pulp_ansible_views.UnpaginatedCollectionViewSet):
-    pagination_class = None
+class MetadataCollectionViewSet(api_base.LocalSettingsMixin,
+                                ViewNamespaceSerializerContextMixin,
+                                pulp_ansible_views.MetadataCollectionViewSet):
     permission_classes = [access_policy.CollectionAccessPolicy]
-    serializer_class = CollectionSerializer
+    serializer_class = MetadataCollectionSerializer
 
 
 class CollectionViewSet(api_base.LocalSettingsMixin,
@@ -85,14 +84,6 @@ class CollectionViewSet(api_base.LocalSettingsMixin,
                         pulp_ansible_views.CollectionViewSet):
     permission_classes = [access_policy.CollectionAccessPolicy]
     serializer_class = CollectionSerializer
-
-
-class UnpaginatedCollectionVersionViewSet(api_base.LocalSettingsMixin,
-                                          ViewNamespaceSerializerContextMixin,
-                                          pulp_ansible_views.UnpaginatedCollectionVersionViewSet):
-    pagination_class = None
-    serializer_class = UnpaginatedCollectionVersionSerializer
-    permission_classes = [access_policy.CollectionAccessPolicy]
 
 
 class CollectionVersionViewSet(api_base.LocalSettingsMixin,

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -16,7 +16,7 @@ from rest_framework.exceptions import APIException, NotFound
 from pulpcore.plugin.models import Task
 from pulpcore.plugin.tasking import enqueue_with_reservation
 from pulp_ansible.app.galaxy.v3 import views as pulp_ansible_views
-from pulp_ansible.app.models import CollectionVersion, AnsibleDistribution
+from pulp_ansible.app.models import Collection, CollectionVersion, AnsibleDistribution
 from pulp_ansible.app.models import CollectionImport as PulpCollectionImport
 from galaxy_ng.app.api import base as api_base
 
@@ -77,7 +77,7 @@ class MetadataCollectionViewSet(api_base.LocalSettingsMixin,
                                 pulp_ansible_views.MetadataCollectionViewSet):
     permission_classes = [access_policy.CollectionAccessPolicy]
     serializer_class = MetadataCollectionSerializer
-
+    queryset = Collection.objects.prefetch_related('versions')
 
 class CollectionViewSet(api_base.LocalSettingsMixin,
                         ViewNamespaceSerializerContextMixin,

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -16,7 +16,8 @@ from rest_framework.exceptions import APIException, NotFound
 from pulpcore.plugin.models import Task
 from pulpcore.plugin.tasking import enqueue_with_reservation
 from pulp_ansible.app.galaxy.v3 import views as pulp_ansible_views
-from pulp_ansible.app.models import Collection, CollectionVersion, AnsibleDistribution
+from pulp_ansible.app.galaxy.v3 import pagination as pulp_pagination
+from pulp_ansible.app.models import CollectionVersion, AnsibleDistribution
 from pulp_ansible.app.models import CollectionImport as PulpCollectionImport
 from galaxy_ng.app.api import base as api_base
 
@@ -77,7 +78,8 @@ class MetadataCollectionViewSet(api_base.LocalSettingsMixin,
                                 pulp_ansible_views.MetadataCollectionViewSet):
     permission_classes = [access_policy.CollectionAccessPolicy]
     serializer_class = MetadataCollectionSerializer
-    queryset = Collection.objects.prefetch_related('versions')
+    pagination_class = pulp_pagination.OptimizedLimitOffsetPagination
+
 
 class CollectionViewSet(api_base.LocalSettingsMixin,
                         ViewNamespaceSerializerContextMixin,


### PR DESCRIPTION
- Removed `Unpaginated` endpoints
- Unified Collections and its Versions metadata in a single `/metadata/`
  endpoint
- Customized href generation for those endpoints

output example: https://gist.github.com/rochacbruno/df9c1c3e2653d1e9592cd8f650de2239

Requires PR: https://github.com/pulp/pulp_ansible/pull/558 (CI will not pass until this PR is merged on pulp_ansible)
Issue: AAH-224