### PR TITLE
Pass .compose.env variables to the containers

### DIFF
--- a/dev/insights/docker-compose.yml
+++ b/dev/insights/docker-compose.yml
@@ -5,9 +5,12 @@ services:
   api:
     env_file:
       - './insights/galaxy_ng.env'
+      - '../.compose.env'
   worker:
     env_file:
       - './insights/galaxy_ng.env'
+      - '../.compose.env'
   content-app:
     env_file:
       - './insights/galaxy_ng.env'
+      - '../.compose.env'

--- a/dev/standalone-keycloak/docker-compose.yml
+++ b/dev/standalone-keycloak/docker-compose.yml
@@ -5,18 +5,21 @@ services:
   api:
     env_file:
       - './standalone-keycloak/galaxy_ng.env'
+      - '../.compose.env'
     environment:
       SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY: ${SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY}
       KEYCLOAK_HOST_LOOPBACK: ${KEYCLOAK_HOST_LOOPBACK}
   worker:
     env_file:
       - './standalone-keycloak/galaxy_ng.env'
+      - '../.compose.env'
     environment:
       SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY: ${SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY}
       KEYCLOAK_HOST_LOOPBACK: ${KEYCLOAK_HOST_LOOPBACK}
   content-app:
     env_file:
       - './standalone-keycloak/galaxy_ng.env'
+      - '../.compose.env'
     environment:
       SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY: ${SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY}
       KEYCLOAK_HOST_LOOPBACK: ${KEYCLOAK_HOST_LOOPBACK}
@@ -25,6 +28,7 @@ services:
     image: quay.io/keycloak/keycloak:latest
     env_file:
       - './standalone-keycloak/keycloak.env'
+      - '../.compose.env'
     ports:
       - 8080:8080
     depends_on:
@@ -37,6 +41,7 @@ services:
       - kc_pg_data:/var/lib/postgresql/data
     env_file:
       - './standalone-keycloak/kc-postgres.env'
+      - '../.compose.env'
     
   ldap:
     image: "rroemhild/test-openldap"

--- a/dev/standalone/docker-compose.yml
+++ b/dev/standalone/docker-compose.yml
@@ -5,9 +5,12 @@ services:
   api:
     env_file:
       - './standalone/galaxy_ng.env'
+      - '../.compose.env'
   worker:
     env_file:
       - './standalone/galaxy_ng.env'
+      - '../.compose.env'
   content-app:
     env_file:
       - './standalone/galaxy_ng.env'
+      - '../.compose.env'


### PR DESCRIPTION
docker compose allows `env_file` to be a list of .env files
those files are loaded in order.

It makes easier to have custom local settings.

Ex:

`.compose.env`
```bash
PULP_GALAXY_ENABLE_API_ACCESS_LOG=true
```

will enable logs to be written to `/var/log/galaxy_api_access.log`

No-Issue