### PR TITLE
Pin click==7.1.2, click>=8.0.0 req py38

### DIFF
--- a/CHANGES/637.bugfix
+++ b/CHANGES/637.bugfix
@@ -1,0 +1,1 @@
+Pin 'click' version to 7.1.2 for 'rq' compat

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -44,7 +44,9 @@ chardet==4.0.0
     #   aiohttp
     #   requests
 click==7.1.2
-    # via rq
+    # via
+    #   galaxy-ng (setup.py)
+    #   rq
 colorama==0.4.4
     # via rich
 commonmark==0.9.1

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -53,7 +53,9 @@ chardet==4.0.0
     #   aiohttp
     #   requests
 click==7.1.2
-    # via rq
+    # via
+    #   galaxy-ng (setup.py)
+    #   rq
 colorama==0.4.4
     # via rich
 commonmark==0.9.1

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -44,7 +44,9 @@ chardet==4.0.0
     #   aiohttp
     #   requests
 click==7.1.2
-    # via rq
+    # via
+    #   galaxy-ng (setup.py)
+    #   rq
 colorama==0.4.4
     # via rich
 commonmark==0.9.1

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,9 @@ requirements = [
     "django-prometheus>=2.0.0",
     "drf-spectacular",
     "pulp-container>=2.5.2",
+    # click 8 requires py38,
+    # can be removed once we require >=py38
+    "click==7.1.2",
 ]
 
 


### PR DESCRIPTION
pulpcore uses 'rq' which uses 'click'.

click version 8.0.0 or higher don't work with
python < 3.8 and we currently use python~=3.6

If click>=8.0.0 is used with python 3.6. it will
eventually raise an exception like:

ValueError: 'default' must be a list when 'multiple' is true.

See https://pulp.plan.io/issues/8744