### PR TITLE
gettext is needed by localization automation to extract strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ docker/migrate:   ## Run django migrations
 docker/resetdb:   ## Cleans database
 	./compose run --rm api /bin/bash -c "./entrypoint.sh manage reset_db && django-admin migrate"
 
+.PHONY: docker/translations
+docker/translations:   ## Generate the translation messages
+	./compose run --rm api bash -c "cd /app/galaxy_ng && django-admin makemessages --all"
+
 # Application management and debugging
 
 # e.g: make api/get URL=/content/community/v3/collections/

--- a/dev/standalone/Dockerfile
+++ b/dev/standalone/Dockerfile
@@ -8,3 +8,9 @@ RUN set -ex; \
     if [[ "${LOCK_REQUIREMENTS}" -eq "1" ]]; then \
     pip install --no-cache-dir --requirement /tmp/requirements.standalone.txt; \
     fi
+
+USER root
+
+RUN dnf install -y gettext
+
+USER galaxy


### PR DESCRIPTION
The `gettext` package is needed to be able to run `django-admin makemessages` in order to extract strings.  This PR adds that dependency to the dev/standalone/Dockerfile, which appears to be a wrapper around the galaxy_ng base image.  

I built it locally and it works:

```
[galaxy@d8cb2f9d6dc0 /]$ dnf list installed | grep gettext
gettext.x86_64                                0.19.8.1-17.el8                         @ubi-8-baseos   
gettext-libs.x86_64                           0.19.8.1-17.el8                         @ubi-8-baseos 
```

Using the following steps, I am now able to extract strings successfully:

```
git clone 
cd galaxy_ng
cp .compose.env.example .compose.env
./compose build
./compose run --rm api bash -c "cd /app/galaxy_ng && django-admin makemessages --all"
```