### PR TITLE
Clowder: Update port numbers and settings

### DIFF
--- a/docker/etc/settings.py
+++ b/docker/etc/settings.py
@@ -4,9 +4,9 @@ DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 AWS_DEFAULT_ACL = None
 
 CONTENT_PATH_PREFIX = "/api/automation-hub/v3/artifacts/collections/"
-GALAXY_API_PATH_PREFIX = "/api/automation-hub"
+ANSIBLE_API_HOSTNAME = os.environ.get('PULP_CONTENT_ORIGIN')
 
-GALAXY_DEPLOYMENT_MODE = os.environ.get('GALAXY_DEPLOYMENT_MODE')
+GALAXY_API_PATH_PREFIX = "/api/automation-hub"
 GALAXY_AUTHENTICATION_CLASSES = ['galaxy_ng.app.auth.auth.RHIdentityAuthentication']
 GALAXY_PERMISSION_CLASSES = ['rest_framework.permissions.IsAuthenticated',
                              'galaxy_ng.app.auth.auth.RHEntitlementRequired']

--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -30,10 +30,16 @@ objects:
             cpu: ${{GALAXY_API_CPU_REQUEST}}
             memory: ${{GALAXY_API_MEMORY_REQUEST}}
         env:
-          - name: GALAXY_DEPLOYMENT_MODE
+          - name: PULP_GALAXY_DEPLOYMENT_MODE
             value: 'insights'
           - name: PULP_CONTENT_ORIGIN
             value: 'localhost'
+          - name: PULP_RH_ENTITLEMENT_REQUIRED
+            value: 'insights'
+          - name: PULP_X_PULP_CONTENT_HOST
+            value: 'automation-hub-pulp-content-app'
+          - name: PULP_X_PULP_CONTENT_PORT
+            value: '10000'
       webServices:
         public:
             enabled: true
@@ -53,7 +59,7 @@ objects:
             cpu: ${{PULP_RESOURCE_MANAGER_CPU_REQUEST}}
             memory: ${{PULP_RESOURCE_MANAGER_MEMORY_REQUEST}}
         env:
-          - name: GALAXY_DEPLOYMENT_MODE
+          - name: PULP_GALAXY_DEPLOYMENT_MODE
             value: 'insights'
           - name: PULP_CONTENT_ORIGIN
             value: 'localhost'
@@ -73,10 +79,15 @@ objects:
             cpu: ${{PULP_CONTENT_APP_CPU_REQUEST}}
             memory: ${{PULP_CONTENT_APP_MEMORY_REQUEST}}
         env:
-          - name: GALAXY_DEPLOYMENT_MODE
+          - name: PULP_GALAXY_DEPLOYMENT_MODE
             value: 'insights'
           - name: PULP_CONTENT_ORIGIN
             value: 'localhost'
+          - name: GUNICORN_PORT
+            value: '10000'
+      webServices:
+        private:
+            enabled: true
 
     - name: pulp-worker
       k8sAccessLevel: edit
@@ -94,7 +105,7 @@ objects:
             cpu: ${{PULP_WORKER_CPU_REQUEST}}
             memory: ${{PULP_WORKER_MEMORY_REQUEST}}
         env:
-          - name: GALAXY_DEPLOYMENT_MODE
+          - name: PULP_GALAXY_DEPLOYMENT_MODE
             value: 'insights'
           - name: IMPORTER_MEMORY_REQUEST
             value: 1Gi


### PR DESCRIPTION
* Add required `PULP_RH_ENTITLEMENT_REQUIRED` environment variable.
* Set pulp-content-app listen port to Clowder's private
  webService port (`10000`).
* Configure pulp-content-app host:port for galaxy-api.
* Remove redundant `GALAXY_DEPLOYMENT_MODE` from container settings.py.
* Add `ANSIBLE_API_HOSTNAME` parameter to be set based on
  `CONTENT_ORIGIN`

No-Issue