### PR TITLE
dev/Dockerfile.base: install python deps as galaxy user, don't chown after

### DIFF
--- a/dev/Dockerfile.base
+++ b/dev/Dockerfile.base
@@ -42,7 +42,12 @@ RUN set -ex; \
     && rm -rf /var/cache/dnf/ \
     && rm -f /var/lib/rpm/__db.* \
     \
-    && python3 -m venv /venv
+    && mkdir /venv \
+    && chown ${USER_NAME}:${USER_GROUP} /venv
+
+USER ${USER_NAME}:${USER_GROUP}
+RUN set -ex; \
+    python3 -m venv /venv
 
 ENV PATH="/venv/bin:${PATH}" \
     VIRTUAL_ENV="/venv"
@@ -55,14 +60,17 @@ RUN set -ex; \
     pip install --no-cache-dir --requirement /tmp/requirements.txt; fi
 
 # Install application
-COPY . /app
+COPY --chown=${USER_NAME}:${USER_GROUP} . /app
 
 # When LOCK_REQUIREMENTS is disabled avoid running collectstatic here
 # on that case developer should run collectstatic manually
 RUN set -ex; \
     pip install --no-cache-dir --editable /app \
-    && pip install -r /app/requirements/requirements.dev.txt \
-    && if [[ "${LOCK_REQUIREMENTS}" -eq "1" ]]; then \
+    && pip install -r /app/requirements/requirements.dev.txt
+
+USER root:root
+RUN set -ex; \
+    if [[ "${LOCK_REQUIREMENTS}" -eq "1" ]]; then \
     PULP_CONTENT_ORIGIN=x django-admin collectstatic; fi
 
 # Finalize installation
@@ -73,8 +81,6 @@ RUN set -ex; \
              /etc/ansible \
              /entrypoints.d \
     && chown -R ${USER_NAME}:${USER_GROUP} \
-        /app \
-        /venv \
         /var/lib/pulp \
         /tmp/ansible \
         /etc/ansible \


### PR DESCRIPTION
In the dev docker environment, `compose build` takes ages, on the `chown -R ...` step.
That's because we have to chown every single python dependency that we just downloaded as root, fixing that.

Before:

	(root) python -m venv /venv	# creates and populates a venv
	(root) pip install ...		# installs deps in there
	(root) chown -R galaxy /venv	# changes owner of all these files

After:

	(root) mkdir /venv
	(root) chown galaxy /venv	# while still empty
	(galaxy) python -m venv /venv
	(galaxy) pip install		# no chown for these
	

We can also skip chowning `/app`, using `COPY --chown` instead.

`django-admin collectstatic` needs to run as root however (fails on `/var/lib/pulp` access otherwise),
and keeping the final chown for the rest of the files.

No-Issue

---

Running the original version except with `chown -c | wc -l` and `time`, and comparing with this PR...

| version | files chowned | time chown | total build time |
|-|-|-|-|
| master | 70866 | 53m53.118s | 54m41.144s |
| this PR | 197 | 0m7.687s | 5m14.362s |