### PR TITLE
Fix imports filter

### DIFF
--- a/CHANGES/646.bugfix
+++ b/CHANGES/646.bugfix
@@ -1,0 +1,1 @@
+Implemented filters for state and keywords on imports API.

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -170,6 +170,8 @@ class CollectionVersionViewSet(api_base.GenericViewSet):
 class CollectionImportFilter(filterset.FilterSet):
     namespace = filters.CharFilter(field_name='galaxy_import__namespace__name')
     name = filters.CharFilter(field_name='galaxy_import__name')
+    keywords = filters.CharFilter(field_name='galaxy_import__name', lookup_expr='icontains')
+    state = filters.CharFilter(field_name='task__state')
     version = filters.CharFilter(field_name='galaxy_import__version')
     created = filters.DateFilter(field_name='galaxy_import__created_at')
     versioning_class = versioning.UIVersioning
@@ -182,6 +184,8 @@ class CollectionImportFilter(filterset.FilterSet):
         model = PulpCollectionImport
         fields = ['namespace',
                   'name',
+                  'keywords',
+                  'state',
                   'version']
 
 


### PR DESCRIPTION
Issue https://issues.redhat.com/browse/AAH-646

Implemented state and keyword filters for imports API.

Request URL: 
http://localhost:8002/api/automation-hub/_ui/v1/imports/collections/?namespace=ibm&keywords=ibm&state=completed&sort=-created&offset=0&limit=10