### PR TITLE
Fixes to the script that generates fakes collections for testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,10 @@ api/create-test-collections:   ## Creates a set of test collections
 	@read -p "How many namespaces to create? : " NS; \
 	read -p "Number of collections on each namespace? : " COLS; \
 	read -p "Add a prefix? : " PREFIX; \
-	ARGS="--prefix=$${PREFIX:-dev} --strategy=faux --ns=$${NS:-6} --cols=$${COLS:-6}"; \
+	ARGS="--prefix=$${PREFIX:-dev} --strategy=$${STRATEGY:-faux} --ns=$${NS:-6} --cols=$${COLS:-6}"; \
 	echo "Creating test collections with args: $${ARGS}"; \
 	export ARGS; \
-	$(call exec_or_run, api, $(DJ_MANAGER), create-test-collections, $${ARGS})
+	./compose exec api django-admin create-test-collections $${ARGS}
 
 .PHONY: api/list-permissions
 api/list-permissions:   ## List all permissions - CONTAINS=str

--- a/galaxy_ng/app/management/commands/create-test-collections.py
+++ b/galaxy_ng/app/management/commands/create-test-collections.py
@@ -3,15 +3,23 @@ from argparse import ArgumentError
 from collections import defaultdict
 from functools import lru_cache
 
-from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
 from django.urls.base import reverse
 from rest_framework.test import APIClient
 
+from galaxy_ng.app.constants import INBOUND_REPO_NAME_FORMAT
 from galaxy_ng.app.models.auth import Group, User
 from galaxy_ng.app.models.namespace import Namespace, create_inbound_repo
 from galaxy_ng.tests.constants import TAGS, TEST_COLLECTION_CONFIGS
 
 STRATEGIES = ["test", "faux"]
+
+
+def valid_prefix(prefix):
+    if prefix and prefix[0].isdigit():
+        raise CommandError("Prefix cannot start with a number")
+    return prefix
 
 
 class Command(BaseCommand):
@@ -51,7 +59,7 @@ class Command(BaseCommand):
             "--prefix",
             help="prefix for namespaces and collections",
             required=False,
