### PR TITLE
Enable view-only collection browsing

### DIFF
--- a/CHANGES/881.feature
+++ b/CHANGES/881.feature
@@ -1,0 +1,1 @@
+Enable unauthenticated view-only collection browsing

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -63,6 +63,9 @@ class AccessPolicyBase(AccessPolicy):
 class NamespaceAccessPolicy(AccessPolicyBase):
     NAME = 'NamespaceViewSet'
 
+    def view_only_mode_enabled(self, request, view, permission):
+        return settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS
+
 
 class CollectionAccessPolicy(AccessPolicyBase):
     NAME = 'CollectionViewSet'
@@ -79,6 +82,9 @@ class CollectionAccessPolicy(AccessPolicyBase):
         except models.Namespace.DoesNotExist:
             raise NotFound(_('Namespace in filename not found.'))
         return request.user.has_perm('galaxy.upload_to_namespace', namespace)
+
+    def view_only_mode_enabled(self, request, view, permission):
+        return settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS
 
 
 class CollectionRemoteAccessPolicy(AccessPolicyBase):
@@ -101,6 +107,9 @@ class MyUserAccessPolicy(AccessPolicyBase):
 
     def is_current_user(self, request, view, action):
         return request.user == view.get_object()
+
+    def view_only_mode_enabled(self, request, view, action):
+        return settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS
 
 
 class SyncListAccessPolicy(AccessPolicyBase):

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -6,7 +6,7 @@ from rest_access_policy import AccessPolicy
 from rest_framework.exceptions import NotFound
 
 from galaxy_ng.app import models
-from galaxy_ng.app.access_control.mixins import ViewOnlyMixin
+from galaxy_ng.app.access_control.mixins import UnauthenticatedCollectionAccessMixin
 
 log = logging.getLogger(__name__)
 
@@ -61,11 +61,11 @@ class AccessPolicyBase(AccessPolicy):
         return entitlement.get('is_entitled', False)
 
 
-class NamespaceAccessPolicy(ViewOnlyMixin, AccessPolicyBase):
+class NamespaceAccessPolicy(UnauthenticatedCollectionAccessMixin, AccessPolicyBase):
     NAME = 'NamespaceViewSet'
 
 
-class CollectionAccessPolicy(ViewOnlyMixin, AccessPolicyBase):
+class CollectionAccessPolicy(UnauthenticatedCollectionAccessMixin, AccessPolicyBase):
     NAME = 'CollectionViewSet'
 
     def can_update_collection(self, request, view, permission):
@@ -80,6 +80,9 @@ class CollectionAccessPolicy(ViewOnlyMixin, AccessPolicyBase):
         except models.Namespace.DoesNotExist:
             raise NotFound(_('Namespace in filename not found.'))
         return request.user.has_perm('galaxy.upload_to_namespace', namespace)
+
+    def unauthenticated_collection_download_enabled(self, request, view, permission):
+        return settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD
 
 
 class CollectionRemoteAccessPolicy(AccessPolicyBase):
@@ -97,7 +100,7 @@ class UserAccessPolicy(AccessPolicyBase):
         return request.user == view.get_object()
 
 
-class MyUserAccessPolicy(ViewOnlyMixin, AccessPolicyBase):
+class MyUserAccessPolicy(UnauthenticatedCollectionAccessMixin, AccessPolicyBase):
     NAME = 'MyUserViewSet'
 
     def is_current_user(self, request, view, action):

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -6,6 +6,7 @@ from rest_access_policy import AccessPolicy
 from rest_framework.exceptions import NotFound
 
 from galaxy_ng.app import models
+from galaxy_ng.app.access_control.mixins import ViewOnlyMixin
 
 log = logging.getLogger(__name__)
 
@@ -60,14 +61,11 @@ class AccessPolicyBase(AccessPolicy):
         return entitlement.get('is_entitled', False)
 
 
-class NamespaceAccessPolicy(AccessPolicyBase):
+class NamespaceAccessPolicy(ViewOnlyMixin, AccessPolicyBase):
     NAME = 'NamespaceViewSet'
 
