### PR TITLE
Speedup dev docker builds by using g+s to avoid chown -R

### DIFF
--- a/dev/Dockerfile.base
+++ b/dev/Dockerfile.base
@@ -41,9 +41,10 @@ RUN set -ex; \
     && dnf clean all \
     && rm -rf /var/cache/dnf/ \
     && rm -f /var/lib/rpm/__db.* \
-    \
-    && mkdir /venv \
-    && chown ${USER_NAME}:${USER_GROUP} /venv
+    && mkdir --mode=2775 /venv \
+    && chown ${USER_NAME}:${USER_GROUP} /venv \
+    && mkdir --mode=2775 /app \
+    && chown ${USER_NAME}:${USER_GROUP} /app
 
 USER ${USER_NAME}:${USER_GROUP}
 RUN set -ex; \
@@ -75,19 +76,19 @@ RUN set -ex; \
 
 # Finalize installation
 RUN set -ex; \
-    mkdir -p /var/lib/pulp/artifact \
+    mkdir -p /entrypoints.d \
+            /etc/ansible \
+    && mkdir --mode=2775 -p /var/lib/pulp \
+    && chown ${USER_NAME}:${USER_GROUP} /var/lib/pulp \
+    && mkdir --mode=2775 -p \
+             /var/lib/pulp/artifact \
              /var/lib/pulp/tmp \
              /tmp/ansible \
-             /etc/ansible \
-             /entrypoints.d \
-    && chown -R ${USER_NAME}:${USER_GROUP} \
-        /var/lib/pulp \
+    && chown ${USER_NAME}:${USER_GROUP} \
         /tmp/ansible \
         /etc/ansible \
-    && chmod -R 0775 /var/lib/pulp \
-                     /app/docker/entrypoint.sh \
+    && chmod -R 0775 /app/docker/entrypoint.sh \
                      /app/docker/bin/* \
-                     /tmp/ansible \
     && mv /app/docker/entrypoint.sh /entrypoint.sh \
     && mv /app/ansible.cfg /etc/ansible/ansible.cfg \
     && mv /app/docker/bin/* /usr/local/bin


### PR DESCRIPTION
No-Issue

This builds on #731. 

Use `mkdir --mode` to make most of the dirs group 'sticky' so group perms stick, so user can continue to write to subdirs even if ROOT unintentionally creates dirs 0755. 

Some rearranging of dir creation order so we can create parent dirs first so we can make them group sticky.
For `/var/lib/pulp` for example, this removes the need for a `chown -R /var/lib/pulp`.

On top of #731, it seems to shave about ~25secs off a `./compose build` down to about ~1m15sec.  Down from about ~3m30s before either #731 or this change.