### PR TITLE
Temporarily pin django to 2.2.20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ class BuildPyCommand(_BuildPyCommand):
 
 
 requirements = [
-    "Django~=2.2.18",
+    "Django==2.2.20",
     "galaxy-importer==0.3.1",
     "pulpcore<3.12,>=3.11",
     "pulp-ansible==0.7.1",


### PR DESCRIPTION
Pin django to 2.2.20 until https://pulp.plan.io/issues/8691 is resolved.
This fixes CI build issues for now.

No-Issue