### PR TITLE
insights/docker-compose-ui: add *.foo.redhat.com extra_hosts

### DIFF
--- a/dev/insights/docker-compose-ui.yaml
+++ b/dev/insights/docker-compose-ui.yaml
@@ -16,3 +16,8 @@ services:
       - label:disable
     ports:
       - "1337:1337"
+    extra_hosts:
+      - "ci.foo.redhat.com:127.0.0.1"
+      - "prod.foo.redhat.com:127.0.0.1"
+      - "qa.foo.redhat.com:127.0.0.1"
+      - "stage.foo.redhat.com:127.0.0.1"


### PR DESCRIPTION
Running the insights mode, the *host* `/etc/hosts` should contain these:

    127.0.0.1 prod.foo.redhat.com
    127.0.0.1 stage.foo.redhat.com
    127.0.0.1 qa.foo.redhat.com
    127.0.0.1 ci.foo.redhat.com

Under some circumstances, the host `/etc/hosts` get mounted inside the container as well, having the container see the same hosts as the host machine.

Under other circumstances, this doesn't happen, and the container `/etc/hosts` is missing these entries.

That causes..

    insights_proxy_1    | GET /beta/ansible/automation-hub from https://ui:8002/beta/ansible/automation-hub
    insights_proxy_1    | An error occurred while resolving an ESI tag for the ci.foo.redhat.com host
    insights_proxy_1    | { [While requesting GET|https://ci.foo.redhat.com:1337/apps/chrome/snippets/body.html|Accept:text/html, application/xhtml+xml, application/xml]: Error: getaddrinfo ENOTFOUND ci.foo.redhat.com ci.foo.redhat.com:1337
    insights_proxy_1    |     at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:56:26)
    insights_proxy_1    |   errno: 'ENOTFOUND',
    insights_proxy_1    |   code: 'ENOTFOUND',
    insights_proxy_1    |   syscall: 'getaddrinfo',
    insights_proxy_1    |   hostname: 'ci.foo.redhat.com',
    insights_proxy_1    |   host: 'ci.foo.redhat.com',
    insights_proxy_1    |   port: '1337',
    insights_proxy_1    |   request:
    insights_proxy_1    |    { url:
    insights_proxy_1    |       'https://ci.foo.redhat.com:1337/apps/chrome/snippets/body.html',
    insights_proxy_1    |      headers:
    insights_proxy_1    |       { accept: 'text/html, application/xhtml+xml, application/xml' },
    insights_proxy_1    |      gzip: true,
    insights_proxy_1    |      method: 'GET' } }
    insights_proxy_1    | An error occurred while resolving an ESI tag for the ci.foo.redhat.com host
    insights_proxy_1    | { [While requesting GET|https://ci.foo.redhat.com:1337/apps/chrome/snippets/head.html|Accept:text/html, application/xhtml+xml, application/xml]: Error: getaddrinfo ENOTFOUND ci.foo.redhat.com ci.foo.redhat.com:1337
    insights_proxy_1    |     at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:56:26)
    insights_proxy_1    |   errno: 'ENOTFOUND',
    insights_proxy_1    |   code: 'ENOTFOUND',
    insights_proxy_1    |   syscall: 'getaddrinfo',
    insights_proxy_1    |   hostname: 'ci.foo.redhat.com',
    insights_proxy_1    |   host: 'ci.foo.redhat.com',
    insights_proxy_1    |   port: '1337',
    insights_proxy_1    |   request:
    insights_proxy_1    |    { url:
    insights_proxy_1    |       'https://ci.foo.redhat.com:1337/apps/chrome/snippets/head.html',
    insights_proxy_1    |      headers:
    insights_proxy_1    |       { accept: 'text/html, application/xhtml+xml, application/xml' },
    insights_proxy_1    |      gzip: true,
    insights_proxy_1    |      method: 'GET' } }

To see the difference on Linux (with Docker 20):
`docker run --rm -it --net=host busybox cat /etc/hosts` .. this one has the host /etc/hosts mounted, so it's using the same one
`docker run --rm -it  busybox cat /etc/hosts` .. this one has its own copy, so without ci.foo

(It seems the default behaviour depends on the OS and Docker version, this issue is probably not happening in docker < 16 and under docker-machine (on Macs), maybe.)

Fixing by explicitly adding the same entries to the container via `extra_hosts` (https://docs.docker.com/compose/compose-file/compose-file-v2/#extra_hosts)

---

Cc @rochacbruno 
Cc @newswangerd @ZitaNemeckova  ... can you please test if insights mode still works for you on Macs?