### PR TITLE
create access policy for container registries endpoint

### DIFF
--- a/CHANGES/896.feature
+++ b/CHANGES/896.feature
@@ -1,0 +1,1 @@
+Create access policy for registries endpoint.

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -171,3 +171,7 @@ class ContainerReadmeAccessPolicy(AccessPolicyBase):
 
 class ContainerNamespaceAccessPolicy(AccessPolicyBase):
     NAME = 'ContainerNamespaceViewset'
+
+
+class ContainerRegistryRemoteAccessPolicy(AccessPolicyBase):
+    NAME = 'ContainerRegistryRemoteViewSet'

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -252,5 +252,34 @@ STANDALONE_STATEMENTS = {
             "effect": "allow",
             "condition": "has_model_or_obj_perms:container.change_containernamespace"
         },
-    ]
+    ],
+
+    'ContainerRegistryRemoteViewSet': [
+        # prevents deletion of registry
+        {
+            "action": "destroy",
+            "principal": "*",
+            "effect": "deny",
+        },
+        # allows authenticated users to VIEW registries
+        {
+            "action": ["list", "retrieve"],
+            "principal": "authenticated",
+            "effect": "allow",
+        },
+        # allows users with model create permissions to create new registries
+        {
+            "action": "create",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.add_containerregistryremote"
+        },
+        # allows users with model create permissions to update registries
+        {
+            "action": "update",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.change_containerregistryremote"
+        },
+    ],
 }

--- a/galaxy_ng/app/api/ui/viewsets/execution_environment.py
+++ b/galaxy_ng/app/api/ui/viewsets/execution_environment.py
@@ -217,4 +217,4 @@ class ContainerRegistryRemoteViewSet(
 ):
     queryset = models.ContainerRegistryRemote.objects.all()
     serializer_class = serializers.ContainerRegistryRemoteSerializer
-    permission_classes = []
+    permission_classes = [access_policy.ContainerRegistryRemoteAccessPolicy]


### PR DESCRIPTION
Issue: AAH-896

See Jira Issue: https://issues.redhat.com/browse/AAH-896

The pr creates the access policy for the container registries endpoint. 
* Allows authenticated users to view registries
* Allows users with model create permissions to create new registries
* Allows users with model update permissions to update registries
* Prevents deletion