### PR TITLE
Add ModelAdmin objects for galaxy_ng

### DIFF
--- a/.travis/check_pulpcore_imports.sh
+++ b/.travis/check_pulpcore_imports.sh
@@ -13,6 +13,7 @@ set -uv
 MATCHES=$(grep -n -r --include \*.py "from pulpcore.*import" . \
     | grep -v "tests\|plugin" \
     | grep -v "pulpcore.app.*viewsets" \
+    | grep -v "galaxy_ng/app/admin" \
     | grep -v "pulpcore\.app.*admin" \
     | grep -v "ProgressReportSerializer")
 

--- a/CHANGES/32.feature
+++ b/CHANGES/32.feature
@@ -1,0 +1,1 @@
+Add django admin AdminModels for most models

--- a/galaxy_ng/app/admin/__init__.py
+++ b/galaxy_ng/app/admin/__init__.py
@@ -1,0 +1,23 @@
+from . import admin
+from . import base
+from . import content_type
+from . import galaxy
+from . import guardian
+from . import permission
+from . import pulpcore
+from . import pulp_ansible
+from . import pulp_container
+from . import sessions
+
+__all__ = (
+    'admin',
+    'base',
+    'content_type',
+    'galaxy',
+    'guardian',
+    'permission',
+    'pulpcore',
+    'pulp_ansible',
+    'pulp_container',
+    'sessions',
+)

--- a/galaxy_ng/app/admin/admin.py
+++ b/galaxy_ng/app/admin/admin.py
@@ -1,0 +1,19 @@
+from django.contrib import admin
+
+from django.contrib.admin.models import LogEntry
+
+
+@admin.register(LogEntry)
+class LogEntryAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'action_time',
+        'user',
+        'content_type',
+        'object_id',
+        'object_repr',
+        'action_flag',
+        'change_message',
+    )
+    list_filter = ('action_time',)
+    raw_id_fields = ('user', 'content_type')

--- a/galaxy_ng/app/admin/base.py
+++ b/galaxy_ng/app/admin/base.py
@@ -1,0 +1,26 @@
+
+import logging
+
+from guardian.admin import GuardedModelAdmin
+
+log = logging.getLogger(__name__)
+
+
+class BaseModelAdmin(GuardedModelAdmin):
+    pass
+
+
+class PulpModelAdmin(BaseModelAdmin):
+    pulp_readonly_fields = ("pulp_id", "pulp_created", "pulp_last_updated")
+    pulp_fields = ("pulp_id", "pulp_created", "pulp_last_updated")
+
+    def get_readonly_fields(self, request, obj=None):
+        res = self.pulp_readonly_fields
+        return res
+    #     res = self.pulp_readonly_fields + tuple(super().get_readonly_fields(request, obj))
+    #     if read_only:
+    #         res += self.get_fields(request, obj)
+    #     return res
+
+    def get_fields(self, request, obj=None):
+        return self.pulp_fields + tuple(super().get_fields(request, obj))

--- a/galaxy_ng/app/admin/content_type.py
+++ b/galaxy_ng/app/admin/content_type.py
@@ -1,0 +1,11 @@
+
+from django.contrib import admin
+from django.contrib.contenttypes.models import ContentType
+
+from .base import BaseModelAdmin
+
+
+# ContentType is not a Pulp model, so no pulp_id etc, use BaseModelAdmin
+@admin.register(ContentType)
+class ContentTypeAdmin(BaseModelAdmin):
+    list_display = ("id", "app_label", "model")

