### PR TITLE
Pin pulp-container

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -161,7 +161,7 @@ psycopg2==2.8.6
     # via pulpcore
 pulp-ansible==0.7.3
     # via galaxy-ng (setup.py)
-pulp-container==2.5.2
+pulp-container==2.5.3
     # via galaxy-ng (setup.py)
 pulpcore==3.11.1
     # via

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -179,7 +179,7 @@ psycopg2==2.8.6
     # via pulpcore
 pulp-ansible==0.7.3
     # via galaxy-ng (setup.py)
-pulp-container==2.5.2
+pulp-container==2.5.3
     # via galaxy-ng (setup.py)
 pulpcore==3.11.1
     # via

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -161,7 +161,7 @@ psycopg2==2.8.6
     # via pulpcore
 pulp-ansible==0.7.3
     # via galaxy-ng (setup.py)
-pulp-container==2.5.2
+pulp-container==2.5.3
     # via galaxy-ng (setup.py)
 pulpcore==3.11.1
     # via

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ requirements = [
     "pulp-ansible==0.7.3",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
-    "pulp-container>=2.5.2",
+    # pulp-container 2.6 requires pulpcore >=3.12.1
+    "pulp-container>=2.5.2,<2.6.0",
     # click 8 requires py38,
     # can be removed once we require >=py38
     "click==7.1.2",


### PR DESCRIPTION
This is currently breaking pulp-operator
https://github.com/pulp/pulp-operator/runs/2652733659?check_suite_focus=true

pulp-container 2.6 requires pulpcore >=3.12.1
https://github.com/pulp/pulp_container/blob/2.6.0/requirements.txt