### PR TITLE
Add configuration for API access logging to dev environment

### DIFF
--- a/dev/Dockerfile.base
+++ b/dev/Dockerfile.base
@@ -94,6 +94,9 @@ RUN set -ex; \
     && mv /app/docker/entrypoint.sh /entrypoint.sh \
     && mv /app/ansible.cfg /etc/ansible/ansible.cfg \
     && mv /app/docker/bin/* /usr/local/bin \
+    && touch /var/log/galaxy_api_access.log \
+    && chmod 0644 /var/log/galaxy_api_access.log \
+    && chown galaxy:galaxy /var/log/galaxy_api_access.log \
     && mkdir -p /etc/pulp/certs/ \
     && echo "DNmNdwgyZugTax9S64J0FITTr9IHPxbuoF1F1CGPr68=" > /etc/pulp/certs/database_fields.symmetric.key
 

--- a/dev/standalone/Dockerfile
+++ b/dev/standalone/Dockerfile
@@ -11,6 +11,9 @@ RUN set -ex; \
 
 USER root
 
-RUN dnf install -y gettext
+RUN dnf install -y gettext; \
+    touch /var/log/galaxy_api_access.log \
+    && chmod 0644 /var/log/galaxy_api_access.log \
+    && chown galaxy:galaxy /var/log/galaxy_api_access.log
 
 USER galaxy

--- a/dev/standalone/Dockerfile
+++ b/dev/standalone/Dockerfile
@@ -11,9 +11,6 @@ RUN set -ex; \
 
 USER root
 
-RUN dnf install -y gettext; \
-    touch /var/log/galaxy_api_access.log \
-    && chmod 0644 /var/log/galaxy_api_access.log \
-    && chown galaxy:galaxy /var/log/galaxy_api_access.log
+RUN dnf install -y gettext;
 
 USER galaxy


### PR DESCRIPTION
Adds logging file with permissions and owner.  Now a dev only needs to update the `GALAXY_ENABLE_API_ACCESS_LOG` to enable logging in the container dev environment.

No-Issue