--- a/galaxy_ng/app/admin/galaxy.py
+++ b/galaxy_ng/app/admin/galaxy.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+from django.contrib import admin
+from django.contrib.auth.hashers import make_password, check_password
+from django.urls import reverse
+from django.utils.html import format_html
+
+from .base import BaseModelAdmin
+
+from galaxy_ng.app.models import (
+    User,
+    Group,
+    Namespace,
+    NamespaceLink,
+    CollectionImport,
+    SyncList,
+    CollectionSyncTask,
+    ContainerDistribution,
+    ContainerDistroReadme,
+    ContainerRegistryRemote,
+    ContainerRegistryRepos,
+    ContainerNamespace,
+    ContainerSyncTask,
+)
+
+
+@admin.register(ContainerDistribution)
+class ContainerDistributionAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'name',
+        'base_path',
+        'content_guard',
+        'remote',
+        'basedistribution_ptr',
+        'repository',
+        'repository_version',
+        'namespace',
+        'private',
+        'description',
+    )
+    list_filter = (
+        'pulp_created',
+        'pulp_last_updated',
+        'content_guard',
+        'remote',
+        'basedistribution_ptr',
+        'repository',
+        'repository_version',
+        'namespace',
+        'private',
+    )
+    search_fields = ('name',)
+
+
+@admin.register(ContainerNamespace)
+class ContainerNamespaceAdmin(admin.ModelAdmin):
+    list_display = ('pulp_id', 'pulp_created', 'pulp_last_updated', 'name')
+    list_filter = ('pulp_created', 'pulp_last_updated')
+    search_fields = ('name',)
+
+
+@admin.register(ContainerDistroReadme)
+class ContainerDistroReadmeAdmin(admin.ModelAdmin):
+    list_display = ('container', 'created', 'updated', 'text')
+    list_filter = ('container', 'created', 'updated')
+
+
+@admin.register(ContainerRegistryRemote)
+class ContainerRegistryRemoteAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'name',
+        'url',
+        'ca_cert',
+        'client_cert',
+        'client_key',
+        'tls_validation',
+        'username',
+        'password',
+        'proxy_url',
+        'proxy_username',
+        'proxy_password',
+        'download_concurrency',
+        'policy',
+        'total_timeout',
+        'connect_timeout',
+        'sock_connect_timeout',
+        'sock_read_timeout',
+        'headers',
+        'rate_limit',
+    )
+    list_filter = ('pulp_created', 'pulp_last_updated', 'tls_validation')
+    search_fields = ('name',)
+
+
+@admin.register(ContainerRegistryRepos)
+class ContainerRegistryReposAdmin(admin.ModelAdmin):
+    list_display = ('registry', 'repository_remote')
+    list_filter = ('registry', 'repository_remote')
+
+
+@admin.register(ContainerSyncTask)
+class ContainerSyncTaskAdmin(admin.ModelAdmin):
+    list_display = ('id', 'repository', 'task')
+    list_filter = ('repository', 'task')
+
+
+@admin.register(User)
+class UserAdmin(BaseModelAdmin):
+    list_display = (
+        'id',
+        'password',
+        'last_login',
+        'is_superuser',
+        'username',
+        'first_name',
+        'last_name',
+        'email',
+        'is_staff',
+        'is_active',
+        'date_joined',
+    )
+    list_filter = (
+        'last_login',
+        'is_superuser',
+        'is_staff',
+        'is_active',
+        'date_joined',
+    )
+    raw_id_fields = ('groups', 'user_permissions')
+
+    def save_model(self, request, obj, form, change):
+        user_database = User.objects.get(pk=obj.pk)
+        # Check firs the case in which the password is not encoded,
+        # then check in the case that the password is encode
+        if not (check_password(form.data['password'], user_database.password)
+                or user_database.password == form.data['password']):
+            obj.password = make_password(obj.password)
+        else:
+            obj.password = user_database.password
+        super().save_model(request, obj, form, change)
+
+
+@admin.register(Group)
+class GroupAdmin(BaseModelAdmin):
+    list_display = ('id', 'name')
+    search_fields = ('name',)
+
+
+@admin.register(Namespace)
+class NamespaceAdmin(BaseModelAdmin):
+    list_display = (
+        'id',
+        'name',
+        'company',
+        'email',
+        'avatar_url',
+        'description',
+        'resources',
+    )
+    search_fields = ['name', 'company', 'email']
+
+
+@admin.register(NamespaceLink)
+class NamespaceLinkAdmin(BaseModelAdmin):
+    list_display = ('id', 'name', 'url', 'namespace')
+    list_filter = ('namespace',)
+    search_fields = ['namespace__name', 'namespace__company', 'name', 'url']
+
+
+@admin.register(CollectionImport)
+class CollectionImportAdmin(BaseModelAdmin):
+    list_display = ('label_and_version', 'task_id', 'created_at', 'label',
+                    'namespace', 'name', 'version')
+    list_display_links = ('label_and_version', 'task_id', 'created_at')
+    list_filter = ('created_at', 'namespace')
+    raw_fields = ('namespace', 'name', 'version', 'task_id', 'created_at')
+    read_only_fields = ('namespace', 'name', 'version', 'task_id', 'created_at')
+    search_fields = ('name', 'namespace')
+    date_hierarchy = 'created_at'
+
+
+@admin.register(CollectionSyncTask)
+class CollectionSyncTaskAdmin(BaseModelAdmin):
+    pass
+
+
+class SyncListCollectionsInline(admin.StackedInline):
+    model = SyncList.collections.through
+
+
+class SyncListNamespacesInline(admin.StackedInline):
+    model = SyncList.namespaces.through
+
+
+@admin.register(SyncList)
+class SyncListAdmin(BaseModelAdmin):
+    list_display = ('id', 'name', 'policy', 'view_repository_link', 'view_upstream_repository_link')
+    list_display_links = ('id', 'name', 'policy',
+                          'view_repository_link', 'view_upstream_repository_link')
+    search_fields = ('name',)
+
+    def view_repository_link(self, obj):
+        url = reverse("admin:ansible_ansiblerepository_change", args=(obj.repository.pulp_id,))
+        return format_html('<a href="{}">{}</a>', url, obj.repository)
+    view_repository_link.short_description = "Repository"
+
+    def view_upstream_repository_link(self, obj):
+        url = reverse("admin:ansible_ansiblerepository_change",
+                      args=(obj.upstream_repository.pulp_id,))
+        return format_html('<a href="{}">{}</a>', url, obj.repository)
+    view_repository_link.short_description = "Upstream Rep"