-            type=str,
+            type=valid_prefix,
             default="",
         )
         parser.add_argument(
@@ -85,7 +93,13 @@ class Command(BaseCommand):
         return self._faux
 
     def handle(self, *args, **options):
-        total = options["cols"] * options["ns"]
+        """Handle command"""
+
+        if options.get("strategy") == "test":
+            total = len(TEST_COLLECTION_CONFIGS)
+        else:
+            total = options["cols"] * options["ns"]
+
         if not options["yes"]:
             confirm = input(
                 f"You are about to populate the system with {total} test collections.\n"
@@ -105,10 +119,9 @@ class Command(BaseCommand):
         self.client = APIClient()
         self.admin_user = User.objects.get(username="admin")
         self.client.force_authenticate(user=self.admin_user)
-        self.prefix = (options["prefix"] or options["strategy"]).lower()
-
-        strategy = options.get("strategy")
-        getattr(self, f"strategy_{strategy}", self.raise_for_strategy)(*args, **options)
+        self.prefix = options["prefix"].lower()
+        self.strategy = options.get("strategy")
+        getattr(self, f"strategy_{self.strategy}", self.raise_for_strategy)(*args, **options)
 
     def upload_collection(self, filename):
         collection_upload_url = reverse(
@@ -137,11 +150,14 @@ class Command(BaseCommand):
                     ]
                 }
             np.save()
+        self.echo(f"Created namespace {namespace_name}")
+        self.echo(reverse("galaxy:api:v3:namespaces-detail", kwargs={"name": namespace_name}))
+
         return np
 
     def apply_prefix(self, config):
         """Apply a prefix to a config"""
-        if self.prefix:
+        if self.prefix and self.prefix != "":
             for key in ["namespace", "name"]:
                 if not config[key].startswith(self.prefix):
                     config[key] = f"{self.prefix}{config[key]}".lower()
@@ -149,7 +165,6 @@ class Command(BaseCommand):
 
     def build_collection(self, template, config):
         """Build a collection from a template and a config"""
-        config = self.apply_prefix(config)
         return self.generator.build_collection(template, config=config)
 
     def gen_version(self):
@@ -158,25 +173,61 @@ class Command(BaseCommand):
         z = random.randint(0, 9)
         return f"{x}.{y}.{z}"
 
+    def apply_dep_prefix(self, dep, np):
+        _, col = dep.split(".")
+        collection_name = f"{self.prefix}{col}"
+        return f"{np.name}.{collection_name}"
+
     def strategy_test(self, *args, **options):
         """Use constants.TEST_COLLECTION_CONFIGS to generate collections"""
         for config in TEST_COLLECTION_CONFIGS:
-            namespace_name = options.get("namespace") or config["namespace"]
+            namespace_name = config["namespace"]
             create_inbound_repo(namespace_name)
             np = self.create_namespace(namespace_name)
             config["namespace"] = np.name
 
+            if settings.GALAXY_REQUIRE_CONTENT_APPROVAL:
+                distro = INBOUND_REPO_NAME_FORMAT.format(namespace_name=np.name)
+            else:
+                distro = "published"
+
+            _new_deps = {}
+            if config.get("dependencies"):
+                _new_deps = {
+                    self.apply_dep_prefix(key, np): value
+                    for key, value in config["dependencies"].items()
+                }
+
+            if _new_deps:
+                config["dependencies"] = _new_deps
+
+            config = self.apply_prefix(config)
             collection = self.build_collection("skeleton", config=config)
             response = self.upload_collection(collection.filename)
 
             self.echo(response.status_code)
             self.echo(response.data)
-            self.echo("Collection '{}' created".format(collection.name))
+            self.echo(f"Collection '{collection.name}' created")
+            if config.get("dependencies"):
+                self.echo(f"Dependencies: {collection.name} depends on {config['dependencies']}")
+            else:
+                self.echo("No dependencies")
+            self.echo(
+                reverse(
+                    "galaxy:api:content:v3:collection-versions-detail",
+                    kwargs={
+                        "path": distro,
+                        "namespace": np.name,
+                        "name": collection.name,
+                        "version": collection.version,
+                    },
+                )
+            )
 
     def strategy_faux(self, *args, **options):
         """Use fauxfactory to generate"""
         _configs = defaultdict(list)
-        _dependency_pool = {}
+        _dependency_pool = []
         for _ in range(options["ns"]):
             namespace_name = self.faux.gen_string(
                 "alpha",
@@ -188,6 +239,12 @@ class Command(BaseCommand):
             create_inbound_repo(namespace_name)
             np = self.create_namespace(namespace_name)
             _collections = []
+
+            if settings.GALAXY_REQUIRE_CONTENT_APPROVAL:
+                distro = INBOUND_REPO_NAME_FORMAT.format(namespace_name=namespace_name)
+            else:
+                distro = "published"
+
             for i in range(options["cols"]):
                 config = {
                     "name": self.faux.gen_string(
@@ -203,20 +260,65 @@ class Command(BaseCommand):
                     "tags": random.sample(TAGS, 3),
                 }
 
-                if i > 3:
-                    config["dependencies"] = _dependency_pool
+                if i > 2:
+                    deps = random.sample(_dependency_pool, random.randint(1, 3))
+                    config["dependencies"] = dict(deps)
 
                 _collections.append(config["name"])
                 _configs[namespace_name].append(config)
 
+                config = self.apply_prefix(config)
                 collection = self.build_collection("skeleton", config=config)
                 response = self.upload_collection(collection.filename)
                 self.echo(response.status_code)
                 self.echo(response.data)
-                self.echo("Collection '{}' created".format(collection.name))
+                self.echo(f"Collection '{collection.name}' created")
+                if config.get("dependencies"):
+                    self.echo(
+                        f"Dependencies: {collection.name} depends on {config['dependencies']}"
+                    )
+                else:
+                    self.echo("No dependencies")
+                self.echo(
+                    reverse(
+                        "galaxy:api:content:v3:collection-versions-detail",
+                        kwargs={
+                            "path": distro,
+                            "namespace": np.name,
+                            "name": config["name"],
+                            "version": config["version"],
+                        },
+                    )
+                )
 
-                if i <= 3:
+                if i <= 2:
+                    _config = config.copy()
+                    x, y, z = config["version"].split(".")
+                    _config["version"] = f"{x}.{y}.{int(z) + 1}"
+                    _config = self.apply_prefix(_config)
+                    _collection = self.build_collection("skeleton", config=_config)
+                    _response = self.upload_collection(_collection.filename)
+                    self.echo(_response.status_code)
+                    self.echo(_response.data)
+                    self.echo(f"A new version for '{_collection.name}' created")
+                    self.echo(
+                        reverse(
+                            "galaxy:api:content:v3:collection-versions-detail",
+                            kwargs={
+                                "path": distro,
+                                "namespace": np.name,
+                                "name": _config["name"],
+                                "version": _config["version"],
+                            },
+                        )
+                    )
+
+                    # add as a dependency to the next collection
                     spec = random.choice(["==", ">=", "<="])
-                    _dependency_pool[
-                        f"{config['namespace']}.{config['name']}"
-                    ] = f"{spec}{config['version']}"
+                    _dependency_pool.append(
+                        (f"{config['namespace']}.{config['name']}", f"{spec}{config['version']}")
+                    )
+                    _spec = random.choice(["==", ">=", "<="])
+                    _dependency_pool.append(
+                        (f"{config['namespace']}.{config['name']}", f"{_spec}{_config['version']}")
+                    )


### PR DESCRIPTION
As part of my other PR #939 I needed to generated fake data for testing, I added here some improvements as I needed.

- [ ] I need help testing on a mac
- [ ] More testing with different options


#### Now it creates more than one version for some random collections

```bash
$ django-admin create-test-collections --strategy=faux --ns=1 --cols=4

You are about to populate the system with 4 test collections.
This operation cannot be undone
Proceed? (Y/n)y

Created namespace ycafiztl
/api/automation-hub/v3/namespaces/ycafiztl/

{'task': '/api/automation-hub/content/inbound-ycafiztl/v3/imports/collections/c5ec2222-9f38-431e-80c1-75dde8d75efb/'}
Collection 'kczhvlinrd' created
/api/automation-hub/content/published/v3/collections/ycafiztl/kczhvlinrd/versions/3.6.2/

A new version for 'kczhvlinrd' created
/api/automation-hub/content/published/v3/collections/ycafiztl/kczhvlinrd/versions/3.6.3/

Collection 'rmgrjelkbw' created
/api/automation-hub/content/published/v3/collections/ycafiztl/rmgrjelkbw/versions/1.3.0/

A new version for 'rmgrjelkbw' created
/api/automation-hub/content/published/v3/collections/ycafiztl/rmgrjelkbw/versions/1.3.1/

Collection 'evmdkwfbyg' created
/api/automation-hub/content/published/v3/collections/ycafiztl/evmdkwfbyg/versions/3.7.9/

A new version for 'evmdkwfbyg' created
/api/automation-hub/content/published/v3/collections/ycafiztl/evmdkwfbyg/versions/3.7.10/

Collection 'kypjjnjpre' created
/api/automation-hub/content/published/v3/collections/ycafiztl/kypjjnjpre/versions/1.8.2/

A new version for 'kypjjnjpre' created
/api/automation-hub/content/published/v3/collections/ycafiztl/kypjjnjpre/versions/1.8.3/

Collection 'lornbmuzob' created
/api/automation-hub/content/published/v3/collections/dgehetuq/lornbmuzob/versions/0.9.7/
```


####  The last one will always have a dependency

```bash
❯ make api/get URL=/content/published/v3/collections/dgehetuq/lornbmuzob/versions/0.9.7/ 

{
    "artifact": {
        ...
    },
    "collection": {
        "href": "/api/automation-hub/content/published/v3/collections/dgehetuq/lornbmuzob/",
        "id": "9afb8ca8-f481-4552-92da-01722dd45b38",
        "name": "lornbmuzob"
    },
    ...,
        "dependencies": {
            "dgehetuq.egpzxetzej": ">=3.5.5",
            "dgehetuq.uihagxuiga": ">=1.6.5"
        },
        
}
```

#### Allow a controlled environment for easy testing

> For example, when we are developing issue AAH789, we can prefix and create collections that we know the structure (NOT RANDOM)

```bash
$ django-admin create-test-collections --strategy=test --prefix=aah789 -y
#or
# ./compose exec api django-admin create-test-collections --strategy=test --prefix=aah789 -y

Created namespace aah789test
/api/automation-hub/v3/namespaces/aah789test/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/9ba97288-b73b-4783-9977-fc47688caa54/'}

Collection 'aah789a' created
Dependencies: aah789a depends on {'aah789test.b': '*'}
/api/automation-hub/content/published/v3/collections/aah789test/aah789a/versions/1.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/4ef154bd-b797-4b06-bbd3-300a276ea474/'}

Collection 'aah789b' created
Dependencies: aah789b depends on {'aah789test.c': '*'}
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/5091aa30-1c06-47a6-8ad0-678e4d5c8b82/'}

Collection 'aah789c' created
Dependencies: aah789c depends on {'aah789test.d': '*'}
/api/automation-hub/content/published/v3/collections/aah789test/aah789c/versions/1.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/f8595e2b-8ee8-4098-9513-04b3b1539b74/'}

Collection 'aah789d' created
No dependencies
/api/automation-hub/content/published/v3/collections/aah789test/aah789d/versions/1.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/af0ff456-bf9b-4e08-9515-5984d7816b90/'}

Collection 'aah789e' created
Dependencies: aah789e depends on {'aah789test.f': '*', 'aah789test.g': '*'}
/api/automation-hub/content/published/v3/collections/aah789test/aah789e/versions/1.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/25670bcd-1cbe-470a-a38e-73b02faca8a6/'}

Collection 'aah789f' created
Dependencies: aah789f depends on {'aah789test.h': '<=3.0.0'}
/api/automation-hub/content/published/v3/collections/aah789test/aah789f/versions/1.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/20d35dea-1a93-47a1-b8ea-219b5cfc3126/'}

Collection 'aah789g' created
Dependencies: aah789g depends on {'aah789test.d': '*'}
/api/automation-hub/content/published/v3/collections/aah789test/aah789g/versions/1.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/04bf4961-6136-47c0-8aa7-ad385912211d/'}

Collection 'aah789h' created
No dependencies
/api/automation-hub/content/published/v3/collections/aah789test/aah789h/versions/1.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/94258886-246c-452d-ae70-5981c67b459f/'}

Collection 'aah789h' created
No dependencies
/api/automation-hub/content/published/v3/collections/aah789test/aah789h/versions/2.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/3eb14096-7f57-45e8-8fbc-335722165d48/'}

Collection 'aah789h' created
No dependencies
/api/automation-hub/content/published/v3/collections/aah789test/aah789h/versions/3.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/fd45b02c-f414-4cfc-a765-a7c8cf0c9873/'}

Collection 'aah789h' created
No dependencies
/api/automation-hub/content/published/v3/collections/aah789test/aah789h/versions/4.0.0/
{'task': '/api/automation-hub/content/inbound-aah789test/v3/imports/collections/98c51cb3-6b9d-4367-af31-dbbd8d09a1d4/'}

Collection 'aah789h' created
No dependencies
/api/automation-hub/content/published/v3/collections/aah789test/aah789h/versions/5.0.0/
```

The above dependency tree is useful for testing

```bash
Dependency Trees:

        A               E
        |             /   \
        B            F     G
        |            |     |
        C         H(1-3)   D
        |
        D

        H has 5 versions, no dependencies


```