### PR TITLE
Fix ManifestSerializer when image is deleted.

### DIFF
--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -142,8 +142,11 @@ class ContainerManifestSerializer(serializers.ModelSerializer):
         # use the prefetched blob_list and artifact_list instead of obj.blobs and
         # blob._artifacts to cut down on queries made.
         for blob in obj.blob_list:
-            layers.append({"digest": blob.digest, "size": blob.artifact_list[0].size})
-
+            # Manifest can be empty after deleting an image.
+            if blob.artifact_list:
+                layers.append(
+                    {"digest": blob.digest, "size": blob.artifact_list[0].size}
+                )
         return layers
 
     def get_config_blob(self, obj):


### PR DESCRIPTION
No-Issue

Motivation:

> @himdel  after deleting a container image (just one image) I'm getting an error for all subsequent calls of the /_content/images endpoint..

```bash
api_1          | pulp [None]: django.request:ERROR: Internal Server Error: /api/automation-hub/_ui/v1/execution-environments/repositories/mysql/_content/images/
api_1          | Traceback (most recent call last):
api_1          |   File "/venv/lib64/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
api_1          |     response = get_response(request)
api_1          |   File "/venv/lib64/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
api_1          |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
api_1          |   File "/venv/lib64/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
api_1          |     return view_func(*args, **kwargs)
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/viewsets.py", line 125, in view
api_1          |     return self.dispatch(request, *args, **kwargs)
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
api_1          |     response = self.handle_exception(exc)
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
api_1          |     self.raise_uncaught_exception(exc)
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
api_1          |     raise exc
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
api_1          |     response = handler(request, *args, **kwargs)
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/mixins.py", line 43, in list
api_1          |     return self.get_paginated_response(serializer.data)
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/serializers.py", line 745, in data
api_1          |     ret = super().data
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/serializers.py", line 246, in data
api_1          |     self._data = self.to_representation(self.instance)
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/serializers.py", line 663, in to_representation
api_1          |     return [
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/serializers.py", line 664, in <listcomp>
api_1          |     self.child.to_representation(item) for item in iterable
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/serializers.py", line 515, in to_representation
api_1          |     ret[field.field_name] = field.to_representation(attribute)
api_1          |   File "/venv/lib64/python3.8/site-packages/rest_framework/fields.py", line 1882, in to_representation
api_1          |     return method(value)
api_1          |   File "/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/execution_environment.py", line 145, in get_layers
api_1          |     layers.append({"digest": blob.digest, "size": blob.artifact_list[0].size})
api_1          | IndexError: list index out of range
```