### PR TITLE
Mark API strings for translation

### DIFF
--- a/.github/workflows/scripts/post_before_script.sh
+++ b/.github/workflows/scripts/post_before_script.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -mveuo pipefail
+source .github/workflows/scripts/utils.sh
+cmd_prefix bash -c "django-admin compilemessages"

--- a/CHANGES/830.misc
+++ b/CHANGES/830.misc
@@ -1,0 +1,1 @@
+Mark API strings for translation and add 'from django.utils.translation import gettext_lazy as _'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include pyproject.toml
 include requirements/requirements.common.txt
 graft galaxy_ng/app/webserver_snippets
 graft galaxy_ng/app/static
+graft galaxy_ng/locale

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 from rest_access_policy import AccessPolicy
 from rest_framework.exceptions import NotFound
 
@@ -65,7 +66,7 @@ class CollectionAccessPolicy(AccessPolicyBase):
         try:
             namespace = models.Namespace.objects.get(name=data['filename'].namespace)
         except models.Namespace.DoesNotExist:
-            raise NotFound('Namespace in filename not found.')
+            raise NotFound(_('Namespace in filename not found.'))
         return request.user.has_perm('galaxy.upload_to_namespace', namespace)
 
 

--- a/galaxy_ng/app/access_control/fields.py
+++ b/galaxy_ng/app/access_control/fields.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Permission
 from django.db.models import Q
+from django.utils.translation import gettext_lazy as _
 
 from guardian.shortcuts import get_perms_for_model
 
@@ -13,17 +14,17 @@ class GroupPermissionField(serializers.Field):
     def _validate_group(self, group_data):
         if 'object_permissions' not in group_data:
             raise ValidationError(detail={
-                'groups': 'object_permissions field is required'})
+                'groups': _('object_permissions field is required')})
 
         if 'id' not in group_data and 'name' not in group_data:
             raise ValidationError(detail={
-                'groups': 'id or name field is required'})
+                'groups': _('id or name field is required')})
 
         perms = group_data['object_permissions']
 
         if not isinstance(perms, list):
             raise ValidationError(detail={
-                'groups': 'object_permissions must be a list of strings'})
+                'groups': _('object_permissions must be a list of strings')})
 
         # validate that the permissions exist
         for perm in perms:
@@ -37,7 +38,7 @@ class GroupPermissionField(serializers.Field):
             # performing N queries for each permission
             if not Permission.objects.filter(filter_q).exists():
                 raise ValidationError(detail={
-                    'groups': 'Permission {} does not exist'.format(perm)})
+                    'groups': _('Permission {} does not exist').format(perm)})
 
     def to_representation(self, value):
         rep = []
@@ -52,7 +53,7 @@ class GroupPermissionField(serializers.Field):
     def to_internal_value(self, data):
         if not isinstance(data, list):
             raise ValidationError(detail={
-                'groups': 'Groups must be a list of group objects'
+                'groups': _('Groups must be a list of group objects')
             })
 
         internal = {}
@@ -67,10 +68,11 @@ class GroupPermissionField(serializers.Field):
                 internal[group] = group_data['object_permissions']
             except auth_models.Group.DoesNotExist:
                 raise ValidationError(detail={
-                    'groups': "Group name=%s, id=%s does not exist" % (group_data.get('name'),
-                                                                       group_data.get('id'))})
+                    'groups': _("Group name=%s, id=%s does not exist") % (
+                        group_data.get('name'), group_data.get('id'))
+                })
             except ValueError:
-                raise ValidationError(detail={'group': 'Invalid group name or ID'})
+                raise ValidationError(detail={'group': _('Invalid group name or ID')})
 
         return internal
 

--- a/galaxy_ng/app/api/base.py
+++ b/galaxy_ng/app/api/base.py
@@ -6,7 +6,6 @@ from rest_framework import views
 from rest_framework import viewsets
 from rest_framework.settings import perform_import
 
-
 GALAXY_EXCEPTION_HANDLER = perform_import(
     settings.GALAXY_EXCEPTION_HANDLER,
     'GALAXY_EXCEPTION_HANDLER'

--- a/galaxy_ng/app/api/ui/serializers/synclist.py
+++ b/galaxy_ng/app/api/ui/serializers/synclist.py
@@ -3,7 +3,7 @@ import logging
 from django.conf import settings
 from django.db import transaction
 from django.db.utils import IntegrityError
-
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import ValidationError
 from rest_framework import serializers
@@ -13,7 +13,6 @@ from pulp_ansible.app.models import AnsibleRepository, AnsibleDistribution
 
 from galaxy_ng.app import models
 from galaxy_ng.app.access_control.fields import GroupPermissionField
-
 
 log = logging.getLogger(__name__)
 
@@ -39,7 +38,7 @@ class SyncListSerializer(serializers.ModelSerializer):
             repository = AnsibleRepository.objects.get(pulp_id=repository_id)
             return repository
         except AnsibleRepository.DoesNotExist:
-            errmsg = 'Repository "{pulp_id}" not found while creating synclist'
+            errmsg = _('Repository "{pulp_id}" not found while creating synclist')
             raise ValidationError(errmsg.format(pulp_id=repository_id))
 
     def to_internal_value(self, data):
@@ -94,7 +93,7 @@ class SyncListSerializer(serializers.ModelSerializer):
                 **validated_data
             )
         except IntegrityError as exc:
-            raise ValidationError("Synclist already exists: %s" % exc)
+            raise ValidationError(_("Synclist already exists: %s") % exc)
 
         collections = []
         for collection_data in collections_data:
