### PR TITLE
Disable streamed sync endpoints

### DIFF
--- a/CHANGES/224.bugfix
+++ b/CHANGES/224.bugfix
@@ -1,0 +1,1 @@
+Disable streamed sync endpoints

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -29,17 +29,20 @@ sync_urls = [
 ]
 
 urlpatterns = [
-    path("", viewsets.RepoMetadataViewSet.as_view({"get": "retrieve"}), name="repo-metadata"),
-    path(
-        "collections/all/",
-        viewsets.UnpaginatedCollectionViewSet.as_view({"get": "list"}),
-        name="all-collections-list",
-    ),
-    path(
-        "collection_versions/all/",
-        viewsets.UnpaginatedCollectionVersionViewSet.as_view({"get": "list"}),
-        name="all-collection-versions-list",
-    ),
+    # The following endpoints are related to issue https://issues.redhat.com/browse/AAH-224
+    # For now endpoints are temporary deactivated
+    #
+    # path("", viewsets.RepoMetadataViewSet.as_view({"get": "retrieve"}), name="repo-metadata"),
+    # path(
+    #     "collections/all/",
+    #     viewsets.UnpaginatedCollectionViewSet.as_view({"get": "list"}),
+    #     name="all-collections-list",
+    # ),
+    # path(
+    #     "collection_versions/all/",
+    #     viewsets.UnpaginatedCollectionVersionViewSet.as_view({"get": "list"}),
+    #     name="all-collection-versions-list",
+    # ),
     path(
         "collections/", viewsets.CollectionViewSet.as_view({"get": "list"}), name="collections-list"
     ),

--- a/galaxy_ng/tests/unit/api/test_api_v3_collections.py
+++ b/galaxy_ng/tests/unit/api/test_api_v3_collections.py
@@ -116,26 +116,29 @@ class TestCollectionViewsets(BaseTestCase):
             "galaxy:api:v3:default-content:collection-artifact-upload"
         )
 
-        self.all_collections_url = reverse(
-            "galaxy:api:content:v3:all-collections-list",
-            kwargs={
-                "path": self.repo.name,
-            },
-        )
-
-        self.all_versions_url = reverse(
-            "galaxy:api:content:v3:all-collection-versions-list",
-            kwargs={
-                "path": self.repo.name,
-            },
-        )
-
-        self.metadata_url = reverse(
-            "galaxy:api:content:v3:repo-metadata",
-            kwargs={
-                "path": self.repo.name,
-            },
-        )
+        # The following tests use endpoints related to
+        # issue https://issues.redhat.com/browse/AAH-224
+        # For now endpoints are temporary deactivated
+        # self.all_collections_url = reverse(
+        #     "galaxy:api:content:v3:all-collections-list",
+        #     kwargs={
+        #         "path": self.repo.name,
+        #     },
+        # )
+        #
+        # self.all_versions_url = reverse(
+        #     "galaxy:api:content:v3:all-collection-versions-list",
+        #     kwargs={
+        #         "path": self.repo.name,
+        #     },
+        # )
+        #
+        # self.metadata_url = reverse(
+        #     "galaxy:api:content:v3:repo-metadata",
+        #     kwargs={
+        #         "path": self.repo.name,
+        #     },
+        # )
 
         # used for href tests
         self.pulp_href_fragment = "pulp_ansible/galaxy"


### PR DESCRIPTION
This PR temporarily disables the streamed sync endpoints (basically reverting #806) to support a timed and planned rollout of client and server functionality.

Related-Issue: AAH-224