### PR TITLE
add additional filters to container registries endpoint

### DIFF
--- a/CHANGES/938.feature
+++ b/CHANGES/938.feature
@@ -1,0 +1,1 @@
+Add created_at and updated_at filters to container registries endpoint.

--- a/galaxy_ng/app/api/ui/viewsets/execution_environment.py
+++ b/galaxy_ng/app/api/ui/viewsets/execution_environment.py
@@ -320,11 +320,15 @@ class ContainerReadmeViewSet(ContainerContentBaseViewset):
 class ContainerRegistryRemoteFilter(filterset.FilterSet):
     name = filters.CharFilter(field_name='name')
     url = filters.CharFilter(field_name='url')
+    created_at = filters.CharFilter(field_name='pulp_created')
+    updated_at = filters.CharFilter(field_name='pulp_last_updated')
 
     sort = filters.OrderingFilter(
         fields=(
             ('name', 'name'),
             ('url', 'url'),
+            ('pulp_created', 'created_at'),
+            ('pulp_last_updated', 'updated_at'),
         ),
     )
 


### PR DESCRIPTION
This pr adds additional fields to the sorting feature, namely `created_at` and `updated_at`.

See issue: https://issues.redhat.com/browse/AAH-925