### PR TITLE
Update tasks to use pulp_id instead of id.

### DIFF
--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -119,7 +119,7 @@ def _get_last_sync_task(repo):
         return
 
     return {
-        "task_id": sync_task.id,
+        "task_id": sync_task.pulp_id,
         "state": sync_task.task.state,
         "started_at": sync_task.task.started_at,
         "finished_at": sync_task.task.finished_at,

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -38,7 +38,7 @@ class LastSyncTaskMixin:
             return
 
         return {
-            "task_id": sync_task.id,
+            "task_id": sync_task.pulp_id,
             "state": sync_task.task.state,
             "started_at": sync_task.task.started_at,
             "finished_at": sync_task.task.finished_at,

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -332,12 +332,12 @@ class CollectionVersionMoveViewSet(api_base.ViewSet):
                 curate_task = dispatch(
                     curate_all_synclist_repository, locks, args=task_args, kwargs=task_kwargs
                 )
-                curate_task_id = curate_task.id
+                curate_task_id = curate_task.pulp_id
 
         return Response(
             data={
-                'copy_task_id': copy_task.id,
-                'remove_task_id': remove_task.id,
+                'copy_task_id': copy_task.pulp_id,
+                'remove_task_id': remove_task.pulp_id,
                 "curate_all_synclist_repository_task_id": curate_task_id,
             },
             status='202'


### PR DESCRIPTION
Pulp now uses `pulp_id` for task IDs, instead of `id`