--- a/galaxy_ng/app/admin/guardian.py
+++ b/galaxy_ng/app/admin/guardian.py
@@ -1,0 +1,18 @@
+from django.contrib import admin
+
+from guardian.models.models import (
+    GroupObjectPermission,
+    UserObjectPermission,
+)
+
+
+@admin.register(UserObjectPermission)
+class UserObjectPermissionAdmin(admin.ModelAdmin):
+    list_display = ("id", "permission", "content_type", "object_pk", "user")
+    list_filter = ("permission", "content_type", "user")
+
+
+@admin.register(GroupObjectPermission)
+class GroupObjectPermissionAdmin(admin.ModelAdmin):
+    list_display = ("id", "permission", "content_type", "object_pk", "group")
+    list_filter = ("permission", "content_type", "group")

--- a/galaxy_ng/app/admin/permission.py
+++ b/galaxy_ng/app/admin/permission.py
@@ -1,0 +1,13 @@
+
+from django.contrib import admin
+from django.contrib.auth.models import Permission
+
+from .base import BaseModelAdmin
+
+
+@admin.register(Permission)
+class PermissionAdmin(BaseModelAdmin):
+    list_display = ('id', '__str__', 'name', 'content_type', 'codename')
+    raw_id_fields = ('content_type',)
+    search_fields = ('name', 'content_type__app_label', 'content_type__model', 'codename')
+    list_filter = ('content_type', 'content_type__app_label', 'content_type__model')

