### PR TITLE
Improvements on Makefile + collection generation for testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,30 @@
+.SILENT:
 DOCKER_IMAGE_NAME = localhost/galaxy_ng/galaxy_ng
+RUNNING = $(shell docker ps -q -f name=api)
 
+# if running is empty, then DJ_MANAGER = manage, else DJ_MANAGER = django-admin
+DJ_MANAGER = $(shell if [ "$(RUNNING)" == "" ]; then echo manage; else echo django-admin; fi)
+
+define exec_or_run
+	# Tries to run on existing container if it exists, otherwise starts a new one.
+	@echo $(1)$(2)$(3)$(4)$(5)
+	@if [ "$(RUNNING)" != "" ]; then \
+		echo "Running on existing container $(RUNNING)" 1>&2; \
+		./compose exec $(1) $(2) $(3) $(4) $(5); \
+	else \
+		echo "Starting new container" 1>&2; \
+		./compose run --use-aliases --service-ports --rm $(1) $(2) $(3) $(4) $(5); \
+	fi
+endef
+
+
+.DEFAULT:
 .PHONY: help
 help:             ## Show the help.
 	@echo "Usage: make <target>"
 	@echo ""
 	@echo "Targets:"
-	@fgrep "##" Makefile | fgrep -v fgrep
+	@fgrep "##" Makefile | fgrep -v fgrep | sed 's/^/\n/' | sed 's/#/\n/'
 
 
 # Update python dependencies lock files (i.e. requirements.*.txt)
@@ -35,7 +54,20 @@ requirements/pip-upgrade-all:     ## Update based on setup.py and *.in files, an
 changelog:        ## Build the changelog
 	towncrier build
 
+.PHONY: lint
+lint:             ## Lint the code
+	flake8 --config flake8.cfg
+
+.PHONY: fmt
+fmt:              ## Format the code using Darker
+	@echo "Formatting code using darker, just like black, but only on changed regions of files."
+	darker
+
 # Container environment management
+
+.PHONY: docker/prune
+docker/prune:     ## Clean all development images and volumes
+	@docker system prune --all --volumes
 
 .PHONY: docker/build
 docker/build:     ## Build all development images.
@@ -45,7 +77,7 @@ docker/build:     ## Build all development images.
 # if TEST is not passed run all tests.
 .PHONY: docker/test
 docker/test:      ## Run unit tests.
-	./compose run api manage test galaxy_ng.tests.unit$(TEST)
+	$(call exec_or_run, api, $(DJ_MANAGER), test, galaxy_ng.tests.unit$(TEST))
 
 .PHONY: docker/loaddata
 docker/loaddata:  ## Load initial data from fixtures
@@ -54,15 +86,25 @@ docker/loaddata:  ## Load initial data from fixtures
 
 .PHONY: docker/migrate
 docker/migrate:   ## Run django migrations
-	./compose run --rm api manage migrate
+	$(call exec_or_run, api, $(DJ_MANAGER), migrate)
 
 .PHONY: docker/resetdb
 docker/resetdb:   ## Cleans database
+	# Databases must be stopped to be able to reset them.
+	./compose down
+	./compose stop
 	./compose run --rm api /bin/bash -c "./entrypoint.sh manage reset_db && django-admin migrate"
 
 .PHONY: docker/translations
 docker/translations:   ## Generate the translation messages
 	./compose run --rm api bash -c "cd /app/galaxy_ng && django-admin makemessages --all"
+
+.PHONY: docker/all
+docker/all: 	                                ## Build, migrate, loaddata, translate and add test collections.
+	make docker/build 
+	make docker/migrate 
+	make docker/loaddata 
+	make docker/translations 
 
 # Application management and debugging
 
@@ -74,13 +116,11 @@ api/get:          ## Make an api get request using 'httpie'
 
 .PHONY: api/shell
 api/shell:        ## Opens django management shell in api container
-	# Tries to exec in a running container or start a containers and run
-	./compose exec api django-admin shell_plus || ./compose run --use-aliases --service-ports --rm api manage shell_plus
+	$(call exec_or_run, api, $(DJ_MANAGER), shell_plus)
 
 .PHONY: api/bash
 api/bash:         ## Opens bash session in the api container
-	# tries to exec in a running container or start a container and run
-	./compose exec api /bin/bash || ./compose run --use-aliases --service-ports --rm api /bin/bash
+	$(call exec_or_run, api, /bin/bash)
 
 .PHONY: api/runserver
 api/runserver:    ## Runs api using django webserver for debugging
