### PR TITLE
Add endpoint for namespace deletion

### DIFF
--- a/CHANGES/709.feature
+++ b/CHANGES/709.feature
@@ -1,0 +1,1 @@
+Enable Namespace deletion endpoint.

--- a/galaxy_ng/app/access_control/statements/insights.py
+++ b/galaxy_ng/app/access_control/statements/insights.py
@@ -13,6 +13,12 @@ INSIGHTS_STATEMENTS = {
             "condition": ["has_model_perms:galaxy.add_namespace", "has_rh_entitlements"]
         },
         {
+            "action": "destroy",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": ["has_model_or_obj_perms:galaxy.delete_namespace", "has_rh_entitlements"]
+        },
+        {
             "action": "update",
             "principal": "authenticated",
             "effect": "allow",

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -7,8 +7,9 @@ STANDALONE_STATEMENTS = {
         },
         {
             "action": "destroy",
-            "principal": "*",
-            "effect": "deny",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_or_obj_perms:galaxy.delete_namespace"
         },
         {
             "action": "create",

--- a/galaxy_ng/app/api/ui/serializers/user.py
+++ b/galaxy_ng/app/api/ui/serializers/user.py
@@ -138,6 +138,7 @@ class CurrentUserSerializer(UserSerializer):
             "add_namespace": obj.has_perm('galaxy.add_namespace'),
             "upload_to_namespace": obj.has_perm('galaxy.upload_to_namespace'),
             "change_namespace": obj.has_perm('galaxy.change_namespace'),
+            "delete_namespace": obj.has_perm('galaxy.delete_namespace'),
             "move_collection": obj.has_perm('ansible.modify_ansible_repo_content'),
             "change_remote": obj.has_perm('ansible.change_collectionremote'),
             "delete_remote": obj.has_perm('ansible.delete_collectionremote'),

--- a/galaxy_ng/app/api/v3/viewsets/namespace.py
+++ b/galaxy_ng/app/api/v3/viewsets/namespace.py
@@ -4,7 +4,15 @@ from django.utils.translation import gettext_lazy as _
 from django_filters import filters
 from django_filters.rest_framework import filterset, DjangoFilterBackend
 
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from pulp_ansible.app.models import Collection
+
 from galaxy_ng.app import models
+from galaxy_ng.app.models.namespace import delete_inbound_repo
 from galaxy_ng.app.access_control.access_policy import NamespaceAccessPolicy
 from galaxy_ng.app.api import base as api_base
 from galaxy_ng.app.api.v3 import serializers
@@ -52,7 +60,7 @@ class NamespaceViewSet(api_base.ModelViewSet):
             return self.serializer_class
 
     @transaction.atomic
-    def create(self, request, *args, **kwargs):
+    def create(self, request: Request, *args, **kwargs) -> Response:
         """Override to validate for name duplication before serializer validation."""
         name = request.data.get('name')
         if name and models.Namespace.objects.filter(name=name).exists():
@@ -61,3 +69,35 @@ class NamespaceViewSet(api_base.ModelViewSet):
                 detail={'name': _('A namespace named %s already exists.') % name}
             )
         return super().create(request, *args, **kwargs)
+
+    @transaction.atomic
+    def destroy(self, request: Request, *args, **kwargs) -> Response:
+        """Delete a namespace.
+
+        1. Perform a check to see if there are any collections in the namespace.
+           If there are, return a failure.
+        2. Delete the inbound pulp distro and repository
+        3. Delete the namespace object.
+
+        return: Response(status=204)
+        """
+        namespace = self.get_object()
+
+        # 1. Check if there are any collections in the namespace.
+        if Collection.objects.filter(namespace=namespace.name).exists():
+            raise ValidationError(
+                detail=_(
+                    'Namespace %s cannot be deleted because '
+                    'there are still collections associated with it.'
+                ) % namespace.name
+            )
+
+        # 2. Delete the inbound pulp distro and repository
+        #    the Namespace model delete will handle this but
+        #    was kept here for better clarity.
+        delete_inbound_repo(namespace.name)
+
+        # 3. Delete the namespace object.
+        self.perform_destroy(namespace)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/galaxy_ng/tests/unit/api/base.py
+++ b/galaxy_ng/tests/unit/api/base.py
@@ -93,7 +93,11 @@ class BaseTestCase(APITestCase):
 
         groups_to_add = {}
         for group in groups:
-            groups_to_add[group] = ['galaxy.upload_to_namespace', 'galaxy.change_namespace']
+            groups_to_add[group] = [
+                'galaxy.upload_to_namespace',
+                'galaxy.change_namespace',
+                'galaxy.delete_namespace'
+            ]
         namespace.groups = groups_to_add
         return namespace
 
@@ -104,6 +108,7 @@ class BaseTestCase(APITestCase):
             'galaxy.add_namespace',
             'galaxy.change_namespace',
             'galaxy.upload_to_namespace',
+            'galaxy.delete_namespace',
 
             # collections
             'ansible.modify_ansible_repo_content',


### PR DESCRIPTION
Allow DELETE requests on `/api/automation-hub/v3/namespaces/<name>/`
path.

1. Perform a check to see if there are any collections in the namespace.
   If there are, return a failure.
2. Delete the inbound pulp distro and repository
3. Delete the namespace object.

return: Response(status=204)

NOTES:
- DELETE endpoints doesn't accept payload
- Return doesn't include a pulp task id as Namespace is on galaxy_ng and
  deleted only after the collection dependents check is performed, there is no pulp_task involved.

Issue: AAH-709