--- a/galaxy_ng/app/admin/pulp_ansible.py
+++ b/galaxy_ng/app/admin/pulp_ansible.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+from django.contrib import admin
+
+from .base import BaseModelAdmin, PulpModelAdmin
+
+from pulp_ansible.app.models import (
+    AnsibleDistribution,
+    AnsibleRepository,
+    Collection,
+    CollectionImport,
+    CollectionRemote,
+    CollectionVersion,
+    Role,
+    RoleRemote,
+    Tag,
+)
+
+
+@admin.register(Role)
+class RoleAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "namespace",
+        "name",
+        "version",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("name",)
+
+
+@admin.register(Collection)
+class CollectionAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "namespace",
+        "name",
+        # "deprecated",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated",
+                   # "deprecated",
+                   )
+    search_fields = (
+        "namespace",
+        "name",
+    )
+
+
+@admin.register(CollectionImport)
+class CollectionImportAdmin(BaseModelAdmin):
+    readonly_fields = ("task", "messages")
+    list_display = ("task", "messages")
+    fields = ("task", "messages")
+
+
+@admin.register(Tag)
+class TagAdmin(PulpModelAdmin):
+    list_display = (
+        "name",
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("name",)
+
+
+@admin.register(CollectionVersion)
+class CollectionVersionAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "namespace",
+        "name",
+        "version",
+        "description",
+        "pulp_type",
+        "is_highest",
+        "pulp_last_updated",
+        "pulp_created",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "is_highest")
+    raw_id_fields = ("tags",)
+    search_fields = ("namespace", "name", "pulp_id", "collection")
+
+    readonly_fields = (
+        "namespace",
+        "name",
+        "version",
+        "is_highest",
+        "collection",
+        "authors",
+        "contents",
+        "dependencies",
+        "description",
+        "homepage",
+        "issues",
+        "license",
+        "docs_blob",
+        "documentation",
+        "repository",
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+    )
+    fields = (
+        "pulp_id",
+        "namespace",
+        "name",
+        "version",
+        "is_highest",
+        "description",
+        "dependencies",
+        "authors",
+        "homepage",
+        "issues",
+        "repository",
+        "license",
+        "contents",
+        "pulp_type",
+        "documentation",
+        "docs_blob",
+        "search_vector",
+        "pulp_created",
+        "pulp_last_updated",
+    )
+
+
+@admin.register(RoleRemote)
+class RoleRemoteAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+        "url",
+        # 'ca_cert',
+        "client_cert",
+        "client_key",
+        "tls_validation",
+        "username",
+        "password",
+        "proxy_url",
+        "download_concurrency",
+        "policy",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "tls_validation")
+    search_fields = ("name",)
+
+
+@admin.register(AnsibleRepository)
+class AnsibleRepositoryAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+        "description",
+        "next_version",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("name",)
+
+
+@admin.register(CollectionRemote)
+class CollectionRemoteAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+        "url",
+        # 'ca_cert',
+        # 'client_cert',
+        # 'client_key',
+        "tls_validation",
+        "username",
+        "password",
+        "proxy_url",
+        "download_concurrency",
+        "policy",
+        "requirements_file",
+        "auth_url",
+        "token",
+    )
+
+    list_filter = ("pulp_created", "pulp_last_updated", "tls_validation")
+    search_fields = ("name",)
+
+
+@admin.register(AnsibleDistribution)
+class AnsibleDistributionAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+        "base_path",
+        "content_guard",
+        "remote",
+        "repository",
+        "repository_version",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "content_guard",
+        "remote",
+        "repository",
+        "repository_version",
+    )
+    search_fields = ("name",)

--- a/galaxy_ng/app/admin/pulp_container.py
+++ b/galaxy_ng/app/admin/pulp_container.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+from django.contrib import admin
+
+from pulp_container.app.models import (
+    Blob,
+    Manifest,
+    BlobManifest,
+    ManifestListManifest,
+    Tag,
+    ContainerNamespace,
+    ContainerRepository,
+    ContainerPushRepository,
+    ContainerRemote,
+    ContainerDistribution,
+    Upload,
+    ContentRedirectContentGuard,
+)
+
+
+@admin.register(Blob)
+class BlobAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'upstream_id',
+        'digest',
+        'media_type',
+    )
+    list_filter = ('pulp_created', 'pulp_last_updated')
+
+
+@admin.register(Manifest)
+class ManifestAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'upstream_id',
+        'digest',
+        'schema_version',
+        'media_type',
+        'config_blob',
+    )
+    list_filter = ('pulp_created', 'pulp_last_updated', 'config_blob')
+    raw_id_fields = ('blobs', 'listed_manifests')
+
+
+@admin.register(BlobManifest)
+class BlobManifestAdmin(admin.ModelAdmin):
+    list_display = ('id', 'manifest', 'manifest_blob')
+    list_filter = ('manifest', 'manifest_blob')
+
+
+@admin.register(ManifestListManifest)
+class ManifestListManifestAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'architecture',
+        'os',
+        'os_version',
+        'os_features',
+        'features',
+        'variant',
+        'image_manifest',
+        'manifest_list',
+    )
+    list_filter = ('image_manifest', 'manifest_list')
+
+
+@admin.register(Tag)
+class TagAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'upstream_id',
+        'name',
+        'tagged_manifest',
+    )
+    list_filter = ('pulp_created', 'pulp_last_updated', 'tagged_manifest')
+    search_fields = ('name',)
+
+
+@admin.register(ContainerNamespace)
+class ContainerNamespaceAdmin(admin.ModelAdmin):
+    list_display = ('pulp_id', 'pulp_created', 'pulp_last_updated', 'name')
+    list_filter = ('pulp_created', 'pulp_last_updated')
+    search_fields = ('name',)
+
+
+@admin.register(ContainerRepository)
+class ContainerRepositoryAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'name',
+        'description',
+        'next_version',
+        'remote',
+    )
+    list_filter = ('pulp_created', 'pulp_last_updated', 'remote')
+    search_fields = ('name',)
+
+
+@admin.register(ContainerPushRepository)
+class ContainerPushRepositoryAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'name',
+        'description',
+        'next_version',
+        'remote',
+    )
+    list_filter = ('pulp_created', 'pulp_last_updated', 'remote')
+    search_fields = ('name',)
+
+
+@admin.register(ContainerRemote)
+class ContainerRemoteAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'name',
+        'url',
+        'ca_cert',
+        'client_cert',
+        'client_key',
+        'tls_validation',
+        'username',
+        'password',
+        'proxy_url',
+        'proxy_username',
+        'proxy_password',
+        'download_concurrency',
+        'policy',
+        'total_timeout',
+        'connect_timeout',
+        'sock_connect_timeout',
+        'sock_read_timeout',
+        'headers',
+        'rate_limit',
+        'upstream_name',
+        'include_foreign_layers',
+        'include_tags',
+        'exclude_tags',
+    )
+    list_filter = (
+        'pulp_created',
+        'pulp_last_updated',
+        'tls_validation',
+        'include_foreign_layers',
+    )
+    search_fields = ('name',)
+
+
+@admin.register(ContainerDistribution)
+class ContainerDistributionAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'name',
+        'base_path',
+        'content_guard',
+        'remote',
+        'repository',
+        'repository_version',
+        'namespace',
+        'private',
+        'description',
+    )
+    list_filter = (
+        'pulp_created',
+        'pulp_last_updated',
+        'content_guard',
+        'remote',
+        'repository',
+        'repository_version',
+        'namespace',
+        'private',
+    )
+    search_fields = ('name',)
+
+
+@admin.register(Upload)
+class UploadAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'size',
+        'repository',
+    )
+    list_filter = ('pulp_created', 'pulp_last_updated', 'repository')
+
+
+@admin.register(ContentRedirectContentGuard)
+class ContentRedirectContentGuardAdmin(admin.ModelAdmin):
+    list_display = (
+        'pulp_id',
+        'pulp_created',
+        'pulp_last_updated',
+        'pulp_type',
+        'name',
+        'description',
+        'shared_secret',
+    )
+    list_filter = ('pulp_created', 'pulp_last_updated')
+    search_fields = ('name',)

