### PR TITLE
Surface versions of all plugins on APIRoot

### DIFF
--- a/galaxy_ng/app/api/views.py
+++ b/galaxy_ng/app/api/views.py
@@ -1,3 +1,5 @@
+import galaxy_importer
+
 from django.apps import apps
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -15,7 +17,10 @@ VERSIONS = {
     "available_versions": {"v3": "v3/"},
     "server_version": apps.get_app_config("galaxy").version,
     "galaxy_ng_version": apps.get_app_config("galaxy").version,
+    "galaxy_importer_version": galaxy_importer.__version__,
+    "pulp_core_version": apps.get_app_config('core').version,
     "pulp_ansible_version": apps.get_app_config('ansible').version,
+    "pulp_container_version": apps.get_app_config('container').version,
 }
 
 


### PR DESCRIPTION
Currently APIRoot shows only versions for galaxy and pulp_ansible,
as we added dependency on more plugins it is useful to get the
isntalled versions for core, container and importer.

No-Issue