### PR TITLE
Add endpoint to return the /excludes/ list from synclists.

### DIFF
--- a/CHANGES/606.misc
+++ b/CHANGES/606.misc
@@ -1,0 +1,1 @@
+Add <path>/excludes/ endpoint to return synclist exclude for given distro

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -100,4 +100,9 @@ urlpatterns = [
         viewsets.TaskViewSet.as_view({'get': 'retrieve'}),
         name='tasks-detail'
     ),
+    path(
+        'excludes/',
+        views.ExcludesView.as_view(),
+        name='excludes-file'
+    ),
 ]

--- a/galaxy_ng/app/api/v3/views/__init__.py
+++ b/galaxy_ng/app/api/v3/views/__init__.py
@@ -1,5 +1,6 @@
 from .auth import TokenView
 from .sync import SyncRemoteView
+from .excludes import ExcludesView
 
 
-__all__ = ("TokenView", "SyncRemoteView")
+__all__ = ("TokenView", "SyncRemoteView", "ExcludesView")

--- a/galaxy_ng/app/api/v3/views/excludes.py
+++ b/galaxy_ng/app/api/v3/views/excludes.py
@@ -1,0 +1,85 @@
+import yaml
+from django.core.exceptions import ObjectDoesNotExist
+from galaxy_ng.app import models
+from galaxy_ng.app.access_control import access_policy
+from galaxy_ng.app.api import base as api_base
+from pulp_ansible.app.models import AnsibleDistribution
+from rest_framework.renderers import (
+    BaseRenderer,
+    BrowsableAPIRenderer,
+    JSONRenderer
+)
+from rest_framework.request import Request
+from rest_framework.response import Response
+from yaml.dumper import SafeDumper
+
+
+def get_synclist_excludes(base_path):
+    """Get Synclist from distro base_path"""
+    try:
+        repo = AnsibleDistribution.objects.get(base_path=base_path).repository
+        synclist = models.SyncList.objects.get(repository=repo, policy="exclude")
+        return synclist.collections.all()
+    except ObjectDoesNotExist:
+        return None
+
+
+def serialize_collection_queryset(queryset):
+    """Serialize a Queryset in to a JSONable format."""
+    return queryset is not None and [
+        {
+            "name": "{collection.namespace}/{collection.name}".format(collection=collection)
+        }
+        for collection in queryset.all()
+    ] or []
+
+
+class RequirementsFileRenderer(BaseRenderer):
+    """Renders requirements YAML format."""
+
+    media_type = 'application/yaml'
+    format = 'yaml'
+    charset = 'utf-8'
+    encoder = SafeDumper
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        """
+        Renders data to YAML.
+
+        Args:
+            data: Object to be rendered as YAML.
+            accepted_media_type: The media type the client accepts.
+            renderer_context: Renderer context.
+
+        Returns:
+            A rendered response in YAML format.
+        """
+        if data is None:
+            return ""
+
+        return yaml.dump(
+            data,
+            stream=None,
+            encoding=self.charset,
+            Dumper=self.encoder,
+            allow_unicode=True,
+            default_flow_style=False,
+        )
+
+
+class ExcludesView(api_base.APIView):
+    permission_classes = [access_policy.CollectionAccessPolicy]
+    action = 'list'
+    renderer_classes = [
+        JSONRenderer,
+        BrowsableAPIRenderer,
+        RequirementsFileRenderer
+    ]
+
+    def get(self, request: Request, *args, **kwargs):
+        """
+        Returns a list of excludes for a given distro.
+        """
+        queryset = get_synclist_excludes(self.kwargs["path"])
+        collections_to_exclude = serialize_collection_queryset(queryset)
+        return Response({"collections": collections_to_exclude})

--- a/galaxy_ng/app/api/v3/views/excludes.py
+++ b/galaxy_ng/app/api/v3/views/excludes.py
@@ -28,7 +28,7 @@ def serialize_collection_queryset(queryset):
     """Serialize a Queryset in to a JSONable format."""
     return queryset is not None and [
         {
-            "name": "{collection.namespace}/{collection.name}".format(collection=collection)
+            "name": "{collection.namespace}.{collection.name}".format(collection=collection)
         }
         for collection in queryset.all()
     ] or []


### PR DESCRIPTION
pulp_ansible sync is going to try a fetch on `{REMOTE}/<path>/excludes/`
this endpoint returns the consolidated synclist for exclude policy.

ex:
Given a synclist distro: `/api/automation-hub/content/5910538-synclist/`

Collections served at: `/api/automation-hub/content/5910538-synclist/v3/collections/`
Excludes served at: `/api/automation-hub/content/5910538-synclist/v3/excludes/`

Accept: application/json
```json
{
    "collections": [
        {
            "name": "newswangerd.collection_demo"
        },
        {
            "name": "fernandomorais.kubernetes_fork"
        }
    ]
}
```

Accept: application/yaml
```yaml
collections:
- name: newswangerd.collection_demo
- name: fernandomorais.kubernetes_fork
```

Issue: AAH-606