### PR TITLE
Fix apache snippet

### DIFF
--- a/galaxy_ng/app/webserver_snippets/apache.conf
+++ b/galaxy_ng/app/webserver_snippets/apache.conf
@@ -1,9 +1,9 @@
 RewriteEngine  on
 RewriteCond "%{REQUEST_FILENAME}"       !-f
 RewriteCond "%{REQUEST_FILENAME}"       !-d
-RewriteRule "^/ui*" "http://${pulp-api}/static/galaxy_ng/index.html" [P]
-ProxyPass "/ui/" "http://${pulp-api}/static/galaxy_ng/index.html"
-ProxyPassReverse "/ui/" "http://${pulp-api}/static/galaxy_ng/index.html"
+RewriteRule "^/ui*" "${pulp-api}/static/galaxy_ng/index.html" [P]
+ProxyPass "/ui/" "${pulp-api}/static/galaxy_ng/index.html"
+ProxyPassReverse "/ui/" "${pulp-api}/static/galaxy_ng/index.html"
 
 # WARNING: This is a workaround. It must be removed once
 #          RBAC policies are configured for pulp_ansible and pulpcore APIs.


### PR DESCRIPTION
scheme is handled by pulp_installer,
${pulp-api} already includes http or https

https://github.com/pulp/pulp_installer/blob/master/roles/pulp_webserver/templates/pulp-vhost.conf.j2#L1-L2
https://github.com/pulp/pulp_installer/blob/master/roles/pulp_webserver/vars/main.yml#L3-L4

related to https://pulp.plan.io/issues/8130