### PR TITLE
Re-Enable /collections/all/ endpoints (now streamed)

### DIFF
--- a/CHANGES/224.misc
+++ b/CHANGES/224.misc
@@ -1,0 +1,1 @@
+Re-enable /collections/all/  streamed andpoints

--- a/docker/etc/settings.py
+++ b/docker/etc/settings.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -32,20 +32,17 @@ sync_urls = [
 
 urlpatterns = [
 
-    # The following endpoints are related to issue https://issues.redhat.com/browse/AAH-224
-    # For now endpoints are temporary deactivated until the issue is resolved.
-    #
-    # path("", viewsets.RepoMetadataViewSet.as_view({"get": "retrieve"}), name="repo-metadata"),
-    # path(
-    #     'collections/all/',
-    #     viewsets.UnpaginatedCollectionViewSet.as_view({'get': 'list'}),
-    #     name='all-collections-list'
-    # ),
-    # path(
-    #     'collection_versions/all/',
-    #     viewsets.UnpaginatedCollectionVersionViewSet.as_view({"get": "list"}),
-    #     name="all-collection-versions-list"
-    # ),
+    path("", viewsets.RepoMetadataViewSet.as_view({"get": "retrieve"}), name="repo-metadata"),
+    path(
+        'collections/all/',
+        viewsets.UnpaginatedCollectionViewSet.as_view({'get': 'list'}),
+        name='all-collections-list'
+    ),
+    path(
+        'collection_versions/all/',
+        viewsets.UnpaginatedCollectionVersionViewSet.as_view({"get": "list"}),
+        name="all-collection-versions-list"
+    ),
 
     path(
         'collections/',


### PR DESCRIPTION
Streamed andpoints enabled on https://github.com/pulp/pulp_ansible/pull/586

Requires PR: https://github.com/pulp/pulp_ansible/pull/586
Issue: AAH-224