### PR TITLE
Change migration to use base_path for Distribution

### DIFF
--- a/galaxy_ng/app/migrations/0017_populate_repos_and_remotes.py
+++ b/galaxy_ng/app/migrations/0017_populate_repos_and_remotes.py
@@ -95,7 +95,7 @@ def populate_initial_repos(apps, schema_editor):
             )
 
         AnsibleDistribution.objects.get_or_create(
-            name=repository.name,
+            base_path=repository.name,
             defaults={
                 "name": repository.name,
                 "base_path": repository.name,


### PR DESCRIPTION
When [galaxy_collection](https://github.com/ansible/galaxy_collection/blob/devel/roles/post_install_config/vars/main.yml#L21-L22) is used on provisioning the 4.2 system it creates a distribution having.

```
base_path: 'rh-certified'    
name: 'red-hat-certified'
```

Then when 4.3 migrations run it tries to fetch existing distribution using the `name` as the key.

```py
AnsibleDistribution.get_or_create(name="rh-certified", defaults={base_path="rh-certified", ...})
```

The problem is that the name in DB is `red-hat-certified` so the above `get_or_create` will fail to `get` and so 
will try to create a new distribution using `name=rh-certified, base_path=rh-certified` and this will raise `IntergrityError` on db because `base_path` is unique.

The simplest solution is to use `base_path` instead of name for querying the existing entity as this is the key field  and avoid the re-recreation.

No-Issue