### PR TITLE
Make the API Root view to raise 404 if distro doesn't exist.

### DIFF
--- a/CHANGES/157.bugfix
+++ b/CHANGES/157.bugfix
@@ -1,0 +1,1 @@
+Made API Root view to raise 404 if distro path is provided but distro doesn´t exist.

--- a/galaxy_ng/app/api/views.py
+++ b/galaxy_ng/app/api/views.py
@@ -1,5 +1,7 @@
 from django.apps import apps
 from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from pulp_ansible.app.models import AnsibleDistribution
 
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -8,19 +10,30 @@ from rest_framework.reverse import reverse
 from galaxy_ng.app.api import base as api_base
 
 
+# define the version matrix at the module level to avoid the redefinition on every API call.
+VERSIONS = {
+    "available_versions": {"v3": "v3/"},
+    "server_version": apps.get_app_config("galaxy").version,
+    "galaxy_ng_version": apps.get_app_config("galaxy").version,
+    "pulp_ansible_version": apps.get_app_config('ansible').version,
+}
+
+
 class ApiRootView(api_base.APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
-        data = {
-            "available_versions": {"v3": "v3/"},
-            "server_version": apps.get_app_config("galaxy").version,
-            "galaxy_ng_version": apps.get_app_config("galaxy").version,
-            "pulp_ansible_version": apps.get_app_config('ansible').version,
-        }
+        """
+        Returns the version matrix for the API + the current distro.
+        """
+        data = {**VERSIONS}
 
         if kwargs.get("path"):
-            data["distro_base_path"] = kwargs["path"]
+            distro = get_object_or_404(
+                AnsibleDistribution,
+                name=self.kwargs["path"]
+            )
+            data["distro_base_path"] = distro.base_path
 
         return Response(data)
 


### PR DESCRIPTION
The api call:

```bash
❯ http :8002/api/automation-hub/content/anything_can_be_passed_here/
```

Before:

```
{
    "available_versions": { "v3": "v3/" },
    "distro_base_path": "anything_can_be_passed_here",
    "galaxy_ng_version": "4.2.0",
    "pulp_ansible_version": "0.5.0",
    "server_version": "4.2.0"
}
```

Now:

```bash
{
    "errors": [
        {
            "status": "404",
            "code": "not_found",
            "title": "Not found."
        }
    ]
}
```

If an existing distro is requested

```bash
{
    "available_versions": {
        "v3": "v3/"
    },
    "server_version": "4.4.0dev",
    "galaxy_ng_version": "4.4.0dev",
    "pulp_ansible_version": "0.7.3",
    "distro_base_path": "5910538-synclist"
}
```

If no distro_bse_path is provided

```bash
GET /api/automation-hub/
{
    "available_versions": {
        "v3": "v3/"
    },
    "server_version": "4.4.0dev",
    "galaxy_ng_version": "4.4.0dev",
    "pulp_ansible_version": "0.7.3"
}
```

Issue: AAH-157