-    def view_only_mode_enabled(self, request, view, permission):
-        return settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS
 
-
-class CollectionAccessPolicy(AccessPolicyBase):
+class CollectionAccessPolicy(ViewOnlyMixin, AccessPolicyBase):
     NAME = 'CollectionViewSet'
 
     def can_update_collection(self, request, view, permission):
@@ -82,9 +80,6 @@ class CollectionAccessPolicy(AccessPolicyBase):
         except models.Namespace.DoesNotExist:
             raise NotFound(_('Namespace in filename not found.'))
         return request.user.has_perm('galaxy.upload_to_namespace', namespace)
-
-    def view_only_mode_enabled(self, request, view, permission):
-        return settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS
 
 
 class CollectionRemoteAccessPolicy(AccessPolicyBase):
@@ -102,14 +97,11 @@ class UserAccessPolicy(AccessPolicyBase):
         return request.user == view.get_object()
 
 
-class MyUserAccessPolicy(AccessPolicyBase):
+class MyUserAccessPolicy(ViewOnlyMixin, AccessPolicyBase):
     NAME = 'MyUserViewSet'
 
     def is_current_user(self, request, view, action):
         return request.user == view.get_object()
-
-    def view_only_mode_enabled(self, request, view, action):
-        return settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS
 
 
 class SyncListAccessPolicy(AccessPolicyBase):

--- a/galaxy_ng/app/access_control/mixins.py
+++ b/galaxy_ng/app/access_control/mixins.py
@@ -38,6 +38,6 @@ class GroupModelPermissionsMixin:
             self._set_groups(self._groups)
 
 
-class ViewOnlyMixin:
-    def view_only_mode_enabled(self, request, view, action):
-        return settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS
+class UnauthenticatedCollectionAccessMixin:
+    def unauthenticated_collection_access_enabled(self, request, view, action):
+        return settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS

--- a/galaxy_ng/app/access_control/mixins.py
+++ b/galaxy_ng/app/access_control/mixins.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import transaction
 from guardian.shortcuts import get_groups_with_perms, assign_perm, remove_perm
 from django_lifecycle import hook
@@ -35,3 +36,8 @@ class GroupModelPermissionsMixin:
     def set_object_groups(self):
         if self._groups:
             self._set_groups(self._groups)
