### PR TITLE
Enable basic (username/password) authentication for galaxy apis.

### DIFF
--- a/CHANGES/901.feature
+++ b/CHANGES/901.feature
@@ -1,0 +1,1 @@
+Enable basic (username/password) authentication for galaxy apis.

--- a/dev/standalone-keycloak/galaxy_ng.env
+++ b/dev/standalone-keycloak/galaxy_ng.env
@@ -1,7 +1,7 @@
 PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
 
 PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
-PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'galaxy_ng.app.auth.token.ExpiringTokenAuthentication']
+PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'galaxy_ng.app.auth.token.ExpiringTokenAuthentication', 'galaxy_ng.app.auth.keycloak.KeycloakBasicAuth']
 PULP_GALAXY_DEPLOYMENT_MODE=standalone
 PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false
 PULP_RH_ENTITLEMENT_REQUIRED=insights

--- a/dev/standalone/galaxy_ng.env
+++ b/dev/standalone/galaxy_ng.env
@@ -1,7 +1,7 @@
 PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
 
 PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
-PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication']
+PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication', 'rest_framework.authentication.BasicAuthentication']
 PULP_GALAXY_DEPLOYMENT_MODE=standalone
 PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false
 PULP_RH_ENTITLEMENT_REQUIRED=insights

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -124,6 +124,7 @@ def configure_keycloak(settings: Dynaconf) -> Dict[str, Any]:
         data["GALAXY_AUTHENTICATION_CLASSES"] = [
             "rest_framework.authentication.SessionAuthentication",
             "galaxy_ng.app.auth.token.ExpiringTokenAuthentication",
+            "galaxy_ng.app.auth.keycloak.KeycloakBasicAuth"
         ]
 
         # Set default to one day expiration

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -57,6 +57,7 @@ GALAXY_PAGINATION_CLASS = "galaxy_ng.app.api.pagination.LimitOffsetPagination"
 GALAXY_AUTHENTICATION_CLASSES = [
     "rest_framework.authentication.SessionAuthentication",
     "rest_framework.authentication.TokenAuthentication",
+    "rest_framework.authentication.BasicAuthentication",
 ]
 # Settings for insights mode
 # GALAXY_AUTHENTICATION_CLASSES = ["galaxy_ng.app.auth.auth.RHIdentityAuthentication"]


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAH-901

Controller needs basic authentication on the galaxy APIs so they can use registry credentials to query our api.