### PR TITLE
Remove pulp-container from 4.2.

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -27,17 +27,17 @@ dataclasses==0.8          # via rich
 defusedxml==0.7.1         # via odfpy
 diff-match-patch==20200713  # via django-import-export
 django-currentuser==0.5.3  # via pulpcore
-django-filter==2.4.0      # via pulpcore
+django-filter==2.3.0      # via pulpcore
 django-guardian==2.3.0    # via pulpcore
-django-import-export==2.4.0  # via pulpcore
+django-import-export==2.3.0  # via pulpcore
 django-lifecycle==0.8.1   # via pulpcore
 django-prometheus==2.1.0  # via galaxy-ng (setup.py)
 django==2.2.24            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.12.4  # via drf-nested-routers, drf-spectacular, pulpcore
-drf-access-policy==0.8.7  # via pulpcore
-drf-nested-routers==0.92.1  # via pulpcore
-drf-spectacular==0.9.14   # via galaxy-ng (setup.py), pulpcore
+djangorestframework==3.11.2  # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.7.0  # via pulpcore
+drf-nested-routers==0.91  # via pulpcore
+drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
 dynaconf==3.1.4           # via pulpcore
 et-xmlfile==1.1.0         # via openpyxl
 flake8==3.9.2             # via galaxy-importer
@@ -60,18 +60,18 @@ packaging==20.9           # via ansible-base, bleach, pulp-ansible
 prometheus-client==0.11.0  # via django-prometheus
 psycopg2==2.8.6           # via pulpcore
 pulp-ansible==0.5.8       # via galaxy-ng (setup.py)
-pulpcore==3.8.1           # via galaxy-ng (setup.py), pulp-ansible
+pulpcore==3.7.6           # via galaxy-ng (setup.py), pulp-ansible
 pycares==4.0.0            # via aiodns
 pycodestyle==2.7.0        # via flake8
 pycparser==2.20           # via cffi
 pyflakes==2.3.1           # via flake8
 pygments==2.9.0           # via rich
 pygtrie==2.3.3            # via pulpcore
-pyparsing==2.4.7          # via drf-access-policy, packaging
+pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 python-gnupg==0.4.7       # via pulpcore
 pytz==2021.1              # via django
-pyyaml==5.3.1             # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+pyyaml==5.4.1             # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
 redis==3.5.3              # via pulpcore, rq
 requests==2.25.1          # via galaxy-importer
 requirements-parser==0.2.0  # via ansible-builder

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -16,8 +16,8 @@ attrs==20.3.0             # via aiohttp, galaxy-importer, jsonschema
 backoff==1.10.0           # via pulpcore
 bleach-allowlist==1.0.3   # via galaxy-importer
 bleach==3.3.0             # via galaxy-importer
-boto3==1.17.93            # via -r requirements/requirements.insights.in, django-storages, watchtower
-botocore==1.20.93         # via boto3, s3transfer
+boto3==1.17.97            # via -r requirements/requirements.insights.in, django-storages, watchtower
+botocore==1.20.97         # via boto3, s3transfer
 certifi==2021.5.30        # via requests
 cffi==1.14.5              # via cryptography, pycares
 chardet==4.0.0            # via aiohttp, requests
@@ -29,18 +29,18 @@ dataclasses==0.8          # via rich
 defusedxml==0.7.1         # via odfpy
 diff-match-patch==20200713  # via django-import-export
 django-currentuser==0.5.3  # via pulpcore
-django-filter==2.4.0      # via pulpcore
+django-filter==2.3.0      # via pulpcore
 django-guardian==2.3.0    # via pulpcore
-django-import-export==2.4.0  # via pulpcore
+django-import-export==2.3.0  # via pulpcore
 django-lifecycle==0.8.1   # via pulpcore
 django-prometheus==2.1.0  # via galaxy-ng (setup.py)
 django-storages[boto3]==1.11.1  # via -r requirements/requirements.insights.in
 django==2.2.24            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, django-storages, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.12.4  # via drf-nested-routers, drf-spectacular, pulpcore
-drf-access-policy==0.8.7  # via pulpcore
-drf-nested-routers==0.92.1  # via pulpcore
-drf-spectacular==0.9.14   # via galaxy-ng (setup.py), pulpcore
+djangorestframework==3.11.2  # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.7.0  # via pulpcore
+drf-nested-routers==0.91  # via pulpcore
+drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
 dynaconf==3.1.4           # via pulpcore
 et-xmlfile==1.1.0         # via openpyxl
 flake8==3.9.2             # via galaxy-importer
@@ -65,19 +65,19 @@ packaging==20.9           # via ansible-base, bleach, pulp-ansible
 prometheus-client==0.11.0  # via django-prometheus
 psycopg2==2.8.6           # via pulpcore
 pulp-ansible==0.5.8       # via galaxy-ng (setup.py)
-pulpcore==3.8.1           # via galaxy-ng (setup.py), pulp-ansible
+pulpcore==3.7.6           # via galaxy-ng (setup.py), pulp-ansible
 pycares==4.0.0            # via aiodns
 pycodestyle==2.7.0        # via flake8
 pycparser==2.20           # via cffi
 pyflakes==2.3.1           # via flake8
 pygments==2.9.0           # via rich
 pygtrie==2.3.3            # via pulpcore
-pyparsing==2.4.7          # via drf-access-policy, packaging
+pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via botocore
 python-gnupg==0.4.7       # via pulpcore
 pytz==2021.1              # via django
-pyyaml==5.3.1             # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+pyyaml==5.4.1             # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
 redis==3.5.3              # via pulpcore, rq
 requests==2.25.1          # via galaxy-importer
 requirements-parser==0.2.0  # via ansible-builder

