### PR TITLE
Add '_ui/v1/settings' endpoint

### DIFF
--- a/CHANGES/917.misc
+++ b/CHANGES/917.misc
@@ -1,0 +1,1 @@
+Add '_ui/v1/settings' endpoint

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -124,6 +124,7 @@ paths = [
     path('', include(router.urls)),
 
     path('auth/', include(auth_views)),
+    path("settings/", views.SettingsView.as_view(), name="settings"),
     path('feature-flags/', views.FeatureFlagsView.as_view(), name='feature-flags'),
     path('controllers/', views.ControllerListView.as_view(), name='controllers'),
     path('groups/', include(group_paths)),

--- a/galaxy_ng/app/api/ui/views/__init__.py
+++ b/galaxy_ng/app/api/ui/views/__init__.py
@@ -6,6 +6,8 @@ from .feature_flags import FeatureFlagsView
 
 from .controller import ControllerListView
 
+from .settings import SettingsView
+
 __all__ = (
     # auth
     "LoginView",
@@ -16,4 +18,7 @@ __all__ = (
 
     # controller
     "ControllerListView",
+
+    # settings
+    "SettingsView",
 )

--- a/galaxy_ng/app/api/ui/views/settings.py
+++ b/galaxy_ng/app/api/ui/views/settings.py
@@ -10,10 +10,10 @@ class SettingsView(api_base.APIView):
 
     def get(self, request, *args, **kwargs):
         data = {}
-        data['GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS'] = settings.get(
-            'GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS'
-        ) or False
-        data['GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD'] = settings.get(
-            'GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD'
-        ) or False
+        keyset = [
+            "GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS",
+            "GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD",
+            "GALAXY_FEATURE_FLAGS",
+        ]
+        data = {key: settings.as_dict().get(key, None) for key in keyset}
         return Response(data)

--- a/galaxy_ng/app/api/ui/views/settings.py
+++ b/galaxy_ng/app/api/ui/views/settings.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.response import Response
+
+from galaxy_ng.app.api import base as api_base
+
+
+class SettingsView(api_base.APIView):
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def get(self, request, *args, **kwargs):
+        data = {}
+        data['GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS'] = settings.get(
+            'GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS'
+        ) or False
+        data['GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD'] = settings.get(
+            'GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD'
+        ) or False
+        return Response(data)

--- a/galaxy_ng/tests/unit/api/test_api_ui_settings.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_settings.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+
+from .base import BaseTestCase, get_current_ui_url
+
+
+class TestUiFeatureFlagsView(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.original_setting = settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS
+        settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS = True
+
+    def tearDown(self):
+        super().tearDown()
+        settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS = self.original_setting
+
+    def test_settings_url(self):
+        self.settings_url = get_current_ui_url('settings')
+        response = self.client.get(self.settings_url)
+        self.assertEqual(response.data['GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS'], True)
+        self.assertEqual(response.data['GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD'], False)


### PR DESCRIPTION
Add '_ui/v1/settings' endpoint to expose `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS` and `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD` to the UI

Depends on #909 for the settings above to be defined.

Issue: AAH-917