### PR TITLE
Use paths, not files syntax for gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,6 +1,6 @@
 [allowlist]
   description = "Our test install exports a test only MINIO ACCESS KEY"
-  files = [
+  paths = [
     ".github/workflows/scripts/install.sh",
     "openshift/clowder/clowd-app.yaml",
     "dev/Dockerfile.base",


### PR DESCRIPTION
The `files` only variable only looks at individual file names, regardless of path.  We should be using the `path` variable here in the `.gitleaks.toml` conf.  