@@ -102,7 +101,8 @@ class SyncListSerializer(serializers.ModelSerializer):
                 collections.append(Collection.objects.get(**collection_data))
             except Collection.DoesNotExist:
                 errmsg = (
-                    'Collection "{namespace}.{name}" not found while creating synclist {synclist}'
+                    _('Collection "{namespace}.{name}" not found '
+                      'while creating synclist {synclist}')
                 )
                 raise ValidationError(
                     errmsg.format(
@@ -140,7 +140,8 @@ class SyncListSerializer(serializers.ModelSerializer):
                 new_collections.append(Collection.objects.get(**collection_data))
             except Collection.DoesNotExist:
                 errmsg = (
-                    'Collection "{namespace}.{name}" not found while updating synclist {synclist}'
+                    _('Collection "{namespace}.{name}" not found '
+                      'while updating synclist {synclist}')
                 )
                 raise ValidationError(
                     errmsg.format(

--- a/galaxy_ng/app/api/ui/serializers/user.py
+++ b/galaxy_ng/app/api/ui/serializers/user.py
@@ -1,4 +1,6 @@
 from django.contrib.auth import password_validation
+from django.utils.translation import gettext_lazy as _
+
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -55,8 +57,8 @@ class UserSerializer(serializers.ModelSerializer):
             for g in group_difference:
                 if not authed_user_groups.filter(pk=g.id).exists():
                     raise ValidationError(detail={
-                        "groups": "'galaxy.change_group' permission is required to change"
-                                  " a users group that the requesting user is not in."
+                        "groups": _("'galaxy.change_group' permission is required to change"
+                                    " a users group that the requesting user is not in.")
                     })
 
         return groups
@@ -66,7 +68,7 @@ class UserSerializer(serializers.ModelSerializer):
         if request_user.is_superuser != data:
             if not request_user.is_superuser:
                 raise ValidationError(detail={
-                    "is_superuser": "Must be a super user to grant super user permissions."
+                    "is_superuser": _("Must be a super user to grant super user permissions.")
                 })
 
         return data
@@ -109,10 +111,11 @@ class UserSerializer(serializers.ModelSerializer):
                     group_ids.append(group.id)
                 except auth_models.Group.DoesNotExist:
                     raise ValidationError(detail={
-                        'groups': "Group name=%s, id=%s does not exist" % (group.get('name'),
-                                                                           group.get('id'))})
+                        'groups': _('Group name=%(name)s, id=%(id)s does not exist') % {
+                            'name': group.get('name'), 'id': group.get('id')}
+                    })
                 except ValueError:
-                    raise ValidationError(detail={'group': 'Invalid group name or ID'})
+                    raise ValidationError(detail={'group': _('Invalid group name or ID')})
             data['groups'] = group_ids
         return super().to_internal_value(data)
 

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -2,6 +2,7 @@ from django.db.models import Exists, OuterRef, Q
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend, OrderingFilter
 from drf_spectacular.utils import extend_schema
@@ -53,7 +54,7 @@ class CollectionViewSet(
         """Returns a CollectionVersions queryset for specified distribution."""
         path = self.kwargs.get('path')
         if path is None:
-            raise Http404("Distribution base path is required")
+            raise Http404(_("Distribution base path is required"))
 
         versions = CollectionVersion.objects.filter(pk__in=self._distro_content).values_list(
             "collection_id",
@@ -151,7 +152,7 @@ class CollectionVersionViewSet(api_base.GenericViewSet):
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 
-    @extend_schema(summary="Retrieve collection version",
+    @extend_schema(summary=_("Retrieve collection version"),
                    responses={200: serializers.CollectionVersionDetailSerializer})
     def retrieve(self, request, *args, **kwargs):
         namespace, name, version = self.kwargs['version'].split('/')
@@ -162,7 +163,7 @@ class CollectionVersionViewSet(api_base.GenericViewSet):
                 version=version,
             )
         except ObjectDoesNotExist:
-            raise NotFound(f'Collection version not found for: {self.kwargs["version"]}')
+            raise NotFound(_('Collection version not found for: {}').format(self.kwargs["version"]))
         serializer = serializers.CollectionVersionDetailSerializer(collection_version)
         return Response(serializer.data)
 
@@ -218,7 +219,7 @@ class CollectionImportViewSet(api_base.GenericViewSet,
 
         return self.get_paginated_response(serializer.data)
 
-    @extend_schema(summary="Retrieve collection import",
+    @extend_schema(summary=_("Retrieve collection import"),
                    responses={200: serializers.ImportTaskDetailSerializer})
     def retrieve(self, request, *args, **kwargs):
         task = self.get_object()

--- a/galaxy_ng/app/api/ui/viewsets/group.py
+++ b/galaxy_ng/app/api/ui/viewsets/group.py
@@ -1,4 +1,5 @@
 from django.db import transaction
+from django.utils.translation import gettext_lazy as _
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend
 
@@ -41,7 +42,7 @@ class GroupViewSet(LocalSettingsMixin, viewsets.GroupViewSet):
         name = request.data['name']
         if Group.objects.filter(name=name).exists():
             raise ConflictError(
-                detail={'name': f'A group named {name} already exists.'}
+                detail={'name': _('A group named %s already exists.') % name}
             )
         return super().create(request, *args, **kwargs)
 

--- a/galaxy_ng/app/api/utils.py
+++ b/galaxy_ng/app/api/utils.py
@@ -5,6 +5,8 @@ import socket
 from urllib3.connection import HTTPConnection
 from urllib3.connectionpool import HTTPConnectionPool
 
+from django.utils.translation import gettext_lazy as _
+
 from galaxy_importer.schema import MAX_LENGTH_NAME, MAX_LENGTH_VERSION
 
 CollectionFilename = namedtuple("CollectionFilename", ["namespace", "name", "version"])
@@ -40,22 +42,22 @@ def parse_collection_filename(filename):
     match = FILENAME_REGEXP.match(filename)
 
     if not match:
-        msg = "Invalid filename {filename}. Expected format: namespace-name-version.tar.gz"
+        msg = _("Invalid filename {filename}. Expected format: namespace-name-version.tar.gz")
         raise ValueError(msg.format(filename=filename))
 
     namespace, name, version = match.groups()
 
     match = VERSION_REGEXP.match(version)
     if not match:
-        msg = "Invalid version string {version} from filename {filename}. Expected semantic version format." # noqa
+        msg = _("Invalid version string {version} from filename {filename}. Expected semantic version format.") # noqa
         raise ValueError(msg.format(version=version, filename=filename))
 
     if len(namespace) > MAX_LENGTH_NAME:
-        raise ValueError(f"Expected namespace to be max length of {MAX_LENGTH_NAME}")
+        raise ValueError(_("Expected namespace to be max length of %s") % MAX_LENGTH_NAME)
     if len(name) > MAX_LENGTH_NAME:
-        raise ValueError(f"Expected name to be max length of {MAX_LENGTH_NAME}")
+        raise ValueError(_("Expected name to be max length of %s") % MAX_LENGTH_NAME)
     if len(version) > MAX_LENGTH_VERSION:
-        raise ValueError(f"Expected version to be max length of {MAX_LENGTH_VERSION}")
+        raise ValueError(_("Expected version to be max length of %s") % MAX_LENGTH_VERSION)
 
     return CollectionFilename(namespace, name, version)
 

--- a/galaxy_ng/app/api/v3/serializers/namespace.py
+++ b/galaxy_ng/app/api/v3/serializers/namespace.py
@@ -3,10 +3,10 @@ import re
 
 from django.db import transaction
 from django.core import validators
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import ValidationError
 from rest_framework import serializers
-
 
 from galaxy_ng.app import models
 from galaxy_ng.app.access_control.fields import GroupPermissionField
@@ -57,7 +57,7 @@ class NamespaceLinkSerializer(serializers.ModelSerializer):
     # adds the URL to the error so the user can figure out which link the error
     # message is for
     def validate_url(self, url):
-        v = validators.URLValidator(message=f"'{url}' is not a valid url.")
+        v = validators.URLValidator(message=_("'%s' is not a valid url.") % url)
         v(url)
         return url
 
@@ -85,16 +85,16 @@ class NamespaceSerializer(serializers.ModelSerializer):
     def validate_name(self, name):
         if not name:
             raise ValidationError(detail={
-                'name': "Attribute 'name' is required"})
+                'name': _("Attribute 'name' is required")})
         if not re.match(r'^[a-z0-9_]+$', name):
             raise ValidationError(detail={
-                'name': 'Name can only contain lower case letters, underscores and numbers'})
+                'name': _('Name can only contain lower case letters, underscores and numbers')})
         if len(name) <= 2:
             raise ValidationError(detail={
-                'name': 'Name must be longer than 2 characters'})
+                'name': _('Name must be longer than 2 characters')})
         if name.startswith('_'):
             raise ValidationError(detail={
-                'name': "Name cannot begin with '_'"})
+                'name': _("Name cannot begin with '_'")})
         return name
 
     @transaction.atomic

