### PR TITLE
Add get_object to ContainerSyncRemoteView + reverted #986

### DIFF
--- a/CHANGES/989.bugfix
+++ b/CHANGES/989.bugfix
@@ -1,0 +1,1 @@
+Add get_object to ContainerSyncRemoteView to fix AAH-989

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -206,8 +206,7 @@ class ContainerRemoteAccessPolicy(AccessPolicyBase, NamespacedAccessPolicyMixin)
 
         # has_container_namespace_perms
 
-        distro = view.get_object()
-        remote = distro.repository.remote.cast()
+        remote = view.get_object()
         repositories = remote.repository_set.all()
 
         # In theory there should never be more than one repository connected to a remote, but

--- a/galaxy_ng/app/api/ui/views/sync.py
+++ b/galaxy_ng/app/api/ui/views/sync.py
@@ -23,7 +23,12 @@ class ContainerSyncRemoteView(api_base.APIView):
     action = 'sync'
 
     def get_object(self):
-        """Return a distro instance to be used by the access_policy to check obj permission"""
+        """Object is a ContainerRemote instance"""
+        distro = self.get_distribution()
+        remote = distro.repository.remote.cast()
+        return remote
+
+    def get_distribution(self):
         distro_path = self.kwargs['base_path']
         distro = get_object_or_404(pulp_models.ContainerDistribution, base_path=distro_path)
 
@@ -36,7 +41,7 @@ class ContainerSyncRemoteView(api_base.APIView):
 
     def post(self, request: Request, *args, **kwargs) -> Response:
         distro_path = kwargs['base_path']
-        distro = self.get_object()
+        distro = self.get_distribution()
         remote = distro.repository.remote.cast()
 
         try:


### PR DESCRIPTION
Issue: AAH-989

## reported issue was

sync..
```
AttributeError at /api/automation-hub/_ui/v1/execution-environments/repositories/alpinex/_content/sync/
'ContainerSyncRemoteView' object has no attribute 'get_object'
Request Method:	POST
Request URL:	http://localhost:8002/api/automation-hub/_ui/v1/execution-environments/repositories/alpinex/_content/sync/
Django Version:	3.2.6
Exception Type:	AttributeError
Exception Value:	
'ContainerSyncRemoteView' object has no attribute 'get_object'
Exception Location:	/src/galaxy_ng/galaxy_ng/app/access_control/access_policy.py, line 209, in has_distro_permission
```
delete...
```
LookupError at /api/automation-hub/_ui/v1/execution-environments/repositories/alpinex/
Could not determine ViewSet base name for model <class 'galaxy_ng.app.models.container.ContainerDistribution'>
Request Method:	DELETE
Request URL:	http://localhost:8002/api/automation-hub/_ui/v1/execution-environments/repositories/alpinex/
Django Version:	3.2.6
Exception Type:	LookupError
Exception Value:	
Could not determine ViewSet base name for model <class 'galaxy_ng.app.models.container.ContainerDistribution'>
Exception Location:	/venv/lib64/python3.8/site-packages/pulpcore/app/util.py, line 44, in get_viewset_for_model
```

(to reproduce, you can just run the UI, add a remote repo, try to sync, and try to delete it)
what I used:
registry url: https://registry.hub.docker.com (any name; no username/password)
remote upstream_name: library/alpine (_/alpine on dockerhub becomes library/alpine)
include tags: latest (otherwise it will fail trying to download too many images) (edited) 