### PR TITLE
Temporarily pin stable 4.3 django==2.2.20 workaround

### DIFF
--- a/CHANGES/584.misc
+++ b/CHANGES/584.misc
@@ -1,0 +1,5 @@
+Temporary pin django==2.2.20
+
+To avoid
+   https://code.djangoproject.com/ticket/32718
+    Issue with assigning file to FileField

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class BuildPyCommand(_BuildPyCommand):
 
 
 requirements = [
-    "Django~=2.2.18",
+    "Django==2.2.20",
     "galaxy-importer==0.3.0",
     "pulpcore<3.12,>=3.11",
     "pulp-ansible==0.7.1",


### PR DESCRIPTION
Pin django to 2.2.20 until https://pulp.plan.io/issues/8691 is resolved.
This fixes CI build issues for now.

No-Issue

(cherry picked from commit 57f3922f3fe7719c5da5519e2b0dafca3ccfb8e5)

This is in lieu of https://pulp.plan.io/issues/8691 or an upstream django fix for https://code.djangoproject.com/ticket/32718
