### PR TITLE
Use red-hat-certified as the standard for base_path

### DIFF
--- a/galaxy_ng/app/migrations/0017_populate_repos_and_remotes.py
+++ b/galaxy_ng/app/migrations/0017_populate_repos_and_remotes.py
@@ -40,6 +40,10 @@ REPOSITORIES = [
             ),
             "pulp_type": "ansible.ansible",
             "rate_limit": 8,
+        },
+        "distribution": {
+            "name": "rh-certified",
+            "base_path": "red-hat-certified"
         }
     }
 ]
@@ -75,6 +79,8 @@ def populate_initial_repos(apps, schema_editor):
 
     for repo_data in REPOSITORIES:
 
+        distribution = repo_data.pop("distribution", {})
+
         remote = repo_data.pop("remote", None)
         if remote is not None:
             remote, _ = CollectionRemote.objects.get_or_create(
@@ -95,10 +101,10 @@ def populate_initial_repos(apps, schema_editor):
             )
 
         AnsibleDistribution.objects.get_or_create(
-            name=repository.name,
+            base_path=distribution.get("base_path", repository.name),
             defaults={
-                "name": repository.name,
-                "base_path": repository.name,
+                "name": distribution.get("name", repository.name),
+                "base_path": distribution.get("base_path", repository.name),
                 "remote": remote,
                 "repository": repository,
                 "pulp_type": "ansible.ansible"

--- a/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
@@ -181,7 +181,8 @@ class TestUiCollectionRemoteViewSet(BaseTestCase):
         repository = response.data['data'][1]['repositories'][0]
 
         self.assertEqual(repository['name'], self.remote_data["name"])
-        self.assertEqual(repository['distributions'][0]['base_path'], self.remote_data["name"])
+        self.assertEqual(repository['distributions'][0]['name'], self.remote_data["name"])
+        self.assertEqual(repository['distributions'][0]['base_path'], "red-hat-certified")
 
         # token is not visible in a GET
         self.assertNotIn('token', response.data['data'][1])

--- a/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_sync_config.py
@@ -47,7 +47,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
 
     def test_positive_get_config_sync_for_certified(self):
         self.client.force_authenticate(user=self.admin_user)
-        response = self.client.get(self.build_config_url(self.certified_remote.name))
+        response = self.client.get(self.build_config_url("red-hat-certified"))
         log.debug('test_positive_get_config_sync_for_certified')
         log.debug('response: %s', response)
         log.debug('response.data: %s', response.data)
@@ -71,7 +71,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
     def test_positive_update_certified_repo_data(self):
         self.client.force_authenticate(user=self.admin_user)
         response = self.client.put(
-            self.build_config_url(self.certified_remote.name),
+            self.build_config_url("red-hat-certified"),
             {
                 "auth_url": "https://auth.com",
                 "token": "TEST",
@@ -87,7 +87,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
         log.debug('response.data: %s', response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        updated = self.client.get(self.build_config_url(self.certified_remote.name))
+        updated = self.client.get(self.build_config_url("red-hat-certified"))
         self.assertEqual(updated.data["auth_url"], "https://auth.com")
         self.assertEqual(updated.data["url"], "https://updated.url.com/")
         self.assertIsNone(updated.data["requirements_file"])
@@ -144,7 +144,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
 
     def test_positive_syncing_returns_a_task_id(self):
         self.client.force_authenticate(user=self.admin_user)
-        response = self.client.post(self.build_sync_url(self.certified_remote.name))
+        response = self.client.post(self.build_sync_url("red-hat-certified"))
         log.debug('test_positive_syncing_returns_a_task_id')
         log.debug('response: %s', response)
         log.debug('response.data: %s', response.data)
@@ -153,7 +153,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
 
     def test_sensitive_fields_are_not_exposed(self):
         self.client.force_authenticate(user=self.admin_user)
-        api_url = self.build_config_url(self.certified_remote.name)
+        api_url = self.build_config_url("red-hat-certified")
         response = self.client.get(api_url)
         self.assertNotIn('password', response.data)
         self.assertNotIn('token', response.data)
@@ -161,7 +161,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
 
     def test_write_only_fields(self):
         self.client.force_authenticate(user=self.admin_user)
-        api_url = self.build_config_url(self.certified_remote.name)
+        api_url = self.build_config_url("red-hat-certified")
         write_only_fields = [
             'client_key',
             'token',
@@ -220,7 +220,7 @@ class TestUiSyncConfigViewSet(BaseTestCase):
         self.client.force_authenticate(user=self.admin_user)
 
         # ensure proxy_url is blank
-        api_url = self.build_config_url(self.certified_remote.name)
+        api_url = self.build_config_url("red-hat-certified")
         response = self.client.get(api_url)
         self.assertIsNone(response.data['proxy_url'])
 

--- a/galaxy_ng/tests/unit/api/test_api_v3_tasks.py
+++ b/galaxy_ng/tests/unit/api/test_api_v3_tasks.py
@@ -33,7 +33,7 @@ class TestUiTaskListViewSet(BaseTestCase):
     def test_tasks_required_fields(self):
         # Spawn a task
         self.client.force_authenticate(user=self.admin_user)
-        response = self.client.post(self.build_sync_url(self.certified_remote.name))
+        response = self.client.post(self.build_sync_url("red-hat-certified"))
         log.debug('Spawn a task for testing tasks/ endpoint')
         log.debug('response: %s', response)
         log.debug('response.data: %s', response.data)


### PR DESCRIPTION
Previous versions provisioned using galaxy_collection roles
used `red-hat-certified` instead of `rh-certified` as the
`base_path` for distro.

So to avoid breaking the migration with DB Integrity Error
we are from now, using `red-hat-certified` as the standard
for this distro `base_path` while keeping `rh-certified`
as its name and related repo/remote names.

No-Issue