### PR TITLE
Implement distro based import aah 558

### DIFF
--- a/CHANGES/558.feature
+++ b/CHANGES/558.feature
@@ -1,0 +1,44 @@
+All collections to be importer to any repo, not just inbound-namespace
+
+
+Notes:
+
+My proposal is based on the idea of being able to push any content to a repo
+/dist  (ie, POST api/automation-hub/content/<str:path>/v3/collections/).
+
+
+A Post there is implemented via
+galaxy_ng.app.api.v3.viewsets.collections.CollectionUploadViewSet.create()
+Currently, it has some logic to figure out the inbound repo based on the
+artifact filename and matching that to a namespace that corresponds (as exists
+in c.r.c).
+
+
+But for standalone, a POST to
+/api/automation-hub/content/mycustomrepo/v3/collections/  would enqueue an
+import to 'inbound-mycustomrepo'.
+
+Depending on config for 'autopromote' it may automatically get moved to
+mycustomrepo if import succeeds, or it may move to a staging repo.
+
+
+This allows customers to push arbitrary collections with no regard to
+namespaces into repositories that they control.
+
+It also eliminates the need for creating inbound-<namespace> repos for every
+namespace.
+
+Most of this would be done in  CollectionUploadViewSet.create() and could be
+enable/disabled based on deployment mode.
+
+
+This also allows customers to use the ansible-galaxy config that is provided on
+the 'Repo Management' page
+(http://localhost:8002/ui/repositories?page_size=10&tab=local).
+
+They would only need to configure one repo or /content/<name>/ endpoint, and it
+would be used for both download and publishing content.
+
+Under the covers content published to
+/api/automation-hub/content/mycustomrepo/v3/collections/  gets directed to the
+matching inbound repo.

--- a/CHANGES/558.feature
+++ b/CHANGES/558.feature
@@ -18,6 +18,8 @@ But for standalone, a POST to
 /api/automation-hub/content/mycustomrepo/v3/collections/  would enqueue an
 import to 'inbound-mycustomrepo'.
 
+NEED to create inbound-mycustomrepo somewhere
+
 Depending on config for 'autopromote' it may automatically get moved to
 mycustomrepo if import succeeds, or it may move to a staging repo.
 

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -55,17 +55,27 @@ class NamespaceAccessPolicy(AccessPolicyBase):
 class CollectionAccessPolicy(AccessPolicyBase):
     NAME = 'CollectionViewSet'
 
+    # NOTE: These are really more about modifying a Repository/Distribution
+    #       that contains these collections.
+    # NOTE: Also really more about modifying Repositories and updating a collection
+    #       and uploading a new collection version are the same thing.
     def can_update_collection(self, request, view, permission):
         collection = view.get_object()
         namespace = models.Namespace.objects.get(name=collection.namespace)
         return request.user.has_perm('galaxy.upload_to_namespace', namespace)
 
+    # FIXME: probably need to add something like 'can_modify_repository' and/or
+    #        'can_modify_distribution'. Or 'upload_to_repository', possibly
+    #        for dest repo and/or inbound repos.
     def can_create_collection(self, request, view, permission):
         data = view._get_data(request)
         try:
             namespace = models.Namespace.objects.get(name=data['filename'].namespace)
         except models.Namespace.DoesNotExist:
             raise NotFound('Namespace in filename not found.')
+        # FIXME: Need to change what we evaulate for perms to upload to a repository.
+        #        The upload_to_namespace perm makes a lot of assumptions which will
+        #        not be true anymore.
         return request.user.has_perm('galaxy.upload_to_namespace', namespace)
 
 

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -69,9 +69,13 @@ class CollectionAccessPolicy(AccessPolicyBase):
     #        for dest repo and/or inbound repos.
     def can_create_collection(self, request, view, permission):
         data = view._get_data(request)
+        log.debug('data=%s', data)
+        log.debug('request.user=%s', request.user)
+
         try:
             namespace = models.Namespace.objects.get(name=data['filename'].namespace)
         except models.Namespace.DoesNotExist:
+            log.exception('didnt find namespace %s', namespace)
             raise NotFound('Namespace in filename not found.')
         # FIXME: Need to change what we evaulate for perms to upload to a repository.
         #        The upload_to_namespace perm makes a lot of assumptions which will

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -123,12 +123,16 @@ class CollectionUploadViewSet(api_base.LocalSettingsMixin,
         """Dispatch a pulp task started on upload of collection version."""
         locks = []
 
+        log.debug('temp_file_pk=%s', temp_file_pk)
+        log.debug('repository=%s', repository)
+
         kwargs["temp_file_pk"] = temp_file_pk
 
         if repository:
             locks.append(repository)
             kwargs["repository_pk"] = repository.pk
 
+        log.debug('kwargs=%s', kwargs)
         if settings.GALAXY_REQUIRE_CONTENT_APPROVAL:
             return enqueue_with_reservation(import_and_move_to_staging, locks, kwargs=kwargs)
         return enqueue_with_reservation(import_and_auto_approve, locks, kwargs=kwargs)
@@ -175,7 +179,14 @@ class CollectionUploadViewSet(api_base.LocalSettingsMixin,
         data = self._get_data(request)
         filename = data['filename']
 
+        log.debug('settings.GALAXY_REQUIRE_CONTENT_APPROVAL=%s',
+                  settings.GALAXY_REQUIRE_CONTENT_APPROVAL)
+        log.debug('kwargs=%s', kwargs)
+        log.debug('filename.namespace=%s', filename.namespace)
+
         path = self._get_path(kwargs, filename_ns=filename.namespace)
+
+        log.debug('path=%s', path)
 
         try:
             namespace = models.Namespace.objects.get(name=filename.namespace)
@@ -184,7 +195,8 @@ class CollectionUploadViewSet(api_base.LocalSettingsMixin,
                 'Namespace "{0}" does not exist.'.format(filename.namespace)
             )
 
-        self._check_path_matches_expected_repo(path, filename_ns=namespace.name)
+        log.debug('namespace=%s', namespace)
+        # self._check_path_matches_expected_repo(path, filename_ns=namespace.name)
 
         self.check_object_permissions(request, namespace)
 

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -184,9 +184,9 @@ class CollectionUploadViewSet(api_base.LocalSettingsMixin,
         log.debug('kwargs=%s', kwargs)
         log.debug('filename.namespace=%s', filename.namespace)
 
-        path = self._get_path(kwargs, filename_ns=filename.namespace)
+        distro_base_path = self._get_path(kwargs, filename_ns=filename.namespace)
 
-        log.debug('path=%s', path)
+        log.debug('distro_base_path=%s', distro_base_path)
 
         try:
             namespace = models.Namespace.objects.get(name=filename.namespace)
@@ -201,7 +201,7 @@ class CollectionUploadViewSet(api_base.LocalSettingsMixin,
         self.check_object_permissions(request, namespace)
 
         try:
-            response = super(CollectionUploadViewSet, self).create(request, path)
+            response = super(CollectionUploadViewSet, self).create(request, distro_base_path)
         except ValidationError:
             log.exception('Failed to publish artifact %s (namespace=%s, sha256=%s)',  # noqa
                           data['file'].name, namespace, data.get('sha256'))
@@ -228,7 +228,7 @@ class CollectionUploadViewSet(api_base.LocalSettingsMixin,
         #       it needs the  repo/distro base_path for the <path> part of url
         import_obj_url = reverse("galaxy:api:content:v3:collection-import",
                                  kwargs={'pk': str(task_detail.pulp_id),
-                                         'path': path})
+                                         'path': distro_base_path})
 
         log.debug('import_obj_url: %s', import_obj_url)
         return Response(

--- a/galaxy_ng/app/models/collectionimport.py
+++ b/galaxy_ng/app/models/collectionimport.py
@@ -46,3 +46,9 @@ class CollectionImport(LifecycleModel, AutoDeleteObjPermsMixin):
 
     def get_absolute_url(self):
         return reverse('galaxy:api:content:collection-import', args=[str(self.task_id)])
+
+    def label(self):
+        return f"{self.namespace}.{self.name}"
+
+    def label_and_version(self):
+        return f"{self.namespace}.{self.name}-{self.version}"

--- a/galaxy_ng/app/models/collectionsync.py
+++ b/galaxy_ng/app/models/collectionsync.py
@@ -1,10 +1,21 @@
+import logging
+
 from django.db import models
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from pulpcore.plugin.models import Task
 from pulp_ansible.app.models import AnsibleRepository, Collection
 
 from .namespace import Namespace
+
+log = logging.getLogger(__name__)
+
+
+@receiver(pre_save, sender=Collection)
+def log_collection_pre_save(sender, instance, raw, using, update_fields, **kwargs):
+    log.debug('Collection pre_save instance=%s', instance)
+    # log.debug('Collection pre_save update_fields=%s', update_fields)
+    # log.debug('Collection pre_save kwargs=%s', repr(kwargs))
 
 
 @receiver(post_save, sender=Collection)
@@ -21,7 +32,11 @@ def create_namespace_if_not_present(sender, instance, created, **kwargs):
     Namespace is created.
     """
 
-    Namespace.objects.get_or_create(name=instance.namespace)
+    # log.debug('post_save ns handler sender=%s', sender)
+    log.debug('post_save ns handler instance=%s', instance)
+
+    ns = Namespace.objects.get_or_create(name=instance.namespace)
+    log.debug('post_save ns handler namespace=%s', ns)
 
 
 class CollectionSyncTask(models.Model):


### PR DESCRIPTION
For case #2, the goal is to support having an optional ‘inbound’ repo for ever exposed repo (Published, Red Hat Reviews, Community, etc) instead of creating an inbound repo for every potential namespace.