### PR TITLE
Collection Version Deletion

### DIFF
--- a/CHANGES/710.feature
+++ b/CHANGES/710.feature
@@ -1,0 +1,1 @@
+Allow collection versions to be deleted

--- a/galaxy_ng/app/access_control/statements/insights.py
+++ b/galaxy_ng/app/access_control/statements/insights.py
@@ -35,6 +35,15 @@ INSIGHTS_STATEMENTS = {
             "condition": "has_rh_entitlements",
         },
         {
+            "action": "destroy",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": [
+                "has_model_perms:ansible.delete_ansible_repo_content",
+                "has_rh_entitlements",
+            ],
+        },
+        {
             "action": "create",
             "principal": "authenticated",
             "effect": "allow",

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -32,8 +32,9 @@ STANDALONE_STATEMENTS = {
         },
         {
             "action": "destroy",
-            "principal": "*",
-            "effect": "deny",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:ansible.delete_ansible_repo_content",
         },
         {
             "action": "create",

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -25,84 +25,68 @@ sync_urls = [
     ),
     path(
         "sync/config/",
-        viewsets.SyncConfigViewSet.as_view({'get': 'retrieve', 'put': 'update'}),
-        name='sync-config'
-    )
+        viewsets.SyncConfigViewSet.as_view({"get": "retrieve", "put": "update"}),
+        name="sync-config",
+    ),
 ]
 
 urlpatterns = [
-
     path("", viewsets.RepoMetadataViewSet.as_view({"get": "retrieve"}), name="repo-metadata"),
     path(
-        'collections/all/',
-        viewsets.UnpaginatedCollectionViewSet.as_view({'get': 'list'}),
-        name='all-collections-list'
+        "collections/all/",
+        viewsets.UnpaginatedCollectionViewSet.as_view({"get": "list"}),
+        name="all-collections-list",
     ),
     path(
-        'collection_versions/all/',
+        "collection_versions/all/",
         viewsets.UnpaginatedCollectionVersionViewSet.as_view({"get": "list"}),
-        name="all-collection-versions-list"
-    ),
-
-    path(
-        'collections/',
-        viewsets.CollectionViewSet.as_view({'get': 'list'}),
-        name='collections-list'
+        name="all-collection-versions-list",
     ),
     path(
-        'collections/<str:namespace>/<str:name>/',
-        viewsets.CollectionViewSet.as_view({'get': 'retrieve', 'patch': 'update'}),
-        name='collections-detail'
+        "collections/", viewsets.CollectionViewSet.as_view({"get": "list"}), name="collections-list"
     ),
     path(
-        'collections/<str:namespace>/<str:name>/versions/',
-        viewsets.CollectionVersionViewSet.as_view({'get': 'list'}),
-        name='collection-versions-list',
+        "collections/<str:namespace>/<str:name>/",
+        viewsets.CollectionViewSet.as_view({"get": "retrieve", "patch": "update"}),
+        name="collections-detail",
     ),
     path(
-        'collections/<str:namespace>/<str:name>/versions/<str:version>/',
-        viewsets.CollectionVersionViewSet.as_view({'get': 'retrieve'}),
-        name='collection-versions-detail',
+        "collections/<str:namespace>/<str:name>/versions/",
+        viewsets.CollectionVersionViewSet.as_view({"get": "list"}),
+        name="collection-versions-list",
     ),
     path(
-        'collections/<str:namespace>/<str:name>/versions/<str:version>/docs-blob/',
-        viewsets.CollectionVersionDocsViewSet.as_view({'get': 'retrieve'}),
-        name='collection-versions-detail-docs',
+        "collections/<str:namespace>/<str:name>/versions/<str:version>/",
+        viewsets.CollectionVersionViewSet.as_view({"get": "retrieve", "delete": "destroy"}),
+        name="collection-versions-detail",
     ),
     path(
-        'imports/collections/<str:pk>/',
-        viewsets.CollectionImportViewSet.as_view({'get': 'retrieve'}),
-        name='collection-import',
+        "collections/<str:namespace>/<str:name>/versions/<str:version>/docs-blob/",
+        viewsets.CollectionVersionDocsViewSet.as_view({"get": "retrieve"}),
+        name="collection-versions-detail-docs",
     ),
     path(
-        'artifacts/collections/',
-        viewsets.CollectionUploadViewSet.as_view({'post': 'create'}),
-        name='collection-artifact-upload'
+        "imports/collections/<str:pk>/",
+        viewsets.CollectionImportViewSet.as_view({"get": "retrieve"}),
+        name="collection-import",
     ),
     path(
-        'artifacts/collections/<str:path>/<str:filename>',
+        "artifacts/collections/",
+        viewsets.CollectionUploadViewSet.as_view({"post": "create"}),
+        name="collection-artifact-upload",
+    ),
+    path(
+        "artifacts/collections/<str:path>/<str:filename>",
         viewsets.CollectionArtifactDownloadView.as_view(),
-        name='collection-artifact-download'
+        name="collection-artifact-download",
     ),
     path(
-        'collections/<str:namespace>/<str:name>/versions/<str:version>/move/'
-        '<str:source_path>/<str:dest_path>/',
-        viewsets.CollectionVersionMoveViewSet.as_view({'post': 'move_content'}),
-        name='collection-version-move',
+        "collections/<str:namespace>/<str:name>/versions/<str:version>/move/"
+        "<str:source_path>/<str:dest_path>/",
+        viewsets.CollectionVersionMoveViewSet.as_view({"post": "move_content"}),
+        name="collection-version-move",
     ),
-    path(
-        'tasks/',
-        viewsets.TaskViewSet.as_view({'get': 'list'}),
-        name='tasks-list'
-    ),
-    path(
-        'tasks/<str:pk>/',
-        viewsets.TaskViewSet.as_view({'get': 'retrieve'}),
-        name='tasks-detail'
-    ),
-    path(
-        'excludes/',
-        views.ExcludesView.as_view(),
-        name='excludes-file'
-    ),
+    path("tasks/", viewsets.TaskViewSet.as_view({"get": "list"}), name="tasks-list"),
+    path("tasks/<str:pk>/", viewsets.TaskViewSet.as_view({"get": "retrieve"}), name="tasks-detail"),
+    path("excludes/", views.ExcludesView.as_view(), name="excludes-file"),
 ]

--- a/galaxy_ng/app/api/v3/viewsets/namespace.py
+++ b/galaxy_ng/app/api/v3/viewsets/namespace.py
@@ -87,9 +87,9 @@ class NamespaceViewSet(api_base.ModelViewSet):
         if Collection.objects.filter(namespace=namespace.name).exists():
             raise ValidationError(
                 detail=_(
-                    'Namespace %s cannot be deleted because '
-                    'there are still collections associated with it.'
-                ) % namespace.name
+                    "Namespace {name} cannot be deleted because "
+                    "there are still collections associated with it."
+                ).format(name=namespace.name)
             )
 
         # 2. Delete the inbound pulp distro and repository


### PR DESCRIPTION
Allow DELETE requests on collection version endpoint.

1. Perform Dependency Check to verify that the collection version can be deleted
2. If it can, perform Collection Repository Cleanup tasks
3. If the collection version can’t be deleted, return the reason why
4. If the version being deleted is the last collection version in the collection,
   remove the collection object as well.

Issue: AAH-710