### PR TITLE
Add Container Repo and Container Image Deletion

### DIFF
--- a/CHANGES/712.feature
+++ b/CHANGES/712.feature
@@ -1,0 +1,1 @@
+Allow container repository to be deleted

--- a/CHANGES/713.feature
+++ b/CHANGES/713.feature
@@ -1,0 +1,1 @@
+Allow container manifest to be deleted

--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,8 @@ api/create-test-collections:   ## Creates a set of test collections
 	export ARGS; \
 	./compose exec api django-admin create-test-collections $${ARGS}
 
-.PHONY: api/push-test-containers
-api/push-test-containers:   ## Pushes a set of test containers
+.PHONY: api/push-test-images
+api/push-test-images:   ## Pushes a set of test container images
 	docker login -u admin -p admin localhost:5001 || echo "!!! docker login failed, check if docker is running"
 	for foo in postgres treafik mongo mariadb redis node mysql busybox alpine docker python hhtpd nginx memcached golang; do  docker pull $$foo; docker image tag $$foo localhost:5001/$$foo:latest; docker push localhost:5001/$$foo:latest; done
 

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,11 @@ api/create-test-collections:   ## Creates a set of test collections
 	export ARGS; \
 	./compose exec api django-admin create-test-collections $${ARGS}
 
+.PHONY: api/push-test-containers
+api/push-test-containers:   ## Pushes a set of test containers
+	docker login -u admin -p admin localhost:5001 || echo "!!! docker login failed, check if docker is running"
+	for foo in postgres treafik mongo mariadb redis node mysql busybox alpine docker python hhtpd nginx memcached golang; do  docker pull $$foo; docker image tag $$foo localhost:5001/$$foo:latest; docker push localhost:5001/$$foo:latest; done
+
 .PHONY: api/list-permissions
 api/list-permissions:   ## List all permissions - CONTAINS=str
 	$(call exec_or_run, api, $(DJ_MANAGER), shell -c 'from django.contrib.auth.models import Permission;from pprint import pprint;pprint([f"{perm.content_type.app_label}:{perm.codename}" for perm in Permission.objects.filter(name__icontains="$(CONTAINS)")])')

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -249,7 +249,13 @@ STANDALONE_STATEMENTS = {
             "action": ["list", "retrieve"],
             "principal": "authenticated",
             "effect": "allow",
-        }
+        },
+        {
+            "action": "destroy",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:pulp_container.delete_containerrepository",
+        },
     ],
 
     # The container readme can't just use the ContainerRepository access policies

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -1,12 +1,10 @@
 from django.conf import settings
-from django.urls import path, include, re_path
+from django.urls import include, path, re_path
 from rest_framework import routers
 
 from galaxy_ng.app import constants
 
-from . import views
-from . import viewsets
-
+from . import views, viewsets
 
 router = routers.SimpleRouter()
 # TODO: Replace with a RedirectView
@@ -39,7 +37,9 @@ container_repo_paths = [
         name='container-repository-images'),
     path(
         'images/<str:manifest_ref>/',
-        viewsets.ContainerRepositoryManifestViewSet.as_view({'get': 'retrieve'}),
+        viewsets.ContainerRepositoryManifestViewSet.as_view(
+            {"get": "retrieve", "delete": "destroy"}
+        ),
         name='container-repository-images-config-blob'),
     path(
         'history/',
@@ -94,9 +94,10 @@ container_paths = [
 
     # This regex can capture "namespace/name" and "name"
     re_path(
-        r'repositories/(?P<base_path>[-\w]+\/{0,1}[-\w]+)/',
-        viewsets.ContainerRepositoryViewSet.as_view({'get': 'retrieve'}),
-        name='container-repository-detail'),
+        r"repositories/(?P<base_path>[-\w]+\/{0,1}[-\w]+)/",
+        viewsets.ContainerRepositoryViewSet.as_view({"get": "retrieve", "delete": "destroy"}),
+        name="container-repository-detail",
+    ),
 ]
 
 # Groups are subclassed from pulpcore and use nested viewsets, so router.register

--- a/galaxy_ng/app/viewsets.py
+++ b/galaxy_ng/app/viewsets.py
@@ -1,9 +1,8 @@
+from pulpcore.plugin import viewsets as pulp_viewsets
 from rest_framework import mixins
 
-from pulpcore.plugin import viewsets as pulp_viewsets
-
-from galaxy_ng.app.api.ui import serializers
 from galaxy_ng.app import models
+from galaxy_ng.app.api.ui import serializers
 
 # This file is necesary to prevent the DRF web API browser from breaking on all of the
 # pulp/api/v3/repositories/ endpoints.
@@ -20,10 +19,17 @@ from galaxy_ng.app import models
 # on the remote field and can't find a viewset name for galaxy's ContainerRegistryRemote model.
 
 
-class ContainerRegistryRemoteViewSet(
-    pulp_viewsets.NamedModelViewSet,
-    mixins.RetrieveModelMixin
-):
+class ContainerRegistryRemoteViewSet(pulp_viewsets.NamedModelViewSet, mixins.RetrieveModelMixin):
     queryset = models.ContainerRegistryRemote.objects.all()
     serializer_class = serializers.ContainerRegistryRemoteSerializer
     endpoint_name = "container-registry"
+
+
+class ContainerDistributionViewSet(
+    pulp_viewsets.NamedModelViewSet,
+    mixins.RetrieveModelMixin,
+    mixins.DestroyModelMixin,
+):
+    queryset = models.ContainerDistribution.objects.all()
+    serializer_class = serializers.ContainerRepositorySerializer
+    endpoint_name = "container-distribution"


### PR DESCRIPTION
Issue: AAH-712
Issue: AAH-713

Added support for `DELETE` request on routes:

```bash
/api/automation-hub/_ui/v1/execution-environments/repositories/<base_path>/
/api/automation-hub/_ui/v1/execution-environments/repositories/<base_path>/_content/images/<str:manifest_ref>/
```

**plus**

Added a `make api/push-test-images` to feed system with some images for manual testing,

It is not possible **yet** to automate container testing as it is pending on #937

So this PR relies on manual testing only. 
