### PR TITLE
Workaround bonfire stripping resource limits of ClowdApp

### DIFF
--- a/docker/etc/settings.py
+++ b/docker/etc/settings.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -20,7 +20,22 @@ export IMAGE_TAG="pr-$IMAGE_TAG"
 
 source "$CICD_ROOT/build.sh"
 # source $APP_ROOT/unit_test.sh
-source $CICD_ROOT/deploy_ephemeral_env.sh
+
+# BEGIN WORKAROUND
+# NOTE(cutwater): See https://issues.redhat.com/browse/RHCLOUD-14977
+source ${CICD_ROOT}/_common_deploy_logic.sh
+export NAMESPACE=$(bonfire namespace reserve)
+bonfire deploy \
+    ${APP_NAME} \
+    --source=appsre \
+    --ref-env insights-stage \
+    --set-template-ref ${APP_NAME}/${COMPONENT_NAME}=${GIT_COMMIT} \
+    --set-image-tag ${IMAGE}=${IMAGE_TAG} \
+    --namespace ${NAMESPACE} \
+    --no-remove-resources \
+    ${COMPONENTS_ARG}
+# END WORKAROUND
+
 # source $CICD_ROOT/smoke_test.sh
 
 # overriding IMAGE_TAG defined by boostrap.sh, for now


### PR DESCRIPTION
This change replaces call to `_deploy_ephemeral_env.sh` script
with it's contents and adds additional required `--no-remove-resources`
parameter to the `bonfire deploy` call.

No-Issue