### PR TITLE
Upgrade galaxy-importer to 0.3.1

### DIFF
--- a/CHANGES/431.bugfix
+++ b/CHANGES/431.bugfix
@@ -1,0 +1,1 @@
+Uses optional file_url from caller, pulp-ansible>=0.8, to support additional pulp backend storage platforms

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -113,7 +113,7 @@ flake8==3.9.0
     # via galaxy-importer
 future==0.18.2
     # via pyjwkest
-galaxy-importer==0.3.0
+galaxy-importer==0.3.1
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -125,7 +125,7 @@ flake8==3.9.0
     # via galaxy-importer
 future==0.18.2
     # via pyjwkest
-galaxy-importer==0.3.0
+galaxy-importer==0.3.1
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -113,7 +113,7 @@ flake8==3.9.0
     # via galaxy-importer
 future==0.18.2
     # via pyjwkest
-galaxy-importer==0.3.0
+galaxy-importer==0.3.1
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ class BuildPyCommand(_BuildPyCommand):
 
 requirements = [
     "Django~=2.2.18",
-    "galaxy-importer==0.3.0",
+    "galaxy-importer==0.3.1",
     "pulpcore<3.12,>=3.11",
     "pulp-ansible==0.7.1",
     "django-prometheus>=2.0.0",


### PR DESCRIPTION
Uses file_url from caller for remote storage to support additional
pulp backend storage types

AAH-431