### PR TITLE
Create per namespace inbound repos on all namespace creation

### DIFF
--- a/CHANGES/739.bugfix
+++ b/CHANGES/739.bugfix
@@ -1,0 +1,1 @@
+Create 'inbound-namespaces' whenever a namespace is created.

--- a/galaxy_ng/app/models/namespace.py
+++ b/galaxy_ng/app/models/namespace.py
@@ -9,7 +9,6 @@ from pulp_ansible.app.models import AnsibleRepository, AnsibleDistribution
 from galaxy_ng.app.access_control import mixins
 from galaxy_ng.app.constants import INBOUND_REPO_NAME_FORMAT
 
-
 __all__ = ("Namespace", "NamespaceLink")
 
 
@@ -48,9 +47,11 @@ class NamespaceManager(models.Manager):
             create_inbound_repo(obj.name)
         return super().bulk_create(objs, **kwargs)
 
-    def delete(self):
-        delete_inbound_repo(self.name)
-        return super().delete()
+    def get_or_create(self, *args, **kwargs):
+        ns, created = super().get_or_create(*args, **kwargs)
+        if created:
+            create_inbound_repo(kwargs['name'])
+        return ns, created
 
 
 class Namespace(LifecycleModel, mixins.GroupModelPermissionsMixin, AutoDeleteObjPermsMixin):
@@ -95,6 +96,10 @@ class Namespace(LifecycleModel, mixins.GroupModelPermissionsMixin, AutoDeleteObj
             NamespaceLink(name=link["name"], url=link["url"], namespace=self)
             for link in links
         )
+
+    def delete(self, *args, **kwargs):
+        delete_inbound_repo(self.name)
+        return super().delete(*args, **kwargs)
 
     class Meta:
         permissions = (

--- a/galaxy_ng/tests/unit/test_models.py
+++ b/galaxy_ng/tests/unit/test_models.py
@@ -45,9 +45,12 @@ class TestNamespaceModelManager(TestCase):
     def test_delete_namespace_deletes_inbound_repo(self):
         """When deleting a Namespace the manager should delete inbound instances."""
         Namespace.objects.get_or_create(name=self.namespace_name)
-        Namespace.objects.filter(name=self.namespace_name).delete()
+        ns = Namespace.objects.get(name=self.namespace_name)
+        ns.delete()
 
         inbound_name = INBOUND_REPO_NAME_FORMAT.format(namespace_name=self.namespace_name)
+
         self.assertFalse(Namespace.objects.filter(name=self.namespace_name).exists())
+
         self.assertFalse(AnsibleRepository.objects.filter(name=inbound_name).exists())
         self.assertFalse(AnsibleDistribution.objects.filter(name=inbound_name).exists())


### PR DESCRIPTION
This will create a new Repository and Distribution for every
Namespace in Galaxy.

Issue: AAH-739