--- a/galaxy_ng/app/admin/pulpcore.py
+++ b/galaxy_ng/app/admin/pulpcore.py
@@ -1,0 +1,673 @@
+import logging
+
+from django.contrib import admin
+
+from pulpcore.app.models import (
+    Label,
+    AccessPolicy,
+    Artifact,
+    Content,
+    ContentArtifact,
+    RemoteArtifact,
+    SigningService,
+    AsciiArmoredDetachedSigningService,
+    Repository,
+    Remote,
+    RepositoryContent,
+    RepositoryVersion,
+    RepositoryVersionContentDetails,
+    Publication,
+    PublishedArtifact,
+    PublishedMetadata,
+    PulpTemporaryFile,
+    ContentGuard,
+    BaseDistribution,
+    ContentAppStatus,
+    Upload,
+    UploadChunk,
+    GroupProgressReport,
+    ProgressReport,
+)
+
+
+from pulpcore.app.models.importer import (
+    Import,
+    Importer,
+    PulpImport,
+    PulpImporter,
+    PulpImporterRepository,
+)
+
+
+from pulpcore.app.models.exporter import (
+    Export,
+    Exporter,
+    ExportedResource,
+    PulpExport,
+    PulpExporter,
+)
+
+
+from pulpcore.app.models.task import (
+    ReservedResource,
+    TaskReservedResource,
+    ReservedResourceRecord,
+    TaskReservedResourceRecord,
+    Worker,
+    TaskGroup,
+    CreatedResource,
+)
+
+
+from .base import BaseModelAdmin, PulpModelAdmin
+
+log = logging.getLogger(__name__)
+
+READ_ONLY = True
+
+
+@admin.register(Label)
+class LabelAdmin(admin.ModelAdmin):
+    list_display = ('pulp_id', 'content_type', 'object_id', 'key', 'value')
+    list_filter = ('content_type',)
+
+
+@admin.register(AccessPolicy)
+class AccessPolicyAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "statements",
+        "viewset_name",
+        "permissions_assignment",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("viewset_name",)
+
+
+@admin.register(Artifact)
+class ArtifactAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "file",
+        "size",
+        "md5",
+        "sha1",
+        "sha224",
+        "sha256",
+        "sha384",
+        "sha512",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+
+
+@admin.register(Content)
+class ContentAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    raw_id_fields = ("_artifacts",)
+
+
+@admin.register(ContentArtifact)
+class ContentArtifactAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "artifact",
+        "content",
+        "relative_path",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+
+
+@admin.register(RemoteArtifact)
+class RemoteArtifactAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "url",
+        "size",
+        "md5",
+        "sha1",
+        "sha224",
+        "sha256",
+        "sha384",
+        "sha512",
+        "content_artifact",
+        "remote",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "content_artifact",
+        "remote",
+    )
+
+
+@admin.register(SigningService)
+class SigningServiceAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "name",
+        "script",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("name",)
+
+
+@admin.register(AsciiArmoredDetachedSigningService)
+class AsciiArmoredDetachedSigningServiceAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "name",
+        "script",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("name",)
+
+
+@admin.register(ReservedResource)
+class ReservedResourceAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "resource",
+        "worker",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "worker")
+    raw_id_fields = ("tasks",)
+
+
+@admin.register(TaskReservedResource)
+class TaskReservedResourceAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "resource",
+        "task",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "resource", "task")
+
+
+@admin.register(ReservedResourceRecord)
+class ReservedResourceRecordAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "resource",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    raw_id_fields = ("tasks",)
+
+
+@admin.register(TaskReservedResourceRecord)
+class TaskReservedResourceRecordAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "resource",
+        "task",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    raw_id_fields = ("resource", "task")
+
+
+@admin.register(Worker)
+class WorkerAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "name",
+        "last_heartbeat",
+        "gracefully_stopped",
+        "cleaned_up",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "last_heartbeat",
+        "gracefully_stopped",
+        "cleaned_up",
+    )
+    search_fields = ("name",)
+
+
+@admin.register(TaskGroup)
+class TaskGroupAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "description",
+        "all_tasks_dispatched",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "all_tasks_dispatched",
+    )
+
+
+@admin.register(CreatedResource)
+class CreatedResourceAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "content_type",
+        "object_id",
+        "task",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    raw_id_fields = ("content_type", "task")
+
+
+@admin.register(Repository)
+class RepositoryAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+        "description",
+        "next_version",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    raw_id_fields = ("content",)
+    search_fields = ("name",)
+
+
+@admin.register(Remote)
+class RemoteAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+        "url",
+        "ca_cert",
+        "client_cert",
+        "client_key",
+        "tls_validation",
+        "username",
+        "password",
+        "proxy_url",
+        "download_concurrency",
+        "policy",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "tls_validation")
+    search_fields = ("name",)
+
+
+@admin.register(RepositoryContent)
+class RepositoryContentAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "content",
+        "repository",
+        "version_added",
+        "version_removed",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "content",
+        "repository",
+        "version_added",
+        "version_removed",
+    )
+
+
+@admin.register(RepositoryVersion)
+class RepositoryVersionAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "repository",
+        "number",
+        "complete",
+        "base_version",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "complete")
+
+
+@admin.register(RepositoryVersionContentDetails)
+class RepositoryVersionContentDetailsAdmin(BaseModelAdmin):
+    list_display = (
+        "id",
+        "count_type",
+        "content_type",
+        "repository_version",
+        "count",
+    )
+
+
+@admin.register(Publication)
+class PublicationAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "complete",
+        "pass_through",
+        "repository_version",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "complete",
+        "pass_through",
+        "repository_version",
+    )
+
+
+@admin.register(PublishedArtifact)
+class PublishedArtifactAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "relative_path",
+        "content_artifact",
+        "publication",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "content_artifact",
+        "publication",
+    )
+
+
+@admin.register(PublishedMetadata)
+class PublishedMetadataAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "relative_path",
+        "publication",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "publication")
+
+
+@admin.register(PulpTemporaryFile)
+class PulpTemporaryFileAdmin(PulpModelAdmin):
+    list_display = ("pulp_id", "pulp_created", "pulp_last_updated", "file")
+    list_filter = ("pulp_created", "pulp_last_updated")
+
+
+@admin.register(ContentGuard)
+class ContentGuardAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+        "description",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("name",)
+
+
+@admin.register(BaseDistribution)
+class BaseDistributionAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+        "base_path",
+        "content_guard",
+        "remote",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "content_guard",
+        "remote",
+    )
+    search_fields = ("name",)
+
+
+@admin.register(ContentAppStatus)
+class ContentAppStatusAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "name",
+        "last_heartbeat",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "last_heartbeat")
+    search_fields = ("name",)
+
+
+@admin.register(Upload)
+class UploadAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "size",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+
+
+@admin.register(UploadChunk)
+class UploadChunkAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "upload",
+        "offset",
+        "size",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "upload")
+
+
+@admin.register(ProgressReport)
+class ProgressReportAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "message",
+        "code",
+        "state",
+        "total",
+        "done",
+        "task",
+        "suffix",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "task")
+
+
+@admin.register(GroupProgressReport)
+class GroupProgressReportAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "message",
+        "code",
+        "total",
+        "done",
+        "task_group",
+        "suffix",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "task_group")
+
+
+@admin.register(Export)
+class ExportAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "params",
+        "task",
+        "exporter",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "task", "exporter")
+
+
+@admin.register(ExportedResource)
+class ExportedResourceAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "content_type",
+        "object_id",
+        "export",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "content_type",
+        "export",
+    )
+
+
+@admin.register(Exporter)
+class ExporterAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("name",)
+
+
+@admin.register(PulpExport)
+class PulpExportAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "params",
+        "task",
+        "exporter",
+        "output_file_info",
+        "toc_info",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "task", "exporter")
+
+
+@admin.register(PulpExporter)
+class PulpExporterAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+        "path",
+        "last_export",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "last_export")
+    raw_id_fields = ("repositories",)
+    search_fields = ("name",)
+
+
+@admin.register(Import)
+class ImportAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "params",
+        "task",
+        "importer",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "task", "importer")
+
+
+@admin.register(Importer)
+class ImporterAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("name",)
+
+
+@admin.register(PulpImporter)
+class PulpImporterAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_type",
+        "name",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated")
+    search_fields = ("name",)
+
+
+@admin.register(PulpImporterRepository)
+class PulpImporterRepositoryAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "source_repo",
+        "pulp_importer",
+        "repository",
+    )
+    list_filter = (
+        "pulp_created",
+        "pulp_last_updated",
+        "pulp_importer",
+        "repository",
+    )
+
+
+@admin.register(PulpImport)
+class PulpImportAdmin(PulpModelAdmin):
+    list_display = (
+        "pulp_id",
+        "pulp_created",
+        "pulp_last_updated",
+        "params",
+        "task",
+        "importer",
+    )
+    list_filter = ("pulp_created", "pulp_last_updated", "task", "importer")