--- a/requirements/requirements.standalone.in
+++ b/requirements/requirements.standalone.in
@@ -1,1 +1,0 @@
-pulp-container~=2.1.0

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -22,27 +22,25 @@ chardet==4.0.0            # via aiohttp, requests
 click==7.1.2              # via galaxy-ng (setup.py), rq
 colorama==0.4.4           # via rich
 commonmark==0.9.1         # via rich
-cryptography==3.4.7       # via ansible-base, pyjwt
+cryptography==3.4.7       # via ansible-base
 dataclasses==0.8          # via rich
 defusedxml==0.7.1         # via odfpy
 diff-match-patch==20200713  # via django-import-export
 django-currentuser==0.5.3  # via pulpcore
-django-filter==2.4.0      # via pulpcore
+django-filter==2.3.0      # via pulpcore
 django-guardian==2.3.0    # via pulpcore
-django-import-export==2.4.0  # via pulpcore
+django-import-export==2.3.0  # via pulpcore
 django-lifecycle==0.8.1   # via pulpcore
 django-prometheus==2.1.0  # via galaxy-ng (setup.py)
-django==2.2.20            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulp-container, pulpcore
+django==2.2.24            # via django-currentuser, django-filter, django-guardian, django-import-export, django-lifecycle, djangorestframework, drf-nested-routers, drf-spectacular, galaxy-ng (setup.py), pulpcore
 djangorestframework-queryfields==1.0.0  # via pulpcore
-djangorestframework==3.12.4  # via drf-nested-routers, drf-spectacular, pulpcore
-drf-access-policy==0.8.7  # via pulpcore
-drf-nested-routers==0.92.1  # via pulpcore
-drf-spectacular==0.9.14   # via galaxy-ng (setup.py), pulpcore
+djangorestframework==3.11.2  # via drf-nested-routers, drf-spectacular, pulpcore
+drf-access-policy==0.7.0  # via pulpcore
+drf-nested-routers==0.91  # via pulpcore
+drf-spectacular==0.9.13   # via galaxy-ng (setup.py), pulpcore
 dynaconf==3.1.4           # via pulpcore
-ecdsa==0.13.3             # via pulp-container
 et-xmlfile==1.1.0         # via openpyxl
 flake8==3.9.2             # via galaxy-importer
-future==0.18.2            # via pyjwkest
 galaxy-importer==0.2.15   # via galaxy-ng (setup.py), pulp-ansible
 gunicorn==20.0.4          # via pulpcore
 idna-ssl==1.1.0           # via aiohttp
@@ -62,36 +60,31 @@ packaging==20.9           # via ansible-base, bleach, pulp-ansible
 prometheus-client==0.11.0  # via django-prometheus
 psycopg2==2.8.6           # via pulpcore
 pulp-ansible==0.5.8       # via galaxy-ng (setup.py)
-pulp-container==2.1.2     # via -r requirements/requirements.standalone.in
-pulpcore==3.8.1           # via galaxy-ng (setup.py), pulp-ansible, pulp-container
+pulpcore==3.7.6           # via galaxy-ng (setup.py), pulp-ansible
 pycares==4.0.0            # via aiodns
 pycodestyle==2.7.0        # via flake8
 pycparser==2.20           # via cffi
-pycryptodomex==3.10.1     # via pyjwkest
 pyflakes==2.3.1           # via flake8
 pygments==2.9.0           # via rich
 pygtrie==2.3.3            # via pulpcore
-pyjwkest==1.4.2           # via pulp-container
-pyjwt[crypto]==1.7.1      # via pulp-container
-pyparsing==2.4.7          # via drf-access-policy, packaging
+pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 python-gnupg==0.4.7       # via pulpcore
 pytz==2021.1              # via django
-pyyaml==5.3.1             # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
+pyyaml==5.4.1             # via ansible-base, ansible-builder, ansible-lint, drf-spectacular, galaxy-importer, pulp-ansible, pulpcore, tablib
 redis==3.5.3              # via pulpcore, rq
-requests==2.25.1          # via galaxy-importer, pyjwkest
+requests==2.25.1          # via galaxy-importer
 requirements-parser==0.2.0  # via ansible-builder
 rich==10.3.0              # via ansible-lint
 rq==1.5.2                 # via pulpcore
 ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.17.9       # via ansible-lint
 semantic-version==2.8.5   # via galaxy-importer, pulp-ansible
-six==1.16.0               # via bleach, jsonschema, pyjwkest, url-normalize
+six==1.16.0               # via bleach, jsonschema
 sqlparse==0.4.1           # via django
 tablib[html,ods,xls,xlsx,yaml]==3.0.0  # via django-import-export
 typing-extensions==3.10.0.0  # via aiohttp, ansible-lint, importlib-metadata, rich, yarl
 uritemplate==3.0.1        # via drf-spectacular
-url-normalize==1.4.3      # via pulp-container
 urllib3==1.26.5           # via requests
 urlman==2.0.1             # via django-lifecycle
 webencodings==0.5.1       # via bleach

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class BuildPyCommand(_BuildPyCommand):
 requirements = [
     "Django~=2.2.20",
     "galaxy-importer==0.2.15",
-    "pulpcore>=3.7,<3.9",
+    "pulpcore~=3.7.5",
     "pulp-ansible==0.5.8",
     "django-prometheus>=2.0.0",
     "drf-spectacular",


### PR DESCRIPTION
- Remove pulp container
- Update to latest django LTS
- Pin to pulp core 3.7

No-Issue