### PR TITLE
Allow running latest/main branches or revision on PR CI.

### DIFF
--- a/.github/workflows/nightly_latest.yml
+++ b/.github/workflows/nightly_latest.yml
@@ -1,0 +1,129 @@
+name: Nightly Latest
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # runs at 4:00 UTC daily
+    - cron: '00 4 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - TEST: pulp
+          - TEST: s3
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # by default, it uses a depth of 1
+          # this fetches all history so that we can read each commit
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install httpie
+        run: |
+          echo ::group::HTTPIE
+          sudo apt-get update -yq
+          sudo -E apt-get -yq --no-install-suggests --no-install-recommends install httpie
+          echo ::endgroup::
+          echo "TEST=${{ matrix.env.TEST }}" >> $GITHUB_ENV
+          echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/.ci/assets/httpie/" >> $GITHUB_ENV
+
+      - name: Before Install
+        
+        run: .github/workflows/scripts/before_install.sh
+        shell: bash
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          GITHUB_PULL_REQUEST: ${{ github.event.number }}
+          GITHUB_PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
+          GITHUB_BRANCH: ${{ github.head_ref }}
+          GITHUB_REPO_SLUG: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
+
+      - uses: actions/setup-ruby@v1
+        if: ${{ env.TEST == 'bindings' || env.TEST == 'generate-bindings' }}
+        with:
+          ruby-version: "2.6"
+
+      - name: Install
+        
+        run: .github/workflows/scripts/install.sh
+        shell: bash
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          GITHUB_PULL_REQUEST: ${{ github.event.number }}
+          GITHUB_PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
+          GITHUB_BRANCH: ${{ github.head_ref }}
+          GITHUB_REPO_SLUG: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
+
+      - name: Before Script
+        
+        run: .github/workflows/scripts/before_script.sh
+        shell: bash
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          GITHUB_PULL_REQUEST: ${{ github.event.number }}
+          GITHUB_PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
+          GITHUB_BRANCH: ${{ github.head_ref }}
+          GITHUB_REPO_SLUG: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
+
+      - name: Setting secrets
+        
+        run: python3 .github/workflows/scripts/secrets.py "$SECRETS_CONTEXT"
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+
+      - name: Install Python client
+        
+        run: .github/workflows/scripts/install_python_client.sh
+        shell: bash
+
+      - name: Install Ruby client
+        if: ${{ env.TEST == 'bindings' || env.TEST == 'generate-bindings' }}
+        run: .github/workflows/scripts/install_ruby_client.sh
+        shell: bash
+
+      - name: Script
+        run: .github/workflows/scripts/script.sh
+        shell: bash
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          GITHUB_PULL_REQUEST: ${{ github.event.number }}
+          GITHUB_PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
+          GITHUB_BRANCH: ${{ github.head_ref }}
+          GITHUB_REPO_SLUG: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
+
+      - name: After failure
+        if: failure()
+        run: |
+          echo "Need to debug? Please check: https://github.com/marketplace/actions/debugging-with-tmate"
+          http --timeout 30 --check-status --pretty format --print hb http://pulp/pulp/api/v3/status/ || true
+          docker images || true
+          docker ps -a || true
+          docker logs pulp || true
+          docker exec pulp ls -latr /etc/yum.repos.d/ || true
+          docker exec pulp cat /etc/yum.repos.d/* || true
+          docker exec pulp pip3 list

--- a/.github/workflows/scripts/post_before_install.sh
+++ b/.github/workflows/scripts/post_before_install.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# This script runs after the before_install script.
+# Features on this script:
+# 
+# - If worflow is Nightly Latest then it forces RUN_ON_LATESTS to 1.
+# - Else, if event is not 'pull_request' then it skips the script.
+# - Read the last commit message and extracts environment variables from it.
+#   - Commit message format: 'env:KEY=value' is parsed and the environment variables are set.
+#   - Available envvars: 
+#     RUN_ON_LATEST - If set to 1, the script will checkout to main/master branches for all repos.
+#     LOCK_REQUIREMENTS - If set to 0, the script will unpin requirements from galaxy_ng/setup.py.
+#     <REPO>_REVISION - If set to specific git commit sha, the script will checkout to that commit.
+#        The above can be commit, tag, branch, or any other git ref. e.g:
+#        env: PULPCORE_REVISION=36692a8c628a5d5af220fb1c7bede712727e1e89
+#        env: GALAXY_IMPORTER_REVISION=branch_foo
+#
+
+echo "Workflow name: $GITHUB_WORKFLOW"
+if [ "$GITHUB_WORKFLOW" == "Nightly Latest" ]; then
+    echo "Forcing RUN_ON_LATEST=1"
+    RUN_ON_LATEST=1
+    export RUN_ON_LATEST
+    LOCK_REQUIREMENTS=1
+    export LOCK_REQUIREMENTS
+else
+    if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+        echo "Skipping post_before_install.sh because this is not a pull request or nightly latest job."
+        exit 0
+    fi
+
+    # Read the latest commit message
+    COMMIT_MSG=$(git log --format=%B --no-merges -1)
+    export COMMIT_MSG
+
+    # Read the commit message and extract the environment variables from there
+    # lines containing the format: 'env:NAME=value' are parsed
+    set -o allexport
+    eval $(echo "${COMMIT_MSG}" | grep 'env:' | awk -F '["=]+' '{print substr($1, 5)"="$2}')
+    set +o allexport
+    # Alternative implementation to above logic.
+    # export $(echo "${COMMIT_MSG}" | grep 'env:' | awk -F '["=]+' '{print substr($1, 5)"="$2}' | xargs)
+fi
+
+# Unpin Requirements from galaxy_ng setup.py?
+# This runs when commit has 'env:LOCK_REQUIRENTS=0'
+# Also forced when 'env:RUN_ON_LATEST=1'
+if [[ "${LOCK_REQUIREMENTS:-1}" == "0" ]] || [[ "${RUN_ON_LATEST:-0}" == "1" ]] ; then
+    echo "Unpinning requirements"
+    original='unpin_requirements = os.getenv("LOCK_REQUIREMENTS") == "0"'
+    new='unpin_requirements = True'
+    sed -i "s/$original/$new/g" setup.py
+    grep 'unpin_requirements' setup.py
+fi
+
+# Got to parent directory where repos are cloned
+cd ..
+
+function get_main_branch_of_repo {
+    local repo=$1
+    local branch
+
+    # tried the following but it didn't work, it was always returning checked out branch.
+    # branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD)
+    # but this works
+    branch=$(git -C "$repo" remote show origin | awk '/HEAD branch/ {print $NF}')
+
+    if [[ "$branch" == "HEAD" ]]; then
+        branch=$(git -C "$repo" symbolic-ref --short HEAD)
+    fi
+
+    echo "$branch"
+}
+
+# if env:RUN_ON_LATEST=1, then checkout all the repos to main branches
+if [[ "${RUN_ON_LATEST:-0}" == "1" ]]; then
+    echo "Running on latest main branches for repos."
+    export GALAXY_IMPORTER_REVISION=$(get_main_branch_of_repo galaxy-importer)
+    export PULPCORE_REVISION=$(get_main_branch_of_repo pulpcore)
+    export PULP_ANSIBLE_REVISION=$(get_main_branch_of_repo pulp_ansible)
+    export PULP_CONTAINER_REVISION=$(get_main_branch_of_repo pulp_container)
+fi
+
+# if env:<REPO>_REVISION is set, then checkout that revision
+for repo in galaxy-importer pulp_container pulp_ansible pulpcore; do
+    UPPER_REPO=$(echo "${repo}" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    export VARNAME="${UPPER_REPO}_REVISION"
+    if [[ "${!VARNAME+x}" ]]; then
+        revision="${!VARNAME}"
+        echo "Checking out ${repo} to ${revision}"
+        # read the repo origin url
+        repourl=$(git -C $repo config --get remote.origin.url)
+        # delete the current repo directory and start a new git repo
+        rm -rf "${repo}"
+        mkdir "${repo}"
+        git -C $repo init
+        # add the remote repo url and fetch the specific revision
+        git -C $repo remote add origin "${repourl}"
+        git -C $repo fetch origin "${revision}"
+        git -C $repo reset --hard FETCH_HEAD
+    fi
+done
+
+# back to the directory where the workflow is being run
+cd galaxy_ng || exit

--- a/CHANGES/871.misc
+++ b/CHANGES/871.misc
@@ -1,0 +1,1 @@
+Allow running latest/main or specific branches on PRs CI


### PR DESCRIPTION
This is already possible to run a PR CI checks using specific pull-request for repos,
for example, one can add:

```bash
Required PR: https://github.com/pulp/pulpcore/pulls/456
Required PR: https://github.com/ansible/galaxy-importer/pulls/999
```

And the CI will checkout to that specific PR before installing and running the tests.

Right now on galaxy_ng if you try it, you will get a **failure on installation** because pip will Conflict on deps version, to solve that add to commit msg also `env:LOCK_REQUIREMENTS=0` and this will work similar to what we have on our docker based environment, it will remove the pinned versions from galaxy_ng/setup.py and allow pip to install.

So the commit message would contain:

```bash
Required PR: https://github.com/pulp/pulpcore/pulls/456
Required PR: https://github.com/ansible/galaxy-importer/pulls/999
env:LOCK_REQUIREMENTS=0
```

This is very useful when you are working on a feature that depends on unmerged Pull Request.

---

This PR also adds more ways of specifying the checkout for the dependency repos.

**Forcing specific git revision for a repo.**

Add `env:PULPCORE_REVISION=36692a8c628a5d5af220fb1c7bede712727e1e89` to the commit message, this is similar to the `Required PR` but works for any revision, so you can also checkout to a point in the past to run the CI.
 
The above will require the `env:LOCK_REQUIREMENTS=0` on your latest commit message.

--- 

**Shortcut to latest**

If all you want is to run your galaxy_ng PR against all repos checked out at master/main branches ensure you have on your commit message the `RUN_ON_LATEST` variable set to 1.

```bash
This is my latest commit message

- Solves X, Y and Z

Issue: AAH-xxx

env:RUN_ON_LATEST=1
```

(this will set each REPO_REVISION=latest and also ensure the LOCK_REQUIREMENTS=0)

---

**Plus: Added a NIghtly Job which runs pointing to all the latest repo branches.**

Every night 4AM a job will run testing latest branches together, we expect this job to fail most of the times, it is here just to enable us to see earlier when things starts breaking and have the opportunity to fix soon.

---

> NOTE: When running PRs using `master/main` branches, probably the `ci.ext.devshift.net` check will fail, and that is expected as we don't want to have those changes merged in before fully compatible with the release stream we are running. The better is to have this kind of PRs opened as drafts with purpose to get review and feedback earlier.

This is an example of PR using this feature: https://github.com/ansible/galaxy_ng/pull/902 (PR CI uses pulpcore master)

Issue: AAH-871