### PR TITLE
Rev to django~=2.2.23 for cve and bug fixes.

### DIFF
--- a/CHANGES/583.bugfix
+++ b/CHANGES/583.bugfix
@@ -1,0 +1,1 @@
+Fix "CVE-2021-32052 django: header injection" by moving to django ~=2.2.23

--- a/CHANGES/584.misc
+++ b/CHANGES/584.misc
@@ -1,0 +1,3 @@
+Decide on django/pulp versions for galaxy_ng 4.3.
+
+Django ~=2.2.23 btw.

--- a/CHANGES/601.bugfix
+++ b/CHANGES/601.bugfix
@@ -1,0 +1,1 @@
+Update the required django to ~=2.2.23

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -71,7 +71,7 @@ django-lifecycle==0.9.1
     # via pulpcore
 django-prometheus==2.1.0
     # via galaxy-ng (setup.py)
-django==2.2.20
+django==2.2.23
     # via
     #   django-currentuser
     #   django-filter

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -82,7 +82,7 @@ django-prometheus==2.1.0
     # via galaxy-ng (setup.py)
 django-storages[boto3]==1.11.1
     # via -r requirements/requirements.insights.in
-django==2.2.20
+django==2.2.23
     # via
     #   django-currentuser
     #   django-filter

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -71,7 +71,7 @@ django-lifecycle==0.9.1
     # via pulpcore
 django-prometheus==2.1.0
     # via galaxy-ng (setup.py)
-django==2.2.20
+django==2.2.23
     # via
     #   django-currentuser
     #   django-filter

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ class BuildPyCommand(_BuildPyCommand):
 
 
 requirements = [
-    "Django==2.2.20",
+    "Django~=2.2.23",
     "galaxy-importer==0.3.2",
     "pulpcore<3.12,>=3.11.1",
     "pulp-ansible==0.7.3",


### PR DESCRIPTION
Bump from LTS 2.2.20 to 2.2.23

2.2.21 included some security improvements but
also a new django bug that caused a bug in pulpcore
https://pulp.plan.io/issues/8691

2.2.22 has fix for:
CVE-2021-32052 django: header injection possibility
  since URLValidator accepted newlines in input on Python.

But 2.2.22 still had the bug introduced in 2.2.21

2.2.23 resolves the issue that causes
https://pulp.plan.io/issues/8691

Issue: AAH-601
Issue: AAH-583
Issue: AAH-584