@@ -92,6 +132,26 @@ api/runserver:    ## Runs api using django webserver for debugging
 	./compose stop api
 	# Run api using django runserver for debugging
 	./compose run --service-ports --use-aliases --name api --rm api manage runserver 0.0.0.0:8000
+
+.PHONY: api/routes
+api/routes:       ## Prints all available routes
+	$(call exec_or_run, api, $(DJ_MANAGER), show_urls)
+
+.EXPORT_ALL_VARIABLES:
+.ONESHELL:
+.PHONY: api/create-test-collections
+api/create-test-collections:   ## Creates a set of test collections
+	@read -p "How many namespaces to create? : " NS; \
+	read -p "Number of collections on each namespace? : " COLS; \
+	read -p "Add a prefix? : " PREFIX; \
+	ARGS="--prefix=$${PREFIX:-dev} --strategy=faux --ns=$${NS:-6} --cols=$${COLS:-6}"; \
+	echo "Creating test collections with args: $${ARGS}"; \
+	export ARGS; \
+	$(call exec_or_run, api, $(DJ_MANAGER), create-test-collections, $${ARGS})
+
+.PHONY: api/list-permissions
+api/list-permissions:   ## List all permissions - CONTAINS=str
+	$(call exec_or_run, api, $(DJ_MANAGER), shell -c 'from django.contrib.auth.models import Permission;from pprint import pprint;pprint([f"{perm.content_type.app_label}:{perm.codename}" for perm in Permission.objects.filter(name__icontains="$(CONTAINS)")])')
 
 # Version / bumpversion management
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,8 +1,10 @@
+# This file contains dev requirements to be installed on dev host only 
+# to add requirements to dev container see requirements/requirements-dev.txt
+
 coverage
 flake8
 
 flake8-black
-
 
 flake8-docstrings
 
@@ -10,3 +12,6 @@ flake8-tuple
 flake8-quotes
 
 check-manifest
+
+darker
+isort

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/pulp/pulp-smash.git#egg=pulp-smash
 pytest
+orionutils

