### PR TITLE
Download collection artifacts from the pulp content app

### DIFF
--- a/CHANGES/924.bugfix
+++ b/CHANGES/924.bugfix
@@ -1,0 +1,1 @@
+Download collection artifacts from the pulp content app instead of the galaxy apis

--- a/galaxy_ng/app/api/v3/serializers/collection.py
+++ b/galaxy_ng/app/api/v3/serializers/collection.py
@@ -106,10 +106,10 @@ class CollectionVersionSerializer(_CollectionVersionSerializer, HrefNamespaceMix
         Get artifact download URL.
         """
 
-        host = settings.ANSIBLE_API_HOSTNAME.strip("/")
-        prefix = settings.GALAXY_API_PATH_PREFIX.strip("/")
+        host = settings.CONTENT_ORIGIN.strip("/")
+        prefix = settings.CONTENT_PATH_PREFIX.strip("/")
         distro_base_path = self.context["path"]
-        return f"{host}/{prefix}/v3/artifacts/collections/{distro_base_path}/{obj.relative_path}"
+        return f"{host}/{prefix}/{distro_base_path}/{obj.relative_path}"
 
     def get_href(self, obj):
         return self._get_href(

--- a/galaxy_ng/app/webserver_snippets/apache.conf
+++ b/galaxy_ng/app/webserver_snippets/apache.conf
@@ -30,8 +30,3 @@ ProxyPassReverse "/ui/" "${pulp-api}/static/galaxy_ng/index.html"
 <Location ~ "^/pulp_ansible/galaxy/">
     Deny from all;
 </Location>
-
-# Disable the pulp content app
-<Location ~ "^/pulp/content/">
-    Deny from all;
-</Location>

--- a/galaxy_ng/app/webserver_snippets/nginx.conf
+++ b/galaxy_ng/app/webserver_snippets/nginx.conf
@@ -34,8 +34,3 @@ location /pulp/api/v3/distributions/ansible/ {
 location ~ ^/pulp_ansible/galaxy/ {
     return 403;
 }
-
-# Disable the pulp content app
-location ~ ^/pulp/content/ {
-    return 403;
-}


### PR DESCRIPTION
This reverts #781.  This relies on the content guards from #976.
Issue: AAH-924