### PR TITLE
Upgrade to pulpcore==3.14.6 to fix OpenShift deploys

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -167,7 +167,7 @@ pulp-ansible==0.9.0
     # via galaxy-ng (setup.py)
 pulp-container==2.7.0
     # via galaxy-ng (setup.py)
-git+https://git@github.com/bmbouter/pulpcore@011e086f5e7afbf12ee2ec155e4b3e5a30dde979#egg=pulpcore
+pulpcore==3.14.6
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -223,8 +223,6 @@ rich==10.1.0
     # via
     #   ansible-lint
     #   enrich
-rpdb==0.1.6
-    # via pulpcore
 rq==1.8.1
     # via pulpcore
 ruamel.yaml==0.17.4

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -187,7 +187,7 @@ pulp-ansible==0.9.0
     # via galaxy-ng (setup.py)
 pulp-container==2.7.0
     # via galaxy-ng (setup.py)
-git+https://git@github.com/bmbouter/pulpcore@011e086f5e7afbf12ee2ec155e4b3e5a30dde979#egg=pulpcore
+pulpcore==3.14.6
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -245,8 +245,6 @@ rich==10.1.0
     # via
     #   ansible-lint
     #   enrich
-rpdb==0.1.6
-    # via pulpcore
 rq==1.8.1
     # via pulpcore
 ruamel.yaml==0.17.4

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -177,7 +177,7 @@ pulp-ansible==0.9.0
     # via galaxy-ng (setup.py)
 pulp-container==2.7.0
     # via galaxy-ng (setup.py)
-git+https://git@github.com/bmbouter/pulpcore@011e086f5e7afbf12ee2ec155e4b3e5a30dde979#egg=pulpcore
+pulpcore==3.14.6
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -233,8 +233,6 @@ rich==10.1.0
     # via
     #   ansible-lint
     #   enrich
-rpdb==0.1.6
-    # via pulpcore
 rq==1.8.1
     # via pulpcore
 ruamel.yaml==0.17.4

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ class BuildPyCommand(_BuildPyCommand):
 requirements = [
     "Django~=2.2.23",
     "galaxy-importer==0.3.4",
-    "pulpcore @ git+https://git@github.com/bmbouter/pulpcore@011e086f5e7afbf12ee2ec155e4b3e5a30dde979#egg=pulpcore",
+    "pulpcore==3.14.6",
     "pulp-ansible>=0.9.0,<0.10.0",
     "django-prometheus>=2.0.0",
     "drf-spectacular",


### PR DESCRIPTION
This PR also removes the temporary pulpcore source checkout debugging

No-Issue