### PR TITLE
Fix download url for V3 unpaginated collection versions endpoint

### DIFF
--- a/galaxy_ng/app/api/v3/serializers/collection.py
+++ b/galaxy_ng/app/api/v3/serializers/collection.py
@@ -22,6 +22,15 @@ log = logging.getLogger(__name__)
 
 
 class HrefNamespaceMixin:
+
+    def _get_download_url(self, obj):
+        """Get artifact download URL."""
+
+        host = settings.ANSIBLE_API_HOSTNAME.strip("/")
+        prefix = settings.GALAXY_API_PATH_PREFIX.strip("/")
+        distro_base_path = self.context["path"]
+        return f"{host}/{prefix}/v3/artifacts/collections/{distro_base_path}/{obj.relative_path}"
+
     def _get_href(self, url_name, **kwargs):
         """Generic get_*_href that uses context["view_namespace"] to reverse the right url"""
 
@@ -90,6 +99,9 @@ class UnpaginatedCollectionVersionSerializer(_UnpaginatedCollectionVersionSerial
     class Meta(_UnpaginatedCollectionVersionSerializer.Meta):
         ref_name = "UnpaginatedCollectionVersionWithFixedHrefsSerializer"
 
+    def get_download_url(self, obj) -> str:
+        return self._get_download_url(obj)
+
     def get_href(self, obj):
         return self._get_href("collections-detail", namespace=obj.namespace, name=obj.name)
 
@@ -102,14 +114,7 @@ class CollectionVersionSerializer(_CollectionVersionSerializer, HrefNamespaceMix
         ref_name = "CollectionVersionWithDownloadUrlSerializer"
 
     def get_download_url(self, obj):
-        """
-        Get artifact download URL.
-        """
-
-        host = settings.ANSIBLE_API_HOSTNAME.strip("/")
-        prefix = settings.GALAXY_API_PATH_PREFIX.strip("/")
-        distro_base_path = self.context["path"]
-        return f"{host}/{prefix}/v3/artifacts/collections/{distro_base_path}/{obj.relative_path}"
+        return self._get_download_url(obj)
 
     def get_href(self, obj):
         return self._get_href(


### PR DESCRIPTION
No-Issue

I filed an issue in redmine, before figuring out this is a galaxy_ng problem: https://pulp.plan.io/issues/9405. Do you need me to create and link this to a jira issue? 

Also, are there tests for the V3 unpaginated endpoints? I ran into this issue while trying to implement synclist on the AH staging environment.