### PR TITLE
galaxy custom access control statements should be lazily loaded.

### DIFF
--- a/galaxy_ng/app/__init__.py
+++ b/galaxy_ng/app/__init__.py
@@ -1,6 +1,5 @@
 from pulpcore.plugin import PulpPluginAppConfig
 from django.db.models.signals import post_migrate
-from galaxy_ng.app.access_control.statements import PULP_CONTAINER_VIEWSETS
 
 
 class PulpGalaxyPluginAppConfig(PulpPluginAppConfig):
@@ -24,6 +23,9 @@ def set_pulp_container_access_policies(sender, **kwargs):
     if apps is None:
         from django.apps import apps
     AccessPolicy = apps.get_model("core", "AccessPolicy")
+
+    from galaxy_ng.app.access_control import statements # noqa
+    PULP_CONTAINER_VIEWSETS = statements.PULP_CONTAINER_VIEWSETS
 
     print("Overriding pulp_container access poliicy")
     for view in PULP_CONTAINER_VIEWSETS:

--- a/galaxy_ng/tests/unit/api/synclist_base.py
+++ b/galaxy_ng/tests/unit/api/synclist_base.py
@@ -7,7 +7,6 @@ from guardian import shortcuts
 from pulp_ansible.app import models as pulp_ansible_models
 
 from galaxy_ng.app import models as galaxy_models
-from galaxy_ng.app.access_control.statements import INSIGHTS_STATEMENTS
 from galaxy_ng.app.models import auth as auth_models
 
 from . import base
@@ -46,6 +45,7 @@ class BaseSyncListViewSet(base.BaseTestCase):
             name=repo_name, base_path=repo_name, repository=self.default_repo
         )
 
+        from galaxy_ng.app.access_control.statements import INSIGHTS_STATEMENTS  # noqa
         patcher = mock.patch(
             "galaxy_ng.app.access_control." "access_policy.AccessPolicyBase._get_statements",
             return_value=INSIGHTS_STATEMENTS,


### PR DESCRIPTION
Tl:DR; 

```py
# doing this import, as this module is not part of django
from galaxy_ng.app.access_control.statements import PULP_CONTAINER_VIEWSETS, ANYTHINGELSE
# happens before django.apps.ready() is executed
# So pulp settings is not loaded yet.
```

---

Galaxy has a custom accesscontrol statements module
if that module is imported before the django settings is configured
by pulp/dynaconf, then it is impossible to access settings on that
module.

It is also safer to load extra-django things only after the app.ready()
is executed.

No-Issue