### PR TITLE
Move signals to its own module and load on app.ready()

### DIFF
--- a/galaxy_ng/app/__init__.py
+++ b/galaxy_ng/app/__init__.py
@@ -1,5 +1,4 @@
 from pulpcore.plugin import PulpPluginAppConfig
-from django.db.models.signals import post_migrate
 
 
 class PulpGalaxyPluginAppConfig(PulpPluginAppConfig):
@@ -11,23 +10,4 @@ class PulpGalaxyPluginAppConfig(PulpPluginAppConfig):
 
     def ready(self):
         super().ready()
-        post_migrate.connect(
-            set_pulp_container_access_policies,
-            sender=self,
-            dispatch_uid="override_pulp_container_access_policies"
-        )
-
-
-def set_pulp_container_access_policies(sender, **kwargs):
-    apps = kwargs.get("apps")
-    if apps is None:
-        from django.apps import apps
-    AccessPolicy = apps.get_model("core", "AccessPolicy")
-
-    from galaxy_ng.app.access_control import statements # noqa
-    PULP_CONTAINER_VIEWSETS = statements.PULP_CONTAINER_VIEWSETS
-
-    print("Overriding pulp_container access poliicy")
-    for view in PULP_CONTAINER_VIEWSETS:
-        policy, created = AccessPolicy.objects.update_or_create(
-            viewset_name=view, defaults={**PULP_CONTAINER_VIEWSETS[view], "customized": True})
+        from .signals import handlers  # noqa

--- a/galaxy_ng/app/models/collectionsync.py
+++ b/galaxy_ng/app/models/collectionsync.py
@@ -1,27 +1,6 @@
 from django.db import models
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from pulpcore.plugin.models import Task
-from pulp_ansible.app.models import AnsibleRepository, Collection
-
-from .namespace import Namespace
-
-
-@receiver(post_save, sender=Collection)
-def create_namespace_if_not_present(sender, instance, created, **kwargs):
-    """Ensure Namespace object exists when Collection object saved.
-
-    django signal for pulp_ansible Collection model, so that whenever a
-    Collection object is created or saved, it will create a Namespace object
-    if the Namespace does not already exist.
-
-    Supports use case: In pulp_ansible sync, when a new collection is sync'd
-    a new Collection object is created, but the Namespace object is defined
-    in galaxy_ng and therefore not created. This signal ensures the
-    Namespace is created.
-    """
-
-    Namespace.objects.get_or_create(name=instance.namespace)
+from pulp_ansible.app.models import AnsibleRepository
 
 
 class CollectionSyncTask(models.Model):

--- a/galaxy_ng/app/signals/__init__.py
+++ b/galaxy_ng/app/signals/__init__.py
@@ -1,0 +1,11 @@
+"""
+Strictly speaking, signal handling and registration code can live anywhere you like, although it’s
+recommended to avoid the application’s root module and its models module to minimize side-effects
+of importing code.
+In practice, signal handlers are usually defined in a signals submodule of the application they
+relate to. Signal receivers are connected in the ready() method of your application configuration
+class. If you’re using the receiver() decorator, simply import the signals submodule inside
+ready().
+https://stackoverflow.com/a/22924754
+https://docs.djangoproject.com/en/3.2/topics/signals/
+"""

--- a/galaxy_ng/app/signals/handlers.py
+++ b/galaxy_ng/app/signals/handlers.py
@@ -1,0 +1,45 @@
+"""
+Signal handlers for the Galaxy application.
+Those signals are loaded by
+galaxy_ng.app.__init__:PulpGalaxyPluginAppConfig.ready() method.
+"""
+from django.apps import apps
+from django.dispatch import receiver
+from django.db.models.signals import post_save, post_migrate
+from pulp_ansible.app.models import Collection
+from galaxy_ng.app.access_control.statements import PULP_CONTAINER_VIEWSETS
+from galaxy_ng.app.models.namespace import Namespace
+
+
+@receiver(post_save, sender=Collection)
+def create_namespace_if_not_present(sender, instance, created, **kwargs):
+    """Ensure Namespace object exists when Collection object saved.
+    django signal for pulp_ansible Collection model, so that whenever a
+    Collection object is created or saved, it will create a Namespace object
+    if the Namespace does not already exist.
+    Supports use case: In pulp_ansible sync, when a new collection is sync'd
+    a new Collection object is created, but the Namespace object is defined
+    in galaxy_ng and therefore not created. This signal ensures the
+    Namespace is created.
+    """
+
+    Namespace.objects.get_or_create(name=instance.namespace)
+
+
+def set_pulp_container_access_policies(sender, **kwargs):
+    apps = kwargs.get("apps")
+    if apps is None:
+        from django.apps import apps
+    AccessPolicy = apps.get_model("core", "AccessPolicy")
+
+    print("Overriding pulp_container access policy")
+    for view in PULP_CONTAINER_VIEWSETS:
+        policy, created = AccessPolicy.objects.update_or_create(
+            viewset_name=view, defaults={**PULP_CONTAINER_VIEWSETS[view], "customized": True})
+
+
+post_migrate.connect(
+    set_pulp_container_access_policies,
+    sender=apps.get_app_config("galaxy"),
+    dispatch_uid="override_pulp_container_access_policies"
+)


### PR DESCRIPTION
Strictly speaking, signal handling and registration code can live anywhere you like, although it’s
recommended to avoid the application’s root module and its models module to minimize side-effects
of importing code.

In practice, signal handlers are usually defined in a signals submodule of the application they
relate to. Signal receivers are connected in the ready() method of your application configuration
class. If you’re using the receiver() decorator, simply import the signals submodule inside
ready().

https://docs.djangoproject.com/en/3.2/topics/signals/
https://stackoverflow.com/a/22924754

No-Issue