### PR TITLE
Enable indexing EEs from Red Hat Registry

### DIFF
--- a/CHANGES/864.feature
+++ b/CHANGES/864.feature
@@ -1,0 +1,4 @@
+Add the ability to index execution environments from Red Hat registry remotes.
+
+This scans the registry for containers that are labeled with the execution environment
+label and creates remote container repositories for them which can be synced.

--- a/CHANGES/864.feature
+++ b/CHANGES/864.feature
@@ -1,4 +1,1 @@
-Add the ability to index execution environments from Red Hat registry remotes.
-
-This scans the registry for containers that are labeled with the execution environment
-label and creates remote container repositories for them which can be synced.
+Add the ability to index execution environments from Red Hat registry remotes. This scans the registry for containers that are labeled with the execution environment label and creates remote container repositories for them which can be synced.

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -323,6 +323,12 @@ STANDALONE_STATEMENTS = {
             "effect": "allow",
             "condition": "has_model_perms:galaxy.change_containerregistryremote"
         },
+        {
+            "action": "index_execution_environments",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.change_containerregistryremote"
+        },
     ],
 
     'ContainerRemoteViewSet': [

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -254,6 +254,7 @@ class ContainerRegistryRemoteSerializer(
     updated_at = serializers.DateTimeField(source='pulp_last_updated', required=False)
     last_sync_task = utils.RemoteSyncTaskField(source="*")
     write_only_fields = serializers.SerializerMethodField()
+    is_indexable = serializers.SerializerMethodField()
 
     class Meta:
         model = models.ContainerRegistryRemote
@@ -277,6 +278,7 @@ class ContainerRegistryRemoteSerializer(
             "proxy_password",
             "write_only_fields",
             "rate_limit",
+            "is_indexable"
         ]
         extra_kwargs = {
             'name': {'read_only': True},
@@ -285,6 +287,11 @@ class ContainerRegistryRemoteSerializer(
 
     def get_write_only_fields(self, obj):
         return utils.get_write_only_fields(self, obj)
+
+    def get_is_indexable(self, obj):
+        if obj.get_registry_backend():
+            return True
+        return False
 
 
 class ContainerRemoteSerializer(

--- a/galaxy_ng/app/api/ui/urls.py
+++ b/galaxy_ng/app/api/ui/urls.py
@@ -81,6 +81,10 @@ container_paths = [
         views.ContainerSyncRegistryView.as_view(),
         name='container-registry-sync'),
     path(
+        "registries/<str:pk>/index/",
+        views.IndexRegistryEEView.as_view(),
+        name='execution-environments-registry-index'),
+    path(
         "registries/",
         viewsets.ContainerRegistryRemoteViewSet.as_view({'get': 'list', 'post': 'create'}),
         name='execution-environments-registry-list'),

--- a/galaxy_ng/app/api/ui/views/__init__.py
+++ b/galaxy_ng/app/api/ui/views/__init__.py
@@ -9,6 +9,8 @@ from .controller import ControllerListView
 from .settings import SettingsView
 from .sync import ContainerSyncRemoteView, ContainerSyncRegistryView
 
+from .index_execution_environments import IndexRegistryEEView
+
 __all__ = (
     # auth
     "LoginView",
@@ -25,5 +27,8 @@ __all__ = (
 
     # sync
     "ContainerSyncRemoteView",
-    "ContainerSyncRegistryView"
+    "ContainerSyncRegistryView",
+
+    # index_execution_environments
+    "IndexRegistryEEView",
 )

--- a/galaxy_ng/app/api/ui/views/index_execution_environments.py
+++ b/galaxy_ng/app/api/ui/views/index_execution_environments.py
@@ -1,0 +1,49 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError
+
+from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
+
+from pulpcore.plugin.tasking import dispatch
+from pulpcore.plugin.viewsets import OperationPostponedResponse
+
+from galaxy_ng.app.api import base as api_base
+from galaxy_ng.app.access_control import access_policy
+from galaxy_ng.app import models
+from galaxy_ng.app import tasks
+
+
+class IndexRegistryEEView(api_base.APIView):
+    permission_classes = [access_policy.ContainerRegistryRemoteAccessPolicy]
+    action = 'index_execution_environments'
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        registry = get_object_or_404(models.ContainerRegistryRemote, pk=kwargs['pk'])
+
+        if not registry.get_registry_backend():
+            raise ValidationError(
+                detail={
+                    'url':
+                        _('Indexing execution environments is not supported on this registry.')
+                })
+
+        serializable_meta = {}
+        for key in self.request.META:
+            val = self.request.META[key]
+            if type(val) == str:
+                serializable_meta[key] = val
+
+        request_data = {
+            "META": serializable_meta,
+        }
+
+        result = dispatch(
+            tasks.index_execution_environments_from_redhat_registry,
+            kwargs={
+                "registry_pk": registry.pk,
+                "request_data": request_data
+            },
+        )
+
+        return OperationPostponedResponse(result, self.request)

--- a/galaxy_ng/app/api/ui/views/index_execution_environments.py
+++ b/galaxy_ng/app/api/ui/views/index_execution_environments.py
@@ -1,12 +1,16 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
+from rest_framework import status
+
+from drf_spectacular.utils import extend_schema
 
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 
 from pulpcore.plugin.tasking import dispatch
 from pulpcore.plugin.viewsets import OperationPostponedResponse
+from pulpcore.plugin.serializers import AsyncOperationResponseSerializer
 
 from galaxy_ng.app.api import base as api_base
 from galaxy_ng.app.access_control import access_policy
@@ -18,6 +22,10 @@ class IndexRegistryEEView(api_base.APIView):
     permission_classes = [access_policy.ContainerRegistryRemoteAccessPolicy]
     action = 'index_execution_environments'
 
+    @extend_schema(
+        description="Trigger an asynchronous delete task",
+        responses={status.HTTP_202_ACCEPTED: AsyncOperationResponseSerializer},
+    )
     def post(self, request: Request, *args, **kwargs) -> Response:
         registry = get_object_or_404(models.ContainerRegistryRemote, pk=kwargs['pk'])
 

--- a/galaxy_ng/app/models/container.py
+++ b/galaxy_ng/app/models/container.py
@@ -73,7 +73,7 @@ class ContainerRegistryRemote(
 
     def get_registry_backend(self):
         for registry in self.RED_HAT_REGISTY_DOMAINS:
-            if self.url in registry:
+            if registry in self.url:
                 return 'redhat'
         return None
 

--- a/galaxy_ng/app/models/container.py
+++ b/galaxy_ng/app/models/container.py
@@ -43,6 +43,10 @@ class ContainerRegistryRemote(
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
 
+    RED_HAT_REGISTY_DOMAINS = (
+        'registry.redhat.io',
+    )
+
     def get_connection_fields(self):
         copy_fields = (
             "url",
@@ -66,6 +70,12 @@ class ContainerRegistryRemote(
             result[field] = getattr(self, field)
 
         return result
+
+    def get_registry_backend(self):
+        for registry in self.RED_HAT_REGISTY_DOMAINS:
+            if self.url in registry:
+                return 'redhat'
+        return None
 
 
 class ContainerRegistryRepos(models.Model):

--- a/galaxy_ng/app/tasks/__init__.py
+++ b/galaxy_ng/app/tasks/__init__.py
@@ -3,5 +3,6 @@ from .deletion import delete_collection, delete_collection_version  # noqa: F401
 from .promotion import call_copy_task, call_remove_task  # noqa: F401
 from .publishing import import_and_auto_approve, import_and_move_to_staging  # noqa: F401
 from .synclist import curate_all_synclist_repository, curate_synclist_repository  # noqa: F401
+from .index_registry import index_execution_environments_from_redhat_registry  # noqa: F401
 
 # from .synchronizing import synchronize  # noqa

--- a/galaxy_ng/app/tasks/index_registry.py
+++ b/galaxy_ng/app/tasks/index_registry.py
@@ -1,0 +1,160 @@
+import json
+import logging
+from urllib.parse import quote, urlencode
+
+from django.core import exceptions
+from django.utils.translation import gettext_lazy as _
+from django.http.request import HttpRequest
+
+from pulpcore.plugin.tasking import dispatch
+
+from pulp_container.app import models as container_models
+
+from galaxy_ng.app.api.ui import serializers
+from galaxy_ng.app import models
+
+
+log = logging.getLogger(__name__)
+
+
+CATALOG_API = "https://catalog.redhat.com/api/containers/v1/repositories"
+
+
+class CouldNotCreateContainerError(Exception):
+    def __init__(self, remote_name, error=""):
+        self.message = _(
+            f"Failed to create container {remote_name}. {error}"
+        )
+
+        super().__init__(self.message)
+
+
+def _get_request(request_data):
+    request = HttpRequest()
+
+    for k in request_data:
+        setattr(request, k, request_data[k])
+
+    return request
+
+
+def _parse_catalog_repositories(response_data):
+    containers = []
+
+    for container in response_data['data']:
+        containers.append({
+            "name": container['repository'],
+            "upstream_name": container['repository'],
+            "description": container['display_data']['short_description'],
+            "readme": container['display_data']['long_description_markdown'],
+        })
+
+    return containers
+
+
+def _update_distro_readme_and_description(distro, container_data):
+    readme = models.ContainerDistroReadme.objects.get_or_create(container=distro)[0]
+    readme.text = container_data['readme']
+    readme.save()
+
+    distro.description = container_data['description']
+    distro.save()
+
+
+def create_or_update_remote_container(container_data, registry_pk, request_data):
+    # check if a distro matching the base name exists
+    remote_repo_type = container_models.ContainerRepository.get_pulp_type()
+
+    try:
+        distro = container_models.ContainerDistribution.objects.get(
+            base_path=container_data['name'])
+
+        repo = distro.repository
+
+        # If a distro matching the container name exists, and it's a remote repository and
+        # it has a container remote attached to it that's associated with the selected
+        # registry, update the container's readme and description.
+        if repo.pulp_type == remote_repo_type and repo.remote is not None:
+            try:
+                remote_registry = models.ContainerRegistryRepos.objects.get(
+                    repository_remote=repo.remote).registry
+                if remote_registry and remote_registry.pk == registry_pk:
+                    _update_distro_readme_and_description(distro, container_data)
+                    return
+
+            except exceptions.ObjectDoesNotExist:
+                raise CouldNotCreateContainerError(
+                    container_data['name'],
+                    error=_(
+                        "A remote container with this name already exists, "
+                        "but is not associated with any registry.")
+                )
+
+        else:
+            raise CouldNotCreateContainerError(
+                container_data['name'],
+                error=_("A local container with this name already exists.")
+            )
+
+    except exceptions.ObjectDoesNotExist:
+        # If no distributions match the selected container, create one.
+        request = _get_request(request_data)
+        serializer = serializers.ContainerRemoteSerializer(
+            data={
+                "name": container_data['name'],
+                "upstream_name": container_data['name'],
+                "registry": str(registry_pk)
+            }, context={"request": request}
+        )
+
+        try:
+            serializer.is_valid(raise_exception=True)
+        except serializers.ValidationError as e:
+            CouldNotCreateContainerError(
+                container_data['name'],
+                error=str(e)
+            )
+        serializer.create(serializer.validated_data)
+
+        distro = container_models.ContainerDistribution.objects.get(
+            base_path=container_data['name'])
+
+        _update_distro_readme_and_description(distro, container_data)
+
+
+def index_execution_environments_from_redhat_registry(registry_pk, request_data):
+    registry = models.ContainerRegistryRemote.objects.get(pk=registry_pk)
+    remotes = []
+
+    query = {
+        "filter": "build_categories=in=('Automation Execution Environment')",
+        "page": 0,
+        "sort_by": "creation_date[asc]"
+    }
+
+    # Iterate through the pages on the API response and add the relevant information
+    # about each container repository.
+    while True:
+        url = CATALOG_API + "?" + urlencode(query, quote_via=quote)
+        downloader = registry.get_downloader(url=url)
+        download_result = downloader.fetch()
+        with open(download_result.path) as fd:
+            data = json.load(fd)
+            remotes = remotes + _parse_catalog_repositories(data)
+            if len(data['data']) == data['page_size']:
+                query['page'] += 1
+            else:
+                break
+
+    for remote in remotes:
+        # create a subtask for each remote, so that if one fails, we can throw a usable error
+        # message for the user to look at and prevent the rest of the repositories from failing.
+        dispatch(
+            create_or_update_remote_container,
+            kwargs={
+                "container_data": remote,
+                "registry_pk": registry.pk,
+                "request_data": request_data
+            },
+            exclusive_resources=['/pulp/api/v3/distributions/']
+        )

--- a/galaxy_ng/app/tasks/index_registry.py
+++ b/galaxy_ng/app/tasks/index_registry.py
@@ -23,7 +23,8 @@ CATALOG_API = "https://catalog.redhat.com/api/containers/v1/repositories"
 class CouldNotCreateContainerError(Exception):
     def __init__(self, remote_name, error=""):
         self.message = _(
-            f"Failed to create container {remote_name}. {error}"
+            "Failed to create container {remote_name}. {error}".format(
+                remote_name=remote_name, error=error)
         )
 
         super().__init__(self.message)
@@ -32,8 +33,8 @@ class CouldNotCreateContainerError(Exception):
 def _get_request(request_data):
     request = HttpRequest()
 
-    for k in request_data:
-        setattr(request, k, request_data[k])
+    for k, v in request_data.items():
+        setattr(request, k, v)
 
     return request
 
@@ -156,5 +157,5 @@ def index_execution_environments_from_redhat_registry(registry_pk, request_data)
                 "registry_pk": registry.pk,
                 "request_data": request_data
             },
-            exclusive_resources=['/pulp/api/v3/distributions/']
+            exclusive_resources=["/api/v3/distributions/"]
         )


### PR DESCRIPTION
Add `_ui/v1/execution-environments/registries/{registry_pk}/index/` endpoint.

```
curl \
  -X POST \
  -H 'Content-Type: application/json' \
  curl_flags  -u admin:admin \
  http://localhost:5001/api/automation-hub/_ui/v1/execution-environments/registries/{registry_pk}/index/
```

Launches a task that:
- Checks if the registry is indexable (for now, that just means that it's a red hat registry instance)
- Launches a task that reaches out to catalog.redhat.com and pulls a list of execution environments
- For each EE in the response, launch a task that creates a new remote repository in the registry.