+
+
+class ViewOnlyMixin:
+    def view_only_mode_enabled(self, request, view, action):
+        return settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -9,7 +9,7 @@ STANDALONE_STATEMENTS = {
             "action": ["list", "retrieve"],
             "principal": "anonymous",
             "effect": "allow",
-            "condition": "view_only_mode_enabled"
+            "condition": "unauthenticated_collection_access_enabled"
         },
         {
             "action": "destroy",
@@ -40,12 +40,23 @@ STANDALONE_STATEMENTS = {
             "action": ["list", "retrieve"],
             "principal": "anonymous",
             "effect": "allow",
-            "condition": "view_only_mode_enabled"
+            "condition": "unauthenticated_collection_access_enabled"
         },
         {
             "action": "destroy",
             "principal": "*",
             "effect": "deny",
+        },
+        {
+            "action": ["download"],
+            "principal": 'authenticated',
+            "effect": "allow",
+        },
+        {
+            "action": ["download"],
+            "principal": 'anonymous',
+            "effect": "allow",
+            "condition": "unauthenticated_collection_download_enabled",
         },
         {
             "action": "create",
@@ -128,7 +139,7 @@ STANDALONE_STATEMENTS = {
             "action": ["retrieve"],
             "principal": "anonymous",
             "effect": "allow",
-            "condition": "view_only_mode_enabled"
+            "condition": "unauthenticated_collection_access_enabled"
         },
         {
             "action": ["retrieve", "update", "partial_update"],

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -1,7 +1,8 @@
-from galaxy_ng.app.settings import GALAXY_ENABLE_VIEW_ONLY_ACCESS
+from django.conf import settings
 
 
-COLLECTION_UNATHENTICATED_ACCESS = "view"
+GALAXY_ENABLE_VIEW_ONLY_ACCESS = settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS
+COLLECTION_UNATHENTICATED_ACCESS = settings.COLLECTION_UNATHENTICATED_ACCESS
 
 
 def get_collection_view_principal():

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -1,8 +1,32 @@
+from galaxy_ng.app.settings import GALAXY_ENABLE_VIEW_ONLY_ACCESS
+
+
+COLLECTION_UNATHENTICATED_ACCESS = "view"
+
+
+def get_collection_view_principal():
+    if COLLECTION_UNATHENTICATED_ACCESS in ("view", "download"):
+        return "*"
+    return "authenticated"
+
+
+def get_collection_download_principal():
+    if COLLECTION_UNATHENTICATED_ACCESS == "download":
+        return "*"
+    return "authenticated"
+
+
+def get_myuserviewset_retrieve_principal():
+    if GALAXY_ENABLE_VIEW_ONLY_ACCESS:
+        return "*"
+    return "authenticated"
+
+
 STANDALONE_STATEMENTS = {
     'NamespaceViewSet': [
         {
             "action": ["list", "retrieve"],
-            "principal": "authenticated",
+            "principal": get_collection_view_principal(),
             "effect": "allow",
         },
         {
@@ -27,8 +51,13 @@ STANDALONE_STATEMENTS = {
     'CollectionViewSet': [
         {
             "action": ["list", "retrieve"],
-            "principal": "authenticated",
+            "principal": get_collection_view_principal(),
             "effect": "allow",
+        },
+        {
+            "action": ["download"],
+            "principal": get_collection_download_principal(),
+            "effect": "allow"
         },
         {
             "action": "destroy",
@@ -113,7 +142,12 @@ STANDALONE_STATEMENTS = {
     ],
     'MyUserViewSet': [
         {
-            "action": ["retrieve", "update", "partial_update"],
+            "action": ["retrieve"],
+            "principal": get_myuserviewset_retrieve_principal(),
+            "effect": "allow",
+        },
+        {
+            "action": ["update", "partial_update"],
             "principal": "authenticated",
             "effect": "allow",
             "condition": "is_current_user"

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -1,34 +1,15 @@
-from django.conf import settings
-
-
-GALAXY_ENABLE_VIEW_ONLY_ACCESS = settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS
-COLLECTION_UNATHENTICATED_ACCESS = settings.COLLECTION_UNATHENTICATED_ACCESS
-
-
-def get_collection_view_principal():
-    if COLLECTION_UNATHENTICATED_ACCESS in ("view", "download"):
-        return "*"
-    return "authenticated"
-
-
-def get_collection_download_principal():
-    if COLLECTION_UNATHENTICATED_ACCESS == "download":
-        return "*"
-    return "authenticated"
-
-
-def get_myuserviewset_retrieve_principal():
-    if GALAXY_ENABLE_VIEW_ONLY_ACCESS:
-        return "*"
-    return "authenticated"
-
-
 STANDALONE_STATEMENTS = {
     'NamespaceViewSet': [
         {
             "action": ["list", "retrieve"],
-            "principal": get_collection_view_principal(),
+            "principal": "authenticated",
             "effect": "allow",
+        },
+        {
+            "action": ["list", "retrieve"],
+            "principal": "anonymous",
+            "effect": "allow",
+            "condition": "view_only_mode_enabled"
         },
         {
             "action": "destroy",
@@ -52,13 +33,14 @@ STANDALONE_STATEMENTS = {
     'CollectionViewSet': [
         {
             "action": ["list", "retrieve"],
-            "principal": get_collection_view_principal(),
+            "principal": "authenticated",
             "effect": "allow",
         },
         {
-            "action": ["download"],
-            "principal": get_collection_download_principal(),
-            "effect": "allow"
+            "action": ["list", "retrieve"],
+            "principal": "anonymous",
+            "effect": "allow",
+            "condition": "view_only_mode_enabled"
         },
         {
             "action": "destroy",
@@ -144,11 +126,12 @@ STANDALONE_STATEMENTS = {
     'MyUserViewSet': [
         {
             "action": ["retrieve"],
-            "principal": get_myuserviewset_retrieve_principal(),
+            "principal": "anonymous",
             "effect": "allow",
+            "condition": "view_only_mode_enabled"
         },
         {
-            "action": ["update", "partial_update"],
+            "action": ["retrieve", "update", "partial_update"],
             "principal": "authenticated",
             "effect": "allow",
             "condition": "is_current_user"

--- a/galaxy_ng/app/api/ui/serializers/user.py
+++ b/galaxy_ng/app/api/ui/serializers/user.py
@@ -126,7 +126,7 @@ class CurrentUserSerializer(UserSerializer):
 
     class Meta(UserSerializer.Meta):
         model = auth_models.User
-        fields = UserSerializer.Meta.fields + ('model_permissions',)
+        fields = UserSerializer.Meta.fields + ('model_permissions', 'is_anonymous',)
         extra_kwargs = dict(
             groups={'read_only': True},
             **UserSerializer.Meta.extra_kwargs

--- a/galaxy_ng/app/api/ui/views/auth.py
+++ b/galaxy_ng/app/api/ui/views/auth.py
@@ -2,7 +2,6 @@ import logging
 
 from django.conf import settings
 from django.contrib import auth as django_auth
-from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from rest_framework.authentication import SessionAuthentication
@@ -45,9 +44,6 @@ class LoginView(api_base.GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=self.request.data)
-
-        if str(request.user) == "AnonymousUser" and settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS:
-            return HttpResponseRedirect('/')
 
         serializer.is_valid(raise_exception=True)
 

--- a/galaxy_ng/app/api/ui/views/auth.py
+++ b/galaxy_ng/app/api/ui/views/auth.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.contrib import auth as django_auth
+from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from rest_framework.authentication import SessionAuthentication
@@ -11,6 +12,7 @@ from rest_framework import status as http_code
 
 from galaxy_ng.app.api import base as api_base
 from galaxy_ng.app.access_control import access_policy
+from galaxy_ng.app.settings import GALAXY_ENABLE_VIEW_ONLY_ACCESS
 
 from galaxy_ng.app.api.ui.serializers import LoginSerializer
 
@@ -44,6 +46,10 @@ class LoginView(api_base.GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=self.request.data)
+
+        if str(request.user) == "AnonymousUser" and GALAXY_ENABLE_VIEW_ONLY_ACCESS:
+            return HttpResponseRedirect('/')
+
         serializer.is_valid(raise_exception=True)
 
         username = serializer.validated_data['username']

--- a/galaxy_ng/app/api/ui/views/auth.py
+++ b/galaxy_ng/app/api/ui/views/auth.py
@@ -12,7 +12,6 @@ from rest_framework import status as http_code
 
 from galaxy_ng.app.api import base as api_base
 from galaxy_ng.app.access_control import access_policy
-from galaxy_ng.app.settings import GALAXY_ENABLE_VIEW_ONLY_ACCESS
 
 from galaxy_ng.app.api.ui.serializers import LoginSerializer
 
@@ -47,7 +46,7 @@ class LoginView(api_base.GenericAPIView):
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=self.request.data)
 
-        if str(request.user) == "AnonymousUser" and GALAXY_ENABLE_VIEW_ONLY_ACCESS:
+        if str(request.user) == "AnonymousUser" and settings.GALAXY_ENABLE_VIEW_ONLY_ACCESS:
             return HttpResponseRedirect('/')
 
         serializer.is_valid(raise_exception=True)

--- a/galaxy_ng/app/api/ui/viewsets/user.py
+++ b/galaxy_ng/app/api/ui/viewsets/user.py
@@ -1,4 +1,3 @@
-from django.shortcuts import get_object_or_404
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend
 
@@ -62,4 +61,4 @@ class CurrentUserViewSet(
     versioning_class = versioning.UIVersioning
 
     def get_object(self):
-        return get_object_or_404(self.model, pk=self.request.user.pk)
+        return self.request.user

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -229,7 +229,7 @@ class CollectionUploadViewSet(api_base.LocalSettingsMixin,
 
 class CollectionArtifactDownloadView(api_base.APIView):
     permission_classes = [access_policy.CollectionAccessPolicy]
-    action = 'retrieve'
+    action = 'download'
 
     def _get_tcp_response(self, url):
         return requests.get(url, stream=True, allow_redirects=False)

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -138,6 +138,9 @@ LOCALE_PATHS = (os.path.join(BASE_DIR, 'locale'),)
 
 CONNECTED_ANSIBLE_CONTROLLERS = []
 
+GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS = False
+GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD = False
+
 GALAXY_ENABLE_API_ACCESS_LOG = False
 # Extra AUTOMATED_LOGGING settings are defined on dynaconf_hooks.py
 # to be overridden by the /etc/pulp/settings.py

--- a/galaxy_ng/tests/unit/api/test_view_only_access.py
+++ b/galaxy_ng/tests/unit/api/test_view_only_access.py
@@ -78,10 +78,10 @@ class ViewOnlyTestCase(BaseTestCase):
             }
         )
 
-    def test_view_only_access_to_collections(self):
+    def test_unauthenticated_access_to_collections(self):
         response = self.client.get(self.collections_detail_url)
         self.assertEqual(response.data['errors'][0]['status'], '403')
-        with self.settings(GALAXY_ENABLE_VIEW_ONLY_ACCESS=True):
+        with self.settings(GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS=True):
             response = self.client.get(self.collections_detail_url)
             self.assertEqual(response.data['name'], self.collection.name)
             self.assertEqual(response.data['namespace'], self.collection.namespace.name)
@@ -90,9 +90,9 @@ class ViewOnlyTestCase(BaseTestCase):
                 response.data['highest_version']['version'], '1.1.2'
             )
 
-    def test_view_only_access_to_namespace(self):
+    def test_unauthenticated_access_to_namespace(self):
         response = self.client.get(self.ns_detail_url)
         self.assertEqual(response.data['errors'][0]['status'], '403')
-        with self.settings(GALAXY_ENABLE_VIEW_ONLY_ACCESS=True):
+        with self.settings(GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS=True):
             response = self.client.get(self.ns_detail_url)
             self.assertEqual(response.data['name'], self.namespace.name)

--- a/galaxy_ng/tests/unit/api/test_view_only_access.py
+++ b/galaxy_ng/tests/unit/api/test_view_only_access.py
@@ -1,7 +1,7 @@
 from django.urls.base import reverse
 from django.test.utils import override_settings
 
-from rest_framework.test import APIClient, APITestCase
+from rest_framework.test import APIClient
 
 from pulp_ansible.app.models import (
     AnsibleDistribution,
@@ -11,6 +11,8 @@ from pulp_ansible.app.models import (
 )
 from galaxy_ng.app import models
 from galaxy_ng.app.constants import DeploymentMode
+
+from .base import BaseTestCase
 
 
 def _create_repo(name, **kwargs):
@@ -34,8 +36,7 @@ def _get_create_version_in_repo(namespace, collection, version, repo):
 
 
 @override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value)
-@override_settings(GALAXY_ENABLE_VIEW_ONLY_ACCESS=True)
-class ViewOnlyTestCase(APITestCase):
+class ViewOnlyTestCase(BaseTestCase):
     def setUp(self):
         super().setUp()
         self.client = APIClient()
@@ -68,13 +69,30 @@ class ViewOnlyTestCase(APITestCase):
             }
         )
 
-    def test_view_only_access_to_collections(self):
-        from galaxy_ng.app.access_control.statements import STANDALONE_STATEMENTS
-        response = self.client.get(self.collections_detail_url)
-        self.assertEqual(STANDALONE_STATEMENTS['MyUserViewSet'][0]['action'], ['retrieve'])
-        self.assertEqual(STANDALONE_STATEMENTS['MyUserViewSet'][0]['principal'], ['*'])
-        self.assertEqual(response.data['namespace'], self.namespace.name)
-        self.assertEqual(response.data['deprecated'], False)
-        self.assertEqual(
-            response.data['highest_version']['version'], '1.1.2'
+        self.ns_url = reverse('galaxy:api:v3:namespaces-list')
+
+        self.ns_detail_url = reverse(
+            'galaxy:api:v3:namespaces-detail',
+            kwargs={
+                "name": self.namespace.name
+            }
         )
+
+    def test_view_only_access_to_collections(self):
+        response = self.client.get(self.collections_detail_url)
+        self.assertEqual(response.data['errors'][0]['status'], '403')
+        with self.settings(GALAXY_ENABLE_VIEW_ONLY_ACCESS=True):
+            response = self.client.get(self.collections_detail_url)
+            self.assertEqual(response.data['name'], self.collection.name)
+            self.assertEqual(response.data['namespace'], self.collection.namespace.name)
+            self.assertEqual(response.data['deprecated'], False)
+            self.assertEqual(
+                response.data['highest_version']['version'], '1.1.2'
+            )
+
+    def test_view_only_access_to_namespace(self):
+        response = self.client.get(self.ns_detail_url)
+        self.assertEqual(response.data['errors'][0]['status'], '403')
+        with self.settings(GALAXY_ENABLE_VIEW_ONLY_ACCESS=True):
+            response = self.client.get(self.ns_detail_url)
+            self.assertEqual(response.data['name'], self.namespace.name)

--- a/galaxy_ng/tests/unit/api/test_view_only_collections.py
+++ b/galaxy_ng/tests/unit/api/test_view_only_collections.py
@@ -1,0 +1,80 @@
+from django.urls.base import reverse
+from django.test.utils import override_settings
+
+from rest_framework.test import APIClient, APITestCase
+
+from pulp_ansible.app.models import (
+    AnsibleDistribution,
+    AnsibleRepository,
+    Collection,
+    CollectionVersion,
+)
+from galaxy_ng.app import models
+from galaxy_ng.app.constants import DeploymentMode
+
+
+def _create_repo(name, **kwargs):
+    repo = AnsibleRepository.objects.create(name=name, **kwargs)
+    AnsibleDistribution.objects.create(
+        name=name, base_path=name, repository=repo
+    )
+    return repo
+
+
+def _get_create_version_in_repo(namespace, collection, version, repo):
+    collection_version, _ = CollectionVersion.objects.get_or_create(
+        namespace=namespace,
+        name=collection.name,
+        collection=collection,
+        version=version,
+    )
+    qs = CollectionVersion.objects.filter(pk=collection_version.pk)
+    with repo.new_version() as new_version:
+        new_version.add_content(qs)
+
+
+@override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value)
+@override_settings(GALAXY_ENABLE_VIEW_ONLY_ACCESS=True)
+class ViewOnlyTestCase(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+
+        self.namespace = models.Namespace.objects.create(name='view_only_namespace')
+        self.collection = Collection.objects.create(
+            namespace=self.namespace, name='view_only_collection'
+        )
+        self.repo = _create_repo(name='view_only_repo')
+
+        _get_create_version_in_repo(
+            self.namespace,
+            self.collection,
+            '1.1.1',
+            self.repo
+        )
+        _get_create_version_in_repo(
+            self.namespace,
+            self.collection,
+            '1.1.2',
+            self.repo
+        )
+
+        self.collections_detail_url = reverse(
+            'galaxy:api:content:v3:collections-detail',
+            kwargs={
+                'path': self.repo.name,
+                'namespace': self.namespace.name,
+                'name': self.collection.name
+            }
+        )
+
+    def test_view_only_access_to_collections(self):
+        from galaxy_ng.app.access_control.statements import STANDALONE_STATEMENTS
+        response = self.client.get(self.collections_detail_url)
+        self.assertEqual(STANDALONE_STATEMENTS['MyUserViewSet'][0]['action'], ['retrieve'])
+        self.assertEqual(STANDALONE_STATEMENTS['MyUserViewSet'][0]['principal'], ['*'])
+        self.assertEqual(response.data['namespace'], self.namespace.name)
+        self.assertEqual(response.data['deprecated'], False)
+        self.assertEqual(
+            response.data['highest_version']['version'], '1.1.2'
+        )


### PR DESCRIPTION
Set the `GALAXY_ENABLE_VIEW_ONLY_ACCESS` in `galaxy_ng/app/settings.py` to `True` and load Hub.
Issue: AAH-881