--- a/galaxy_ng/app/management/commands/create-test-collections.py
+++ b/galaxy_ng/app/management/commands/create-test-collections.py
@@ -1,0 +1,222 @@
+import random
+from argparse import ArgumentError
+from collections import defaultdict
+from functools import lru_cache
+
+from django.core.management.base import BaseCommand
+from django.urls.base import reverse
+from rest_framework.test import APIClient
+
+from galaxy_ng.app.models.auth import Group, User
+from galaxy_ng.app.models.namespace import Namespace, create_inbound_repo
+from galaxy_ng.tests.constants import TAGS, TEST_COLLECTION_CONFIGS
+
+STRATEGIES = ["test", "faux"]
+
+
+class Command(BaseCommand):
+    """Django management command to feed the system with testing collections
+    Those collections are meant for testing only.
+    namespace defaults to 'test'
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("--namespace", help="namespace name")
+        parser.add_argument(
+            "--strategy",
+            help="generation stategy to call",
+            type=str,
+            default="faux",
+            required=False,
+            choices=STRATEGIES,
+        )
+        parser.add_argument(
+            "-n",
+            "--ns",
+            help="number of namespaces to generate",
+            required=False,
+            type=int,
+            default=21,  # 21 is good for pagination testing
+        )
+        parser.add_argument(
+            "-c",
+            "--cols",
+            help="number of collections to generate",
+            required=False,
+            type=int,
+            default=21,  # 21 is good for pagination testing
+        )
+        parser.add_argument(
+            "-p",
+            "--prefix",
+            help="prefix for namespaces and collections",
+            required=False,
+            type=str,
+            default="",
+        )
+        parser.add_argument(
+            "-y",
+            "--yes",
+            action="store_true",
+            help="don't ask confirmation",
+            default=False,
+            required=False,
+        )
+
+    def echo(self, message):
+        self.stdout.write(self.style.SUCCESS(message))
+
+    @property
+    def generator(self):
+        """Imports on demand, avoids import error when dep not installed"""
+        if not hasattr(self, "_generator"):
+            from orionutils import generator  # noqa
+
+            self._generator = generator
+        return self._generator
+
+    @property
+    def faux(self):
+        """Imports on demand, avoids import error when dep not installed"""
+        if not hasattr(self, "_faux"):
+            import fauxfactory  # noqa
+
+            self._faux = fauxfactory
+        return self._faux
+
+    def handle(self, *args, **options):
+        total = options["cols"] * options["ns"]
+        if not options["yes"]:
+            confirm = input(
+                f"You are about to populate the system with {total} test collections.\n"
+                "This operation cannot be undone\n"
+                "Proceed? (Y/n)"
+            ).lower()
+            while 1:
+                if confirm not in ("y", "n", "yes", "no"):
+                    confirm = input('Please enter either "y/yes" or "n/no": ')
+                    continue
+                if confirm in ("y", "yes"):
+                    break
+                else:
+                    self.echo("Process canceled.")
+                    return
+
+        self.client = APIClient()
+        self.admin_user = User.objects.get(username="admin")
+        self.client.force_authenticate(user=self.admin_user)
+        self.prefix = (options["prefix"] or options["strategy"]).lower()
+
+        strategy = options.get("strategy")
+        getattr(self, f"strategy_{strategy}", self.raise_for_strategy)(*args, **options)
+
+    def upload_collection(self, filename):
+        collection_upload_url = reverse(
+            "galaxy:api:v3:default-content:collection-artifact-upload",
+        )
+        return self.client.post(collection_upload_url, {"file": open(filename, "rb")})
+
+    def raise_for_strategy(self, *args, **kwargs):
+        """No strategy, no action"""
+        raise ArgumentError("Selected strategy doen't exist")
+
+    @lru_cache(maxsize=None)
+    def create_namespace(self, namespace_name, groups=None):
+        namespace_name = f"{self.prefix}{namespace_name}".lower()
+        np, _ = Namespace.objects.get_or_create(name=namespace_name)
+        if not np.groups:
+            if groups:
+                np.groups = groups
+            else:
+                pe = Group.objects.get(name="system:partner-engineers")
+                np.groups = {
+                    pe: [
+                        "galaxy.upload_to_namespace",
+                        "galaxy.change_namespace",
+                        "galaxy.delete_namespace",
+                    ]
+                }
+            np.save()
+        return np
+
+    def apply_prefix(self, config):
+        """Apply a prefix to a config"""
+        if self.prefix:
+            for key in ["namespace", "name"]:
+                if not config[key].startswith(self.prefix):
+                    config[key] = f"{self.prefix}{config[key]}".lower()
+        return config
+
+    def build_collection(self, template, config):
+        """Build a collection from a template and a config"""
+        config = self.apply_prefix(config)
+        return self.generator.build_collection(template, config=config)
+
+    def gen_version(self):
+        x = random.randint(0, 3)
+        y = random.randint(1, 9)
+        z = random.randint(0, 9)
+        return f"{x}.{y}.{z}"
+
+    def strategy_test(self, *args, **options):
+        """Use constants.TEST_COLLECTION_CONFIGS to generate collections"""
+        for config in TEST_COLLECTION_CONFIGS:
+            namespace_name = options.get("namespace") or config["namespace"]
+            create_inbound_repo(namespace_name)
+            np = self.create_namespace(namespace_name)
+            config["namespace"] = np.name
+
+            collection = self.build_collection("skeleton", config=config)
+            response = self.upload_collection(collection.filename)
+
+            self.echo(response.status_code)
+            self.echo(response.data)
+            self.echo("Collection '{}' created".format(collection.name))
+
+    def strategy_faux(self, *args, **options):
+        """Use fauxfactory to generate"""
+        _configs = defaultdict(list)
+        _dependency_pool = {}
+        for _ in range(options["ns"]):
+            namespace_name = self.faux.gen_string(
+                "alpha",
+                8,
+                validator=lambda v: v not in _configs,
+                tries=100,
+                default=self.faux.gen_string("alpha", 8),
+            ).lower()
+            create_inbound_repo(namespace_name)
+            np = self.create_namespace(namespace_name)
+            _collections = []
+            for i in range(options["cols"]):
+                config = {
+                    "name": self.faux.gen_string(
+                        "alpha",
+                        10,
+                        validator=lambda v: v not in _collections,
+                        tries=100,
+                        default=self.faux.gen_string("alpha", 10),
+                    ).lower(),
+                    "description": self.faux.gen_iplum(words=8),
+                    "namespace": np.name,
+                    "version": self.gen_version(),
+                    "tags": random.sample(TAGS, 3),
+                }
+
+                if i > 3:
+                    config["dependencies"] = _dependency_pool
+
+                _collections.append(config["name"])
+                _configs[namespace_name].append(config)
+
+                collection = self.build_collection("skeleton", config=config)
+                response = self.upload_collection(collection.filename)
+                self.echo(response.status_code)
+                self.echo(response.data)
+                self.echo("Collection '{}' created".format(collection.name))
+
+                if i <= 3:
+                    spec = random.choice(["==", ">=", "<="])
+                    _dependency_pool[
+                        f"{config['namespace']}.{config['name']}"
+                    ] = f"{spec}{config['version']}"

--- a/galaxy_ng/tests/constants.py
+++ b/galaxy_ng/tests/constants.py
@@ -1,0 +1,64 @@
+"""
+Constants to be use by testing scripts and development management commands.
+"""
+
+TEST_COLLECTION_CONFIGS = [
+    {"name": "a", "namespace": "test", "dependencies": {"test.b": "*"}},
+    {"name": "b", "namespace": "test", "dependencies": {"test.c": "*"}},
+    {"name": "c", "namespace": "test", "dependencies": {"test.d": "*"}},
+    {"name": "d", "namespace": "test"},
+    {"name": "e", "namespace": "test", "dependencies": {"test.f": "*", "test.g": "*"}},
+    {"name": "f", "namespace": "test", "dependencies": {"test.h": "<=3.0.0"}},
+    {"name": "g", "namespace": "test", "dependencies": {"test.d": "*"}},
+    {"name": "h", "namespace": "test", "version": "1.0.0"},
+    {"name": "h", "namespace": "test", "version": "2.0.0"},
+    {"name": "h", "namespace": "test", "version": "3.0.0"},
+    {"name": "h", "namespace": "test", "version": "4.0.0"},
+    {"name": "h", "namespace": "test", "version": "5.0.0"},
+]
+"""
+TEST_COLLECTION_CONFIGS Dependency Trees:
+
+        A               E
+        |             /   \
+        B            F     G
+        |            |     |
+        C         H(1-3)   D
+        |
+        D
+
+        H has 5 versions, no dependencies
+
+
+The TEST_COLLECTION_CONFIGS are used to build collections with orionutils.
+
+ex:
+
+    from orionutils.generator import build_collection
+    collection = build_collection("skeleton", config=TEST_COLLECTION_CONFIGS)
+    print(collection.filename)
+
+"""
+
+TAGS = [
+    "system",
+    "database",
+    "web",
+    "middleware",
+    "infra",
+    "linux",
+    "rhel",
+    "fedora",
+    "cloud",
+    "monitoring",
+    "windows",
+    "nginx_config",
+    "container",
+    "docker",
+    "development",
+    "kubernetes",
+    "java",
+    "python",
+    "rust",
+    "proxy",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,19 @@ exclude = '''
 '''
 
 
+[tool.darker]
+src = [
+    "galaxy_ng",
+]
+revision = "master"
+isort = true
+lint = [
+    "flake8 --config flake8.cfg",
+]
+log_level = "INFO"
+line_length = 100
+
+
 [tool.check-manifest]
 ignore = [
     ".gitleaks.toml",

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -1,8 +1,16 @@
+# This file contains dev requirements to be installed inside container image.
+# to add requirements to developer host machine see dev_requirements.txt
+
 ipython
 ipdb
 pdbr
 django-extensions
 
+# used by management commands
+orionutils
+fauxfactory
+
+# used by shell_plus
 jedi==0.17.2
 # jedi 0.18.x is buggy when used with ipython
 # ^ https://github.com/ipython/ipython/issues/12740#issuecomment-751273584

--- a/unittest_requirements.txt
+++ b/unittest_requirements.txt
@@ -1,1 +1,2 @@
 mock
+orionutils


### PR DESCRIPTION
# This PR adds enhancements and features to dev Makefile.

## 1 Better output on `make help`

Before `make help` would output targets and summary in the same line and was difficult to keep aligned.

Now `make help` adds a newline between the targets and summary.

```bash
Usage: make <target>

Targets:

help:             
# Show the help.

requirements/no-pip-upgrade:     
# Update based on setup.py and *.in files without asking pip for latest version

requirements/pip-upgrade-single-package:     
# Update based on setup.py and *.in files, and parameter via pip, i.e. package=djangorestframework

requirements/pip-upgrade-all:     
# Update based on setup.py and *.in files, and all packages via pip

changelog:        
# Build the changelog

lint:             
# Lint the code

fmt:              
# Format the code using Darker

docker/prune:     
# Clean all development images and volumes

docker/build:     
# Build all development images.

docker/test:      
# Run unit tests.

docker/loaddata:  
# Load initial data from fixtures

docker/migrate:   
# Run django migrations

docker/resetdb:   
# Cleans database

docker/translations:   
# Generate the translation messages

docker/all: 	                                
# Build, migrate, loaddata, translate and add test collections.

api/get:          
# Make an api get request using 'httpie'

api/shell:        
# Opens django management shell in api container

api/bash:         
# Opens bash session in the api container

api/runserver:    
# Runs api using django webserver for debugging

api/routes:       
# Prints all available routes

api/create-test-collections:   
# Creates a set of test collections
```

## 2. Linting

To lint the code we already use `flake8 --config=flake8.cfg`, this command has been aliased:

```bash
make lint
```

The above will only show the errors but not fix them.

## 3. Automatic code formatting

You can safely run:

```bash
make fmt
```

Whenever you want, before committing your code.

This uses a tool called **darker** which will run **black** and **isort** **ONLY** on the files that have changed. **This allows us to gradually format our codebase instead of doing it all in a single huge PR.**


## 4. Reuse existing container instead of starting new one.

Most of the make targets:

```bash
make docker/test TEST=.api.test_api_v3_collections
make docker/migrate
make docker/translations
make api/shell
make api/routes
make api/create-test-collections
```

can now use the function `exec_or_run` so if the **api** container is running, we can just run the 
command inside it, instead of starting a new one.


## 5. Added `make api/routes`

Whenever you need to list all the URLS on galaxy, or copy the reverse url path run:

Example:

```bash
$ make api/routes | grep upload
/api/automation-hub/content/<str:path>/v3/artifacts/collections/	galaxy_ng.app.api.v3.viewsets.collection.CollectionUploadViewSet	galaxy:api:content:v3:collection-artifact-upload
/api/automation-hub/v3/artifacts/collections/	galaxy_ng.app.api.v3.viewsets.collection.CollectionUploadViewSet	galaxy:api:v3:default-content:collection-artifact-upload
/pulp/api/v3/uploads/	pulpcore.app.viewsets.upload.UploadViewSet	uploads-list
/pulp/api/v3/uploads/<pk>/	pulpcore.app.viewsets.upload.UploadViewSet	uploads-detail
/pulp/api/v3/uploads/<pk>/commit/	pulpcore.app.viewsets.upload.UploadViewSet	uploads-commit
/pulp/api/v3/uploads/<pk>/commit\.<format>/	pulpcore.app.viewsets.upload.UploadViewSet	uploads-commit
/pulp/api/v3/uploads/<pk>\.<format>/	pulpcore.app.viewsets.upload.UploadViewSet	uploads-detail
/pulp/api/v3/uploads\.<format>/	pulpcore.app.viewsets.upload.UploadViewSet	uploads-list
/pulp_ansible/galaxy/<path:path>/api/v3/artifacts/collections/	pulp_ansible.app.galaxy.v3.views.CollectionUploadViewSet	collection-artifact-upload
/v2/<path>/blobs/uploads\/	pulp_container.app.registry_api.BlobUploads	docker-upload-list
/v2/<path>/blobs/uploads\//<pk>	pulp_container.app.registry_api.BlobUploads	docker-upload-detail
```

## 6. Added `create-test-collections` management command.

A utility to create a set of test collections, useful when you want to test the application without 
having to push or upload collections manually.

This uses @ironfroggy 's **orionutils** to build collections and @omaciel 's **fauxfactory** to generate data for each collection.

Examples:

### Create a namespace and a collection

```bash
django-admin create-test-collections --prefix=dev --ns=1 --cols=1
```

The above will create a namespace and a collection.

### Create 6 namespaces with 10 collections each

```bash
django-admin create-test-collections --prefix=dev --ns=6 --cols=10
```

Creates 6 namespaces with 10 collections each. (total 60 collections uploaded)


### Populating a system for manual testing:


Checking the system has no collections published.

```bash
❯ make api/get URL=/content/published/v3/collections/

{
    "data": [],
    "links": {
        "first": "/api/automation-hub/content/published/v3/collections/?limit=10&offset=0",
        "last": "/api/automation-hub/content/published/v3/collections/?limit=10&offset=0",
        "next": null,
        "previous": null
    },
    "meta": {
        "count": 0
    }
}
```

Create and publish 1 namespace with 3 collections.

```bash
❯ make api/create-test-collections                   

How many namespaces to create? : 1
Number of collections on each namespace? : 3
Add a prefix? : dev

Creating test collections with args: --prefix=dev --strategy=faux --ns=1 --cols=3

Running on existing container 65af13be432c

You are about to populate the system with 3 test collections.
This operation cannot be undone
Proceed? (Y/n)
y

pulp [None]: orionutils.generator:INFO: build at /tmp//venv/lib64/python3.8/site-packages/orionutils/collections/skeleton
{'task': '/api/automation-hub/content/inbound-devvafklkur/v3/imports/collections/941b8eb8-9fc6-42be-8cf6-1b6676c157b0/'}
Collection 'devsbsaqrajjw' created

pulp [None]: orionutils.generator:INFO: build at /tmp//venv/lib64/python3.8/site-packages/orionutils/collections/skeleton
{'task': '/api/automation-hub/content/inbound-devvafklkur/v3/imports/collections/b6155174-b745-478a-b325-4a2ab926dbdb/'}
Collection 'devvyyzrzdrei' created

pulp [None]: orionutils.generator:INFO: build at /tmp//venv/lib64/python3.8/site-packages/orionutils/collections/skeleton
{'task': '/api/automation-hub/content/inbound-devvafklkur/v3/imports/collections/50059991-6c27-44eb-ad6b-e30262b089ca/'}
Collection 'devqzvguwyzaw' created
```

Verify the collections are published.

```bash
❯ make api/get URL=/content/published/v3/collections/
{
    "data": [
        {
            "created_at": "2021-09-06T16:14:16.293772Z",
            "deprecated": false,
            "highest_version": {
                "href": "/api/automation-hub/content/published/v3/collections/devvafklkur/devvyyzrzdrei/versions/3.3.2/",
                "version": "3.3.2"
            },
            "href": "/api/automation-hub/content/published/v3/collections/devvafklkur/devvyyzrzdrei/",
            "name": "devvyyzrzdrei",
            "namespace": "devvafklkur",
            "updated_at": "2021-09-06T16:14:17.353489Z",
            "versions_url": "/api/automation-hub/content/published/v3/collections/devvafklkur/devvyyzrzdrei/versions/"
        },
        {
            "created_at": "2021-09-06T16:14:17.086637Z",
            "deprecated": false,
            "highest_version": {
                "href": "/api/automation-hub/content/published/v3/collections/devvafklkur/devqzvguwyzaw/versions/2.8.7/",
                "version": "2.8.7"
            },
            "href": "/api/automation-hub/content/published/v3/collections/devvafklkur/devqzvguwyzaw/",
            "name": "devqzvguwyzaw",
            "namespace": "devvafklkur",
            "updated_at": "2021-09-06T16:14:17.353489Z",
            "versions_url": "/api/automation-hub/content/published/v3/collections/devvafklkur/devqzvguwyzaw/versions/"
        },
        {
            "created_at": "2021-09-06T16:14:15.592030Z",
            "deprecated": false,
            "highest_version": {
                "href": "/api/automation-hub/content/published/v3/collections/devvafklkur/devsbsaqrajjw/versions/0.9.6/",
                "version": "0.9.6"
            },
            "href": "/api/automation-hub/content/published/v3/collections/devvafklkur/devsbsaqrajjw/",
            "name": "devsbsaqrajjw",
            "namespace": "devvafklkur",
            "updated_at": "2021-09-06T16:14:17.353489Z",
            "versions_url": "/api/automation-hub/content/published/v3/collections/devvafklkur/devsbsaqrajjw/versions/"
        }
    ],
    "links": {
        "first": "/api/automation-hub/content/published/v3/collections/?limit=10&offset=0",
        "last": "/api/automation-hub/content/published/v3/collections/?limit=10&offset=0",
        "next": null,
        "previous": null
    },
    "meta": {
        "count": 3
    }
}
```


![screenshot](https://user-images.githubusercontent.com/458654/132246160-1297cf57-5652-46e0-b79e-b958cfb96046.png)


## 7. Added test case for upload collections

Using the collection generation added a simple test case to ensure collections are uploaded correctly.

```bash
make docker/test TEST=.api.test_api_v3_collections
```

## 8. easy way to list permissions

```bash
❯ make api/list-permissions CONTAINS=tag
...
['ansible:add_tag',
 'ansible:change_tag',
 'ansible:delete_tag',
 'ansible:view_tag',
 'container:add_tag',
 'container:change_tag',
 'container:delete_tag',
 'container:view_tag']

```

**NOTE** I am not sure the make targets works on a mac system.

No-Issue