### PR TITLE
Clowder: Add pulp encryption secret

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,7 @@
 [allowlist]
   description = "Our test install exports a test only MINIO ACCESS KEY"
-  files = [ '''.github/workflows/scripts/install.sh''', '''dev/Dockerfile.base''' ]
+  files = [
+    ".github/workflows/scripts/install.sh",
+    "openshift/clowder/clowd-app.yaml",
+    "dev/Dockerfile.base",
+  ]

--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -5,6 +5,15 @@ metadata:
   name: automation-hub
 objects:
 - apiVersion: v1
+  kind: Secret
+  metadata:
+    name: pulp-key
+    namespace: automation-hub
+  data:
+    database_fields.symmetric.key: |
+      DNmNdwgyZugTax9S64J0FITTr9IHPxbuoF1F1CGPr68=
+
+- apiVersion: v1
   kind: ConfigMap
   metadata:
     name: galaxy-importer-config
@@ -46,6 +55,14 @@ objects:
               value: 'insights'
             - name: PULP_CONTENT_ORIGIN
               value: 'localhost'
+          volumeMounts:
+          - name: pulp-key
+            mountPath: /etc/pulp/certs
+            readOnly: true
+          volumes:
+          - name: pulp-key
+            secret:
+              secretName: pulp-key
 
     deployments:
     - name: "backend${SUFFIX}"
@@ -106,6 +123,14 @@ objects:
             value: '10000'
           - name: PULP_REDIS_SSL
             value: ${REDIS_SSL}
+        volumeMounts:
+          - name: pulp-key
+            mountPath: /etc/pulp/certs
+            readOnly: true
+        volumes:
+          - name: pulp-key
+            secret:
+              secretName: pulp-key
       webServices:
         public:
             enabled: true
@@ -134,6 +159,14 @@ objects:
             value: '10000'
           - name: PULP_REDIS_SSL
             value: ${REDIS_SSL}
+        volumeMounts:
+          - name: pulp-key
+            mountPath: /etc/pulp/certs
+            readOnly: true
+        volumes:
+          - name: pulp-key
+            secret:
+              secretName: pulp-key
       webServices:
         private:
             enabled: true
@@ -176,10 +209,16 @@ objects:
         volumeMounts:
           - name: importer-config
             mountPath: /etc/galaxy-importer
+          - name: pulp-key
+            mountPath: /etc/pulp/certs
+            readOnly: true
         volumes:
           - name: importer-config
             configMap:
               name: galaxy-importer-config
+          - name: pulp-key
+            secret:
+              secretName: pulp-key
 
     # Creates a database if local mode, or uses RDS in production
     database:

--- a/openshift/database-migration.yaml
+++ b/openshift/database-migration.yaml
@@ -19,9 +19,9 @@ objects:
             - name: quay-cloudservices-pull
             - name: rh-registry-pull
           volumes:
-            - name: settings
-              configMap:
-                name: galaxy-config
+            - name: pulp-key
+              secret:
+                secretName: pulp-key
           containers:
             - name: database-migration-${IMAGE_TAG}
               image: ${IMAGE}:${IMAGE_TAG}
@@ -35,8 +35,9 @@ objects:
                   cpu: ${{CPU_LIMIT}}
                   memory: ${{MEMORY_LIMIT}}
               volumeMounts:
-                - mountPath: /etc/pulp
-                  name: settings
+                - name: pulp-key
+                  mountPath: /etc/pulp/certs
+                  readOnly: true
               env:
                 - name: PULP_SECRET_KEY
                   valueFrom:


### PR DESCRIPTION
Mount pulp encryption secret in ClowdApp and database migration
template.

NOTES:
  1. For stage and production deployment a secret must exist
     before the deployment is executed.
  2. Migtation template ref must be updated along with image tag
     in the app-interface to pick up changes in this commit.

No-Issue