--- a/galaxy_ng/app/api/v3/serializers/sync.py
+++ b/galaxy_ng/app/api/v3/serializers/sync.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 from rest_framework import serializers
 
 from pulp_ansible.app import viewsets as pulp_viewsets
@@ -80,14 +82,14 @@ class CollectionRemoteSerializer(LastSyncTaskMixin, pulp_viewsets.CollectionRemo
     created_at = serializers.DateTimeField(source='pulp_created', required=False)
     updated_at = serializers.DateTimeField(source='pulp_last_updated', required=False)
     proxy_password = serializers.CharField(
-        help_text="Password for proxy authentication.",
+        help_text=_("Password for proxy authentication."),
         allow_null=True,
         required=False,
         style={'input_type': 'password'},
         write_only=True
     )
     proxy_username = serializers.CharField(
-        help_text="User for proxy authentication.",
+        help_text=_("User for proxy authentication."),
         allow_null=True,
         required=False,
         write_only=False,  # overwriting this as pulpcore defaults to True
@@ -100,14 +102,14 @@ class CollectionRemoteSerializer(LastSyncTaskMixin, pulp_viewsets.CollectionRemo
         style={'input_type': 'password'}
     )
     password = serializers.CharField(
-        help_text="Remote password.",
+        help_text=_("Remote password."),
         allow_null=True,
         required=False,
         style={'input_type': 'password'},
         write_only=True
     )
     username = serializers.CharField(
-        help_text="Remote user.",
+        help_text=_("Remote user."),
         allow_null=True,
         required=False,
         write_only=False,  # overwriting this as pulpcore defaults to True
@@ -156,8 +158,8 @@ class CollectionRemoteSerializer(LastSyncTaskMixin, pulp_viewsets.CollectionRemo
             raise serializers.ValidationError(
                 detail={
                     'requirements_file':
-                        'Syncing content from community domains without specifying a '
-                        'requirements file is not allowed.'
+                        _('Syncing content from community domains without specifying a '
+                          'requirements file is not allowed.')
                 }
             )
         return super().validate(data)

--- a/galaxy_ng/app/api/v3/views/sync.py
+++ b/galaxy_ng/app/api/v3/views/sync.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
 
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 
 from pulp_ansible.app import models as pulp_models
 from pulp_ansible.app.tasks.collections import sync as collection_sync
@@ -25,8 +26,8 @@ class SyncRemoteView(api_base.APIView):
 
         if not distro.repository or not distro.repository.remote:
             raise ValidationError(
-                detail={'remote': f'The {distro_path} distribution does not have'
-                                  ' any remotes associated with it.'})
+                detail={'remote': _('The %s distribution does not have'
+                                    ' any remotes associated with it.') % distro_path})
 
         remote = distro.repository.remote.ansible_collectionremote
 
@@ -36,8 +37,8 @@ class SyncRemoteView(api_base.APIView):
             raise ValidationError(
                 detail={
                     'requirements_file':
-                        'Syncing content from galaxy.ansible.com without specifying a '
-                        'requirements file is not allowed.'
+                        _('Syncing content from galaxy.ansible.com without specifying a '
+                          'requirements file is not allowed.')
                 })
 
         result = dispatch(

--- a/galaxy_ng/app/api/v3/viewsets/namespace.py
+++ b/galaxy_ng/app/api/v3/viewsets/namespace.py
@@ -1,5 +1,6 @@
 from django.db import transaction
 from django.db.models import Q
+from django.utils.translation import gettext_lazy as _
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend
 
@@ -57,6 +58,6 @@ class NamespaceViewSet(api_base.ModelViewSet):
         if name and models.Namespace.objects.filter(name=name).exists():
             # Ensures error raised is 409, not 400.
             raise ConflictError(
-                detail={'name': f'A namespace named {name} already exists.'}
+                detail={'name': _('A namespace named %s already exists.') % name}
             )
         return super().create(request, *args, **kwargs)

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -11,6 +11,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     # END: Pulp standard middleware
     'django_prometheus.middleware.PrometheusAfterMiddleware',
     'django_currentuser.middleware.ThreadLocalUserMiddleware',
@@ -114,6 +115,23 @@ SPECTACULAR_SETTINGS = {
 # Disable django guardian anonymous user
 # https://django-guardian.readthedocs.io/en/stable/configuration.html#anonymous-user-name
 ANONYMOUS_USER_NAME = None
+
+# L10N settings
+USE_L10N = True
+USE_I18N = True
+
+# Default language
+LANGUAGE_CODE = 'en-us'
+
+LANGUAGES = [
+    ('ja', 'Japanese'),
+    ('nl', 'Dutch'),
+    ('fr', 'French'),
+    ('es', 'Spanish'),
+    ('zh-hans', 'Chinese'),
+]
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+LOCALE_PATHS = (os.path.join(BASE_DIR, 'locale'),)
 
 GALAXY_ENABLE_API_ACCESS_LOG = os.getenv('GALAXY_ENABLE_API_ACCESS_LOG', default=False)
 

--- a/galaxy_ng/app/tasks/publishing.py
+++ b/galaxy_ng/app/tasks/publishing.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.utils.translation import gettext_lazy as _
 
 from pulpcore.plugin.models import Task
 from pulp_ansible.app.models import AnsibleDistribution, AnsibleRepository, CollectionVersion
@@ -50,7 +51,7 @@ def import_and_move_to_staging(temp_file_pk, **kwargs):
     try:
         staging_repo = AnsibleDistribution.objects.get(name=STAGING_NAME).repository
     except AnsibleRepository.DoesNotExist:
-        raise RuntimeError(f'Could not find staging repository: "{STAGING_NAME}"')
+        raise RuntimeError(_('Could not find staging repository: "%s"') % STAGING_NAME)
 
     inbound_repo = AnsibleRepository.objects.get(pk=inbound_repository_pk)
 
@@ -80,7 +81,7 @@ def import_and_auto_approve(temp_file_pk, **kwargs):
     try:
         golden_repo = AnsibleDistribution.objects.get(name=GOLDEN_NAME).repository
     except AnsibleRepository.DoesNotExist:
-        raise RuntimeError(f'Could not find staging repository: "{GOLDEN_NAME}"')
+        raise RuntimeError(_('Could not find staging repository: "%s"') % GOLDEN_NAME)
 
     inbound_repo = AnsibleRepository.objects.get(pk=inbound_repository_pk)
 

--- a/galaxy_ng/app/tasks/synclist.py
+++ b/galaxy_ng/app/tasks/synclist.py
@@ -3,6 +3,7 @@ import itertools
 
 from django.conf import settings
 from django.db.models import F, Q
+from django.utils.translation import gettext_lazy as _
 
 from pulpcore.plugin.models import (
     CreatedResource,
@@ -41,7 +42,7 @@ def curate_all_synclist_repository(upstream_repository_name, **kwargs):
     synclist_qs = models.SyncList.objects.filter(upstream_repository=upstream_repository)
 
     task_group = TaskGroup.objects.create(
-        description=f"Curating all synclists repos that curate from {upstream_repository_name}"
+        description=_("Curating all synclists repos that curate from %s") % upstream_repository_name
     )
     task_group.save()
 
@@ -52,14 +53,14 @@ def curate_all_synclist_repository(upstream_repository_name, **kwargs):
     current_task.save()
 
     GroupProgressReport(
-        message="Synclists curating upstream repo",
+        message=_("Synclists curating upstream repo"),
         code="synclist.curate",
         total=synclist_qs.count(),
         task_group=task_group,
     ).save()
 
     with ProgressReport(
-        message="Synclists curating upstream repo task",
+        message=_("Synclists curating upstream repo task"),
         code="synclist.curate.log",
         total=synclist_qs.count(),
     ) as task_progress_report:
@@ -87,7 +88,7 @@ def curate_all_synclist_repository(upstream_repository_name, **kwargs):
             progress_report.update(done=F("done") + len(synclist_ids))
 
     log.info(
-        "Finishing curating %s synclist repos based on %s update",
+        _("Finishing curating %s synclist repos based on %s update"),
         synclist_qs.count(),
         upstream_repository,
     )
@@ -116,7 +117,7 @@ def curate_synclist_repository(synclist_pk, **kwargs):
     latest_upstream = upstream_repository.latest_version()
 
     log.info(
-        'Applying synclist "%s" with policy=%s to curate repo "%s" from upstream repo "%s"',
+        _('Applying synclist "%s" with policy=%s to curate repo "%s" from upstream repo "%s"'),
         synclist.name,
         synclist.policy,
         synclist.repository.name,
@@ -158,6 +159,6 @@ def curate_synclist_repository(synclist_pk, **kwargs):
             "remove_content_units": ["*"],
         }
     else:
-        raise RuntimeError("Unexpected synclist policy {}".format(synclist.policy))
+        raise RuntimeError(_("Unexpected synclist policy {}").format(synclist.policy))
 
     add_and_remove(**task_kwargs)

--- a/galaxy_ng/locale/es/LC_MESSAGES/django.po
+++ b/galaxy_ng/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,272 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-08-22 23:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: galaxy_ng/app/access_control/access_policy.py:69
+msgid "Namespace in filename not found."
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:17
+msgid "object_permissions field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:21
+msgid "id or name field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:27
+msgid "object_permissions must be a list of strings"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:41
+msgid "Permission {} does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:56
+msgid "Groups must be a list of group objects"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:71
+#, python-format
+msgid "Group name=%s, id=%s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:75
+#: galaxy_ng/app/api/ui/serializers/user.py:118
+msgid "Invalid group name or ID"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:41
+#, python-brace-format
+msgid "Repository \"{pulp_id}\" not found while creating synclist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:96
+#, python-format
+msgid "Synclist already exists: %s"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:104
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while creating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:143
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while updating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:60
+msgid ""
+"'galaxy.change_group' permission is required to change a users group that "
+"the requesting user is not in."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:71
+msgid "Must be a super user to grant super user permissions."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:114
+#, python-format
+msgid "Group name=%(name)s, id=%(id)s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:57
+msgid "Distribution base path is required"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:155
+msgid "Retrieve collection version"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:166
+msgid "Collection version not found for: {}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:222
+msgid "Retrieve collection import"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/group.py:45
+#, python-format
+msgid "A group named %s already exists."
+msgstr "Ya existe un grupo llamado %s."
+
+#: galaxy_ng/app/api/utils.py:45
+#, python-brace-format
+msgid ""
+"Invalid filename {filename}. Expected format: namespace-name-version.tar.gz"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:52
+#, python-brace-format
+msgid ""
+"Invalid version string {version} from filename {filename}. Expected semantic "
+"version format."
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:56
+#, python-format
+msgid "Expected namespace to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:58
+#, python-format
+msgid "Expected name to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:60
+#, python-format
+msgid "Expected version to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:60
+#, python-format
+msgid "'%s' is not a valid url."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:88
+msgid "Attribute 'name' is required"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:91
+msgid "Name can only contain lower case letters, underscores and numbers"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:94
+msgid "Name must be longer than 2 characters"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:97
+msgid "Name cannot begin with '_'"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:85
+msgid "Password for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:92
+msgid "User for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:105
+msgid "Remote password."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:112
+msgid "Remote user."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:161
+msgid ""
+"Syncing content from community domains without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:29
+#, python-format
+msgid "The %s distribution does not have any remotes associated with it."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:40
+msgid ""
+"Syncing content from galaxy.ansible.com without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:172
+#, python-format
+msgid "Path does not match: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:186
+#, python-brace-format
+msgid "Namespace \"{0}\" does not exist."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:279
+#, python-format
+msgid "Unexpected response from content app. Code: %s."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:301
+#, python-format
+msgid "Collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:309
+#, python-format
+msgid "Repo(s) for moving collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:313
+#, python-format
+msgid "Collection %s not found in source repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:317
+#, python-format
+msgid "Collection %s already found in destination repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/namespace.py:61
+#, python-format
+msgid "A namespace named %s already exists."
+msgstr ""
+
+#: galaxy_ng/app/exceptions.py:8
+msgid "Data conflicts with existing entity."
+msgstr ""
+
+#: galaxy_ng/app/tasks/publishing.py:54 galaxy_ng/app/tasks/publishing.py:84
+#, python-format
+msgid "Could not find staging repository: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:45
+#, python-format
+msgid "Curating all synclists repos that curate from %s"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:56
+msgid "Synclists curating upstream repo"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:63
+msgid "Synclists curating upstream repo task"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:91
+#, python-format
+msgid "Finishing curating %s synclist repos based on %s update"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:120
+#, python-format
+msgid ""
+"Applying synclist \"%s\" with policy=%s to curate repo \"%s\" from upstream "
+"repo \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:162
+msgid "Unexpected synclist policy {}"
+msgstr ""

--- a/galaxy_ng/locale/fr/LC_MESSAGES/django.po
+++ b/galaxy_ng/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,272 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-08-22 23:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: galaxy_ng/app/access_control/access_policy.py:69
+msgid "Namespace in filename not found."
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:17
+msgid "object_permissions field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:21
+msgid "id or name field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:27
+msgid "object_permissions must be a list of strings"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:41
+msgid "Permission {} does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:56
+msgid "Groups must be a list of group objects"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:71
+#, python-format
+msgid "Group name=%s, id=%s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:75
+#: galaxy_ng/app/api/ui/serializers/user.py:118
+msgid "Invalid group name or ID"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:41
+#, python-brace-format
+msgid "Repository \"{pulp_id}\" not found while creating synclist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:96
+#, python-format
+msgid "Synclist already exists: %s"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:104
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while creating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:143
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while updating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:60
+msgid ""
+"'galaxy.change_group' permission is required to change a users group that "
+"the requesting user is not in."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:71
+msgid "Must be a super user to grant super user permissions."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:114
+#, python-format
+msgid "Group name=%(name)s, id=%(id)s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:57
+msgid "Distribution base path is required"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:155
+msgid "Retrieve collection version"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:166
+msgid "Collection version not found for: {}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:222
+msgid "Retrieve collection import"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/group.py:45
+#, python-format
+msgid "A group named %s already exists."
+msgstr "Un groupe nommé %s existe déjà."
+
+#: galaxy_ng/app/api/utils.py:45
+#, python-brace-format
+msgid ""
+"Invalid filename {filename}. Expected format: namespace-name-version.tar.gz"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:52
+#, python-brace-format
+msgid ""
+"Invalid version string {version} from filename {filename}. Expected semantic "
+"version format."
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:56
+#, python-format
+msgid "Expected namespace to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:58
+#, python-format
+msgid "Expected name to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:60
+#, python-format
+msgid "Expected version to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:60
+#, python-format
+msgid "'%s' is not a valid url."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:88
+msgid "Attribute 'name' is required"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:91
+msgid "Name can only contain lower case letters, underscores and numbers"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:94
+msgid "Name must be longer than 2 characters"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:97
+msgid "Name cannot begin with '_'"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:85
+msgid "Password for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:92
+msgid "User for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:105
+msgid "Remote password."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:112
+msgid "Remote user."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:161
+msgid ""
+"Syncing content from community domains without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:29
+#, python-format
+msgid "The %s distribution does not have any remotes associated with it."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:40
+msgid ""
+"Syncing content from galaxy.ansible.com without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:172
+#, python-format
+msgid "Path does not match: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:186
+#, python-brace-format
+msgid "Namespace \"{0}\" does not exist."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:279
+#, python-format
+msgid "Unexpected response from content app. Code: %s."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:301
+#, python-format
+msgid "Collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:309
+#, python-format
+msgid "Repo(s) for moving collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:313
+#, python-format
+msgid "Collection %s not found in source repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:317
+#, python-format
+msgid "Collection %s already found in destination repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/namespace.py:61
+#, python-format
+msgid "A namespace named %s already exists."
+msgstr ""
+
+#: galaxy_ng/app/exceptions.py:8
+msgid "Data conflicts with existing entity."
+msgstr ""
+
+#: galaxy_ng/app/tasks/publishing.py:54 galaxy_ng/app/tasks/publishing.py:84
+#, python-format
+msgid "Could not find staging repository: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:45
+#, python-format
+msgid "Curating all synclists repos that curate from %s"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:56
+msgid "Synclists curating upstream repo"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:63
+msgid "Synclists curating upstream repo task"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:91
+#, python-format
+msgid "Finishing curating %s synclist repos based on %s update"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:120
+#, python-format
+msgid ""
+"Applying synclist \"%s\" with policy=%s to curate repo \"%s\" from upstream "
+"repo \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:162
+msgid "Unexpected synclist policy {}"
+msgstr ""

--- a/galaxy_ng/locale/ja/LC_MESSAGES/django.po
+++ b/galaxy_ng/locale/ja/LC_MESSAGES/django.po
@@ -1,0 +1,272 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-08-22 23:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: galaxy_ng/app/access_control/access_policy.py:69
+msgid "Namespace in filename not found."
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:17
+msgid "object_permissions field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:21
+msgid "id or name field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:27
+msgid "object_permissions must be a list of strings"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:41
+msgid "Permission {} does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:56
+msgid "Groups must be a list of group objects"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:71
+#, python-format
+msgid "Group name=%s, id=%s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:75
+#: galaxy_ng/app/api/ui/serializers/user.py:118
+msgid "Invalid group name or ID"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:41
+#, python-brace-format
+msgid "Repository \"{pulp_id}\" not found while creating synclist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:96
+#, python-format
+msgid "Synclist already exists: %s"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:104
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while creating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:143
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while updating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:60
+msgid ""
+"'galaxy.change_group' permission is required to change a users group that "
+"the requesting user is not in."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:71
+msgid "Must be a super user to grant super user permissions."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:114
+#, python-format
+msgid "Group name=%(name)s, id=%(id)s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:57
+msgid "Distribution base path is required"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:155
+msgid "Retrieve collection version"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:166
+msgid "Collection version not found for: {}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:222
+msgid "Retrieve collection import"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/group.py:45
+#, python-format
+msgid "A group named %s already exists."
+msgstr "%sという名前のグループはすでに存在します。"
+
+#: galaxy_ng/app/api/utils.py:45
+#, python-brace-format
+msgid ""
+"Invalid filename {filename}. Expected format: namespace-name-version.tar.gz"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:52
+#, python-brace-format
+msgid ""
+"Invalid version string {version} from filename {filename}. Expected semantic "
+"version format."
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:56
+#, python-format
+msgid "Expected namespace to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:58
+#, python-format
+msgid "Expected name to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:60
+#, python-format
+msgid "Expected version to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:60
+#, python-format
+msgid "'%s' is not a valid url."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:88
+msgid "Attribute 'name' is required"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:91
+msgid "Name can only contain lower case letters, underscores and numbers"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:94
+msgid "Name must be longer than 2 characters"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:97
+msgid "Name cannot begin with '_'"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:85
+msgid "Password for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:92
+msgid "User for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:105
+msgid "Remote password."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:112
+msgid "Remote user."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:161
+msgid ""
+"Syncing content from community domains without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:29
+#, python-format
+msgid "The %s distribution does not have any remotes associated with it."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:40
+msgid ""
+"Syncing content from galaxy.ansible.com without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:172
+#, python-format
+msgid "Path does not match: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:186
+#, python-brace-format
+msgid "Namespace \"{0}\" does not exist."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:279
+#, python-format
+msgid "Unexpected response from content app. Code: %s."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:301
+#, python-format
+msgid "Collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:309
+#, python-format
+msgid "Repo(s) for moving collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:313
+#, python-format
+msgid "Collection %s not found in source repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:317
+#, python-format
+msgid "Collection %s already found in destination repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/namespace.py:61
+#, python-format
+msgid "A namespace named %s already exists."
+msgstr ""
+
+#: galaxy_ng/app/exceptions.py:8
+msgid "Data conflicts with existing entity."
+msgstr ""
+
+#: galaxy_ng/app/tasks/publishing.py:54 galaxy_ng/app/tasks/publishing.py:84
+#, python-format
+msgid "Could not find staging repository: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:45
+#, python-format
+msgid "Curating all synclists repos that curate from %s"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:56
+msgid "Synclists curating upstream repo"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:63
+msgid "Synclists curating upstream repo task"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:91
+#, python-format
+msgid "Finishing curating %s synclist repos based on %s update"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:120
+#, python-format
+msgid ""
+"Applying synclist \"%s\" with policy=%s to curate repo \"%s\" from upstream "
+"repo \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:162
+msgid "Unexpected synclist policy {}"
+msgstr ""

--- a/galaxy_ng/locale/nl/LC_MESSAGES/django.po
+++ b/galaxy_ng/locale/nl/LC_MESSAGES/django.po
@@ -1,0 +1,272 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-08-22 23:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: galaxy_ng/app/access_control/access_policy.py:69
+msgid "Namespace in filename not found."
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:17
+msgid "object_permissions field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:21
+msgid "id or name field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:27
+msgid "object_permissions must be a list of strings"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:41
+msgid "Permission {} does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:56
+msgid "Groups must be a list of group objects"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:71
+#, python-format
+msgid "Group name=%s, id=%s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:75
+#: galaxy_ng/app/api/ui/serializers/user.py:118
+msgid "Invalid group name or ID"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:41
+#, python-brace-format
+msgid "Repository \"{pulp_id}\" not found while creating synclist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:96
+#, python-format
+msgid "Synclist already exists: %s"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:104
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while creating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:143
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while updating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:60
+msgid ""
+"'galaxy.change_group' permission is required to change a users group that "
+"the requesting user is not in."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:71
+msgid "Must be a super user to grant super user permissions."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:114
+#, python-format
+msgid "Group name=%(name)s, id=%(id)s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:57
+msgid "Distribution base path is required"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:155
+msgid "Retrieve collection version"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:166
+msgid "Collection version not found for: {}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:222
+msgid "Retrieve collection import"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/group.py:45
+#, python-format
+msgid "A group named %s already exists."
+msgstr "Een groep met de naam %s bestaat al."
+
+#: galaxy_ng/app/api/utils.py:45
+#, python-brace-format
+msgid ""
+"Invalid filename {filename}. Expected format: namespace-name-version.tar.gz"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:52
+#, python-brace-format
+msgid ""
+"Invalid version string {version} from filename {filename}. Expected semantic "
+"version format."
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:56
+#, python-format
+msgid "Expected namespace to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:58
+#, python-format
+msgid "Expected name to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:60
+#, python-format
+msgid "Expected version to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:60
+#, python-format
+msgid "'%s' is not a valid url."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:88
+msgid "Attribute 'name' is required"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:91
+msgid "Name can only contain lower case letters, underscores and numbers"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:94
+msgid "Name must be longer than 2 characters"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:97
+msgid "Name cannot begin with '_'"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:85
+msgid "Password for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:92
+msgid "User for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:105
+msgid "Remote password."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:112
+msgid "Remote user."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:161
+msgid ""
+"Syncing content from community domains without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:29
+#, python-format
+msgid "The %s distribution does not have any remotes associated with it."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:40
+msgid ""
+"Syncing content from galaxy.ansible.com without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:172
+#, python-format
+msgid "Path does not match: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:186
+#, python-brace-format
+msgid "Namespace \"{0}\" does not exist."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:279
+#, python-format
+msgid "Unexpected response from content app. Code: %s."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:301
+#, python-format
+msgid "Collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:309
+#, python-format
+msgid "Repo(s) for moving collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:313
+#, python-format
+msgid "Collection %s not found in source repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:317
+#, python-format
+msgid "Collection %s already found in destination repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/namespace.py:61
+#, python-format
+msgid "A namespace named %s already exists."
+msgstr ""
+
+#: galaxy_ng/app/exceptions.py:8
+msgid "Data conflicts with existing entity."
+msgstr ""
+
+#: galaxy_ng/app/tasks/publishing.py:54 galaxy_ng/app/tasks/publishing.py:84
+#, python-format
+msgid "Could not find staging repository: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:45
+#, python-format
+msgid "Curating all synclists repos that curate from %s"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:56
+msgid "Synclists curating upstream repo"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:63
+msgid "Synclists curating upstream repo task"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:91
+#, python-format
+msgid "Finishing curating %s synclist repos based on %s update"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:120
+#, python-format
+msgid ""
+"Applying synclist \"%s\" with policy=%s to curate repo \"%s\" from upstream "
+"repo \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:162
+msgid "Unexpected synclist policy {}"
+msgstr ""

--- a/galaxy_ng/locale/zh/LC_MESSAGES/django.po
+++ b/galaxy_ng/locale/zh/LC_MESSAGES/django.po
@@ -1,0 +1,272 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-08-22 23:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: galaxy_ng/app/access_control/access_policy.py:69
+msgid "Namespace in filename not found."
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:17
+msgid "object_permissions field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:21
+msgid "id or name field is required"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:27
+msgid "object_permissions must be a list of strings"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:41
+msgid "Permission {} does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:56
+msgid "Groups must be a list of group objects"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:71
+#, python-format
+msgid "Group name=%s, id=%s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/access_control/fields.py:75
+#: galaxy_ng/app/api/ui/serializers/user.py:118
+msgid "Invalid group name or ID"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:41
+#, python-brace-format
+msgid "Repository \"{pulp_id}\" not found while creating synclist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:96
+#, python-format
+msgid "Synclist already exists: %s"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:104
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while creating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/synclist.py:143
+#, python-brace-format
+msgid ""
+"Collection \"{namespace}.{name}\" not found while updating synclist "
+"{synclist}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:60
+msgid ""
+"'galaxy.change_group' permission is required to change a users group that "
+"the requesting user is not in."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:71
+msgid "Must be a super user to grant super user permissions."
+msgstr ""
+
+#: galaxy_ng/app/api/ui/serializers/user.py:114
+#, python-format
+msgid "Group name=%(name)s, id=%(id)s does not exist"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:57
+msgid "Distribution base path is required"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:155
+msgid "Retrieve collection version"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:166
+msgid "Collection version not found for: {}"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/collection.py:222
+msgid "Retrieve collection import"
+msgstr ""
+
+#: galaxy_ng/app/api/ui/viewsets/group.py:45
+#, python-format
+msgid "A group named %s already exists."
+msgstr "名为 %s 的组已存在。"
+
+#: galaxy_ng/app/api/utils.py:45
+#, python-brace-format
+msgid ""
+"Invalid filename {filename}. Expected format: namespace-name-version.tar.gz"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:52
+#, python-brace-format
+msgid ""
+"Invalid version string {version} from filename {filename}. Expected semantic "
+"version format."
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:56
+#, python-format
+msgid "Expected namespace to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:58
+#, python-format
+msgid "Expected name to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/utils.py:60
+#, python-format
+msgid "Expected version to be max length of %s"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:60
+#, python-format
+msgid "'%s' is not a valid url."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:88
+msgid "Attribute 'name' is required"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:91
+msgid "Name can only contain lower case letters, underscores and numbers"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:94
+msgid "Name must be longer than 2 characters"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/namespace.py:97
+msgid "Name cannot begin with '_'"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:85
+msgid "Password for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:92
+msgid "User for proxy authentication."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:105
+msgid "Remote password."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:112
+msgid "Remote user."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/serializers/sync.py:161
+msgid ""
+"Syncing content from community domains without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:29
+#, python-format
+msgid "The %s distribution does not have any remotes associated with it."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/views/sync.py:40
+msgid ""
+"Syncing content from galaxy.ansible.com without specifying a requirements "
+"file is not allowed."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:172
+#, python-format
+msgid "Path does not match: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:186
+#, python-brace-format
+msgid "Namespace \"{0}\" does not exist."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:279
+#, python-format
+msgid "Unexpected response from content app. Code: %s."
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:301
+#, python-format
+msgid "Collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:309
+#, python-format
+msgid "Repo(s) for moving collection %s not found"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:313
+#, python-format
+msgid "Collection %s not found in source repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/collection.py:317
+#, python-format
+msgid "Collection %s already found in destination repo"
+msgstr ""
+
+#: galaxy_ng/app/api/v3/viewsets/namespace.py:61
+#, python-format
+msgid "A namespace named %s already exists."
+msgstr ""
+
+#: galaxy_ng/app/exceptions.py:8
+msgid "Data conflicts with existing entity."
+msgstr ""
+
+#: galaxy_ng/app/tasks/publishing.py:54 galaxy_ng/app/tasks/publishing.py:84
+#, python-format
+msgid "Could not find staging repository: \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:45
+#, python-format
+msgid "Curating all synclists repos that curate from %s"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:56
+msgid "Synclists curating upstream repo"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:63
+msgid "Synclists curating upstream repo task"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:91
+#, python-format
+msgid "Finishing curating %s synclist repos based on %s update"
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:120
+#, python-format
+msgid ""
+"Applying synclist \"%s\" with policy=%s to curate repo \"%s\" from upstream "
+"repo \"%s\""
+msgstr ""
+
+#: galaxy_ng/app/tasks/synclist.py:162
+msgid "Unexpected synclist policy {}"
+msgstr ""

--- a/galaxy_ng/tests/unit/api/test_localization.py
+++ b/galaxy_ng/tests/unit/api/test_localization.py
@@ -1,0 +1,133 @@
+import logging
+
+from galaxy_ng.app.constants import DeploymentMode
+from galaxy_ng.app.models import auth as auth_models
+
+from .base import BaseTestCase, get_current_ui_url
+
+log = logging.getLogger(__name__)
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+class TestLocalization(BaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.group_url = get_current_ui_url('groups')
+        self.admin_user = auth_models.User.objects.create(username='admin',
+                                                          is_superuser=True)
+        self.group = auth_models.Group.objects.create(name='test_group')
+        self.user.groups.add(self.group)
+        self.admin_user.save()
+
+    def _switch_lang_post(self, language):
+        response = self.client.post(
+            self.group_url,
+            {"name": "test_group"},
+            HTTP_ACCEPT_LANGUAGE=language
+        )
+        return response.data['errors'][0]['detail']
+
+    def _switch_lang_get(self, language):
+        response = self.client.get(
+            self.group_url + 'notfoundgroup/',
+            HTTP_ACCEPT_LANGUAGE=language
+        )
+        return response.data['errors'][0]['title']
+
+    def test_auto_localization(self):
+        with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
+            self.client.force_authenticate(user=self.admin_user)
+
+            response = self.client.get(
+                self.group_url + 'notfoundgroup/'
+            )
+            self.assertEqual(
+                response.data['errors'][0]['title'],
+                'Not found.'
+            )
+
+            response = self._switch_lang_get('es')
+            self.assertEqual(
+                response,
+                'No encontrado.'
+            )
+
+            response = self._switch_lang_get('fr')
+            self.assertEqual(
+                response,
+                'Pas trouvé.'
+            )
+
+            response = self._switch_lang_get('nl')
+            self.assertEqual(
+                response,
+                'Niet gevonden.'
+            )
+
+            response = self._switch_lang_get('ja')
+            self.assertEqual(
+                response,
+                '見つかりませんでした。'
+            )
+
+            response = self._switch_lang_get('zh')
+            self.assertEqual(
+                response,
+                '未找到。'
+            )
+
+            response = self._switch_lang_get('cs')
+            self.assertEqual(
+                response,
+                'Not found.'
+            )
+
+    def test_localization_files(self):
+        with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
+            self.client.force_authenticate(user=self.admin_user)
+
+            response = self.client.post(
+                self.group_url,
+                {"name": "test_group"}
+            )
+            self.assertEqual(
+                response.data['errors'][0]['detail'],
+                'A group named test_group already exists.'
+            )
+
+            response = self._switch_lang_post('fr')
+            self.assertEqual(
+                response,
+                'Un groupe nommé test_group existe déjà.'
+            )
+
+            response = self._switch_lang_post('es')
+            self.assertEqual(
+                response,
+                'Ya existe un grupo llamado test_group.'
+            )
+
+            response = self._switch_lang_post('nl')
+            self.assertEqual(
+                response,
+                'Een groep met de naam test_group bestaat al.'
+            )
+
+            response = self._switch_lang_post('ja')
+            self.assertEqual(
+                response,
+                'test_groupという名前のグループはすでに存在します。'
+            )
+
+            response = self._switch_lang_post('zh')
+            self.assertEqual(
+                response,
+                '名为 test_group 的组已存在。'
+            )
+
+            response = self._switch_lang_post('cs')
+            self.assertEqual(
+                response,
+                'A group named test_group already exists.'
+            )


### PR DESCRIPTION
Issue: [AAH-830](https://issues.redhat.com/browse/AAH-830)
Marked most of the strings for translation and added gettext_lazy import, but I'm not sure about these translations:
 - `self.stdout.write`
 - `self.status_messages.append`
 - `parser.add_argument('name', type=slugify, help=_("Remote Name"))`
 - `log.info, log.debug, log.warning`
