### PR TITLE
Add auth_provider to users/ endpoint to denote an SSO user

### DIFF
--- a/CHANGES/952.bugfix
+++ b/CHANGES/952.bugfix
@@ -1,0 +1,1 @@
+Add auth_provider to users/ endpoint to denote an SSO user

--- a/galaxy_ng/app/api/ui/serializers/user.py
+++ b/galaxy_ng/app/api/ui/serializers/user.py
@@ -21,6 +21,7 @@ class GroupSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
+    auth_provider = serializers.SerializerMethodField()
 
     class Meta:
         model = auth_models.User
@@ -33,12 +34,22 @@ class UserSerializer(serializers.ModelSerializer):
             'groups',
             'password',
             'date_joined',
-            'is_superuser'
+            'is_superuser',
+            'auth_provider',
         )
         extra_kwargs = {
             'date_joined': {'read_only': True},
             'password': {'write_only': True, 'allow_blank': True, 'required': False}
         }
+
+    def get_auth_provider(self, user):
+        if hasattr(user, 'social_auth') and user.social_auth.all():
+            providers = []
+            for social in user.social_auth.all():
+                providers.append(social.provider)
+            return providers
+
+        return ['django']
 
     def validate_password(self, password):
         if password:

--- a/galaxy_ng/app/api/ui/views/settings.py
+++ b/galaxy_ng/app/api/ui/views/settings.py
@@ -14,6 +14,7 @@ class SettingsView(api_base.APIView):
             "GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS",
             "GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD",
             "GALAXY_FEATURE_FLAGS",
+            "GALAXY_TOKEN_EXPIRATION",
         ]
         data = {key: settings.as_dict().get(key, None) for key in keyset}
         return Response(data)


### PR DESCRIPTION
Issue: AAH-952
Assignment: Add auth_provider to users/ endpoint to denote an SSO user
See on Jira: https://issues.redhat.com/browse/AAH-952

Creates a new serializer method field, "auth_provider" that checks to see if the user is an SSO user. If so, method returns the SSO provider; if not it returns "django" as a string. 