--- a/galaxy_ng/app/admin/sessions.py
+++ b/galaxy_ng/app/admin/sessions.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+
+from django.contrib.sessions.models import Session
+
+
+@admin.register(Session)
+class SessionAdmin(admin.ModelAdmin):
+    list_display = ('session_key', 'session_data', 'expire_date')
+    list_filter = ('expire_date',)

--- a/galaxy_ng/app/models/__init__.py
+++ b/galaxy_ng/app/models/__init__.py
@@ -21,7 +21,10 @@ from .collectionsync import (
 from .container import (
     ContainerDistribution,
     ContainerDistroReadme,
-    ContainerNamespace
+    ContainerNamespace,
+    ContainerRegistryRemote,
+    ContainerRegistryRepos,
+    ContainerSyncTask,
 )
 
 __all__ = (
@@ -34,5 +37,8 @@ __all__ = (
     'CollectionSyncTask',
     'ContainerDistribution',
     'ContainerDistroReadme',
-    'ContainerNamespace'
+    'ContainerNamespace',
+    'ContainerRegistryRemote',
+    'ContainerRegistryRepos',
+    'ContainerSyncTask',
 )

--- a/galaxy_ng/app/models/collectionimport.py
+++ b/galaxy_ng/app/models/collectionimport.py
@@ -46,3 +46,9 @@ class CollectionImport(LifecycleModel, AutoDeleteObjPermsMixin):
 
     def get_absolute_url(self):
         return reverse('galaxy:api:content:collection-import', args=[str(self.task_id)])
+
+    def label(self):
+        return f"{self.namespace}.{self.name}"
+
+    def label_and_version(self):
+        return f"{self.namespace}.{self.name}-{self.version}"


### PR DESCRIPTION
Use pulpcore.admin.BaseModel for guardian obj perms

Use pulpcore AdminModels from plugins package.

Add pulp_container admin models.

Add galaxy container admin models.

Utility formatters for collection import for use
in admin.

Issue: AAH-32