### PR TITLE
Localization: Add first wave of translations for fr, ja and zh

### DIFF
--- a/CHANGES/799.misc
+++ b/CHANGES/799.misc
@@ -1,0 +1,1 @@
+Localization: Add first wave of translations for fr, ja and zh

--- a/galaxy_ng/locale/fr/LC_MESSAGES/django.po
+++ b/galaxy_ng/locale/fr/LC_MESSAGES/django.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -19,92 +18,92 @@ msgstr ""
 
 #: galaxy_ng/app/access_control/access_policy.py:69
 msgid "Namespace in filename not found."
-msgstr ""
+msgstr "L'espace de nom dans le nom de fichier n'a pas été trouvé."
 
 #: galaxy_ng/app/access_control/fields.py:17
 msgid "object_permissions field is required"
-msgstr ""
+msgstr "le champ object_permissions est obligatoire"
 
 #: galaxy_ng/app/access_control/fields.py:21
 msgid "id or name field is required"
-msgstr ""
+msgstr "Ce champ est obligatoire."
 
 #: galaxy_ng/app/access_control/fields.py:27
 msgid "object_permissions must be a list of strings"
-msgstr ""
+msgstr "object_permissions doit être une liste de chaînes de caractères"
 
 #: galaxy_ng/app/access_control/fields.py:41
 msgid "Permission {} does not exist"
-msgstr ""
+msgstr "La permission {} n'existe pas"
 
 #: galaxy_ng/app/access_control/fields.py:56
 msgid "Groups must be a list of group objects"
-msgstr ""
+msgstr "Les groupes doivent correspondre à une liste d'objets de groupe"
 
 #: galaxy_ng/app/access_control/fields.py:71
 #, python-format
 msgid "Group name=%s, id=%s does not exist"
-msgstr ""
+msgstr "Le groupe name=%s, id=%s n'existe pas"
 
 #: galaxy_ng/app/access_control/fields.py:75
 #: galaxy_ng/app/api/ui/serializers/user.py:118
 msgid "Invalid group name or ID"
-msgstr ""
+msgstr "Nom de groupe ou ID invalide"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:41
 #, python-brace-format
 msgid "Repository \"{pulp_id}\" not found while creating synclist"
-msgstr ""
+msgstr "Le référentiel \"{pulp_id}\" n'a pas été trouvé lors de la création de la synclist"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:96
 #, python-format
 msgid "Synclist already exists: %s"
-msgstr ""
+msgstr "Synclist existe déjà : %s"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:104
 #, python-brace-format
 msgid ""
 "Collection \"{namespace}.{name}\" not found while creating synclist "
 "{synclist}"
-msgstr ""
+msgstr "La collection \"{namespace}.{name}\" n'a pas été trouvée lors de la création de la synclist {synclist}"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:143
 #, python-brace-format
 msgid ""
 "Collection \"{namespace}.{name}\" not found while updating synclist "
 "{synclist}"
-msgstr ""
+msgstr "La collection \"{namespace}.{name}\" n'a pas été trouvée lors de la mise à jour de la liste syntaxique {synclist}"
 
 #: galaxy_ng/app/api/ui/serializers/user.py:60
 msgid ""
 "'galaxy.change_group' permission is required to change a users group that "
 "the requesting user is not in."
-msgstr ""
+msgstr "L'autorisation 'galaxy.change_group' est nécessaire pour modifier un groupe d'utilisateurs dont l'utilisateur demandeur ne fait pas partie."
 
 #: galaxy_ng/app/api/ui/serializers/user.py:71
 msgid "Must be a super user to grant super user permissions."
-msgstr ""
+msgstr "Il faut être un super utilisateur pour accorder des autorisations de super utilisateur."
 
 #: galaxy_ng/app/api/ui/serializers/user.py:114
 #, python-format
 msgid "Group name=%(name)s, id=%(id)s does not exist"
-msgstr ""
+msgstr "Le groupe name=%(name)s, id=%(id)s n'existe pas"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:57
 msgid "Distribution base path is required"
-msgstr ""
+msgstr "Le chemin de la base de distribution est requis"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:155
 msgid "Retrieve collection version"
-msgstr ""
+msgstr "Récupérer la version de la collection"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:166
 msgid "Collection version not found for: {}"
-msgstr ""
+msgstr "Version de la collection non trouvée pour : {}"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:222
 msgid "Retrieve collection import"
-msgstr ""
+msgstr "Récupérer l'importation de la collection"
 
 #: galaxy_ng/app/api/ui/viewsets/group.py:45
 #, python-format
@@ -115,158 +114,158 @@ msgstr "Un groupe nommé %s existe déjà."
 #, python-brace-format
 msgid ""
 "Invalid filename {filename}. Expected format: namespace-name-version.tar.gz"
-msgstr ""
+msgstr "Nom de fichier non valide {filename}. Format attendu : namespace-name-version.tar.gz"
 
 #: galaxy_ng/app/api/utils.py:52
 #, python-brace-format
 msgid ""
 "Invalid version string {version} from filename {filename}. Expected semantic "
 "version format."
-msgstr ""
+msgstr "Chaîne de version non valide {version} à partir du nom de fichier {filename}. Format de version sémantique attendu."
 
 #: galaxy_ng/app/api/utils.py:56
 #, python-format
 msgid "Expected namespace to be max length of %s"
-msgstr ""
+msgstr "L'espace de nom attendu est d'une longueur maximale de %s"
 
 #: galaxy_ng/app/api/utils.py:58
 #, python-format
 msgid "Expected name to be max length of %s"
-msgstr ""
+msgstr "Le nom doit avoir une longueur maximale de %s"
 
 #: galaxy_ng/app/api/utils.py:60
 #, python-format
 msgid "Expected version to be max length of %s"
-msgstr ""
+msgstr "La version attendue est d'une longueur maximale de %s"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:60
 #, python-format
 msgid "'%s' is not a valid url."
-msgstr ""
+msgstr "\"%s\" n'est pas un choix valide."
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:88
 msgid "Attribute 'name' is required"
-msgstr ""
+msgstr "L'attribut \"nom\" est obligatoire"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:91
 msgid "Name can only contain lower case letters, underscores and numbers"
-msgstr ""
+msgstr "Le nom ne peut contenir que des lettres minuscules, des caractères de soulignement et des chiffres"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:94
 msgid "Name must be longer than 2 characters"
-msgstr ""
+msgstr "Le nom doit comporter plus de 2 caractères"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:97
 msgid "Name cannot begin with '_'"
-msgstr ""
+msgstr "Le nom ne peut pas commencer par '_'"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:85
 msgid "Password for proxy authentication."
-msgstr ""
+msgstr "Mot de passe pour l'authentification du proxy."
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:92
 msgid "User for proxy authentication."
-msgstr ""
+msgstr "Utilisateur pour l'authentification du proxy."
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:105
 msgid "Remote password."
-msgstr ""
+msgstr "Mot de passe utilisateur à distance."
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:112
 msgid "Remote user."
-msgstr ""
+msgstr "Utilisateur distant."
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:161
 msgid ""
 "Syncing content from community domains without specifying a requirements "
 "file is not allowed."
-msgstr ""
+msgstr "La synchronisation du contenu des domaines communautaires sans spécifier un fichier d'exigences n'est pas autorisée."
 
 #: galaxy_ng/app/api/v3/views/sync.py:29
 #, python-format
 msgid "The %s distribution does not have any remotes associated with it."
-msgstr ""
+msgstr "La distribution %s n'a pas d’utilisateurs distants associés à elle."
 
 #: galaxy_ng/app/api/v3/views/sync.py:40
 msgid ""
 "Syncing content from galaxy.ansible.com without specifying a requirements "
 "file is not allowed."
-msgstr ""
+msgstr "La synchronisation du contenu de galaxy.ansible.com sans spécifier un fichier d'exigences n'est pas autorisée."
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:172
 #, python-format
 msgid "Path does not match: \"%s\""
-msgstr ""
+msgstr "Le chemin ne correspond pas : \"%s\""
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:186
 #, python-brace-format
 msgid "Namespace \"{0}\" does not exist."
-msgstr ""
+msgstr "L'espace de nommage \"{0}\" n'existe pas."
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:279
 #, python-format
 msgid "Unexpected response from content app. Code: %s."
-msgstr ""
+msgstr "Réponse inattendue de l'application de contenu. Code : %s."
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:301
 #, python-format
 msgid "Collection %s not found"
-msgstr ""
+msgstr "Collection %s non trouvée"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:309
 #, python-format
 msgid "Repo(s) for moving collection %s not found"
-msgstr ""
+msgstr "Repo(s) pour déplacer la collection %s non trouvé(s)"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:313
 #, python-format
 msgid "Collection %s not found in source repo"
-msgstr ""
+msgstr "Collection %s non trouvée dans le repo source"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:317
 #, python-format
 msgid "Collection %s already found in destination repo"
-msgstr ""
+msgstr "Collection %s déjà trouvée dans le repo de destination"
 
 #: galaxy_ng/app/api/v3/viewsets/namespace.py:61
 #, python-format
 msgid "A namespace named %s already exists."
-msgstr ""
+msgstr "Un espace de nom nommé %s existe déjà."
 
 #: galaxy_ng/app/exceptions.py:8
 msgid "Data conflicts with existing entity."
-msgstr ""
+msgstr "Les données entrent en conflit avec une entité existante."
 
 #: galaxy_ng/app/tasks/publishing.py:54 galaxy_ng/app/tasks/publishing.py:84
 #, python-format
 msgid "Could not find staging repository: \"%s\""
-msgstr ""
+msgstr "Impossible de trouver le référentiel «staging» : \"%s\""
 
 #: galaxy_ng/app/tasks/synclist.py:45
 #, python-format
 msgid "Curating all synclists repos that curate from %s"
-msgstr ""
+msgstr "Curation de tous les dépôts synclistes à partir de %s"
 
 #: galaxy_ng/app/tasks/synclist.py:56
 msgid "Synclists curating upstream repo"
-msgstr ""
+msgstr "Synclistes conservant le repo amont"
 
 #: galaxy_ng/app/tasks/synclist.py:63
 msgid "Synclists curating upstream repo task"
-msgstr ""
+msgstr "Tâche de curation de repo amont par Synclists"
 
 #: galaxy_ng/app/tasks/synclist.py:91
 #, python-format
 msgid "Finishing curating %s synclist repos based on %s update"
-msgstr ""
+msgstr "Fin de la préparation de %s repos synclistes basés sur la mise à jour %s"
 
 #: galaxy_ng/app/tasks/synclist.py:120
 #, python-format
 msgid ""
 "Applying synclist \"%s\" with policy=%s to curate repo \"%s\" from upstream "
 "repo \"%s\""
-msgstr ""
+msgstr "Application de synclist \"%s\" avec policy=%s au repo curate \"%s\" à partir du repo amont \"%s\""
 
 #: galaxy_ng/app/tasks/synclist.py:162
 msgid "Unexpected synclist policy {}"
-msgstr ""
+msgstr "Politique syncliste inattendue {}"

--- a/galaxy_ng/locale/ja/LC_MESSAGES/django.po
+++ b/galaxy_ng/locale/ja/LC_MESSAGES/django.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -19,254 +18,254 @@ msgstr ""
 
 #: galaxy_ng/app/access_control/access_policy.py:69
 msgid "Namespace in filename not found."
-msgstr ""
+msgstr "ファイル名の名前空間が見つかりません。"
 
 #: galaxy_ng/app/access_control/fields.py:17
 msgid "object_permissions field is required"
-msgstr ""
+msgstr "object_permissions フィールドは必須です。"
 
 #: galaxy_ng/app/access_control/fields.py:21
 msgid "id or name field is required"
-msgstr ""
+msgstr "ID または名前のフィールドは必須です。"
 
 #: galaxy_ng/app/access_control/fields.py:27
 msgid "object_permissions must be a list of strings"
-msgstr ""
+msgstr "object_permissions は文字列のリストでなければなりません"
 
 #: galaxy_ng/app/access_control/fields.py:41
 msgid "Permission {} does not exist"
-msgstr ""
+msgstr "パーミッション {} は存在しません"
 
 #: galaxy_ng/app/access_control/fields.py:56
 msgid "Groups must be a list of group objects"
-msgstr ""
+msgstr "グループは、グループオブジェクトの一覧でなければなりません"
 
 #: galaxy_ng/app/access_control/fields.py:71
 #, python-format
 msgid "Group name=%s, id=%s does not exist"
-msgstr ""
+msgstr "グループ名=%s、id=%s は存在しません"
 
 #: galaxy_ng/app/access_control/fields.py:75
 #: galaxy_ng/app/api/ui/serializers/user.py:118
 msgid "Invalid group name or ID"
-msgstr ""
+msgstr "無効なグループ名または ID"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:41
 #, python-brace-format
 msgid "Repository \"{pulp_id}\" not found while creating synclist"
-msgstr ""
+msgstr "同期リストの作成中にリポジトリー \"{pulp_id}\" が見つかりませんでした"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:96
 #, python-format
 msgid "Synclist already exists: %s"
-msgstr ""
+msgstr "同期リストはすでに存在します: %s"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:104
 #, python-brace-format
 msgid ""
 "Collection \"{namespace}.{name}\" not found while creating synclist "
 "{synclist}"
-msgstr ""
+msgstr "同期リスト {synclist} の作成中にコレクション \"{namespace}.{name}\" が見つかりませんでした"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:143
 #, python-brace-format
 msgid ""
 "Collection \"{namespace}.{name}\" not found while updating synclist "
 "{synclist}"
-msgstr ""
+msgstr "同期リスト {synclist} の更新中にコレクション \"{namespace}.{name}\" が見つかりませんでした"
 
 #: galaxy_ng/app/api/ui/serializers/user.py:60
 msgid ""
 "'galaxy.change_group' permission is required to change a users group that "
 "the requesting user is not in."
-msgstr ""
+msgstr "要求するユーザーが所属しないユーザーグループを変更するには、「galaxy.change_group」パーミッションが必要です。"
 
 #: galaxy_ng/app/api/ui/serializers/user.py:71
 msgid "Must be a super user to grant super user permissions."
-msgstr ""
+msgstr "スーパーユーザーパーミッションを付与するには、スーパーユーザーである必要があります。"
 
 #: galaxy_ng/app/api/ui/serializers/user.py:114
 #, python-format
 msgid "Group name=%(name)s, id=%(id)s does not exist"
-msgstr ""
+msgstr "グループ名=%(name)s、id=%(id)s は存在しません"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:57
 msgid "Distribution base path is required"
-msgstr ""
+msgstr "ディストリビューションベースパスが必要です"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:155
 msgid "Retrieve collection version"
-msgstr ""
+msgstr "コレクションバージョンの取得"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:166
 msgid "Collection version not found for: {}"
-msgstr ""
+msgstr "コレクションバージョンが見つかりません: {}"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:222
 msgid "Retrieve collection import"
-msgstr ""
+msgstr "コレクションインポートの取得"
 
 #: galaxy_ng/app/api/ui/viewsets/group.py:45
 #, python-format
 msgid "A group named %s already exists."
-msgstr "%sという名前のグループはすでに存在します。"
+msgstr "%s という名前のグループはすでに存在します。"
 
 #: galaxy_ng/app/api/utils.py:45
 #, python-brace-format
 msgid ""
 "Invalid filename {filename}. Expected format: namespace-name-version.tar.gz"
-msgstr ""
+msgstr "ファイル名 {filename} が無効です。想定される形式: namespace-name-version.tar.gz"
 
 #: galaxy_ng/app/api/utils.py:52
 #, python-brace-format
 msgid ""
 "Invalid version string {version} from filename {filename}. Expected semantic "
 "version format."
-msgstr ""
+msgstr "ファイル名 {filename} のバージョン文字列 {version} が無効です。セマンティックのバージョン形式が必要です。"
 
 #: galaxy_ng/app/api/utils.py:56
 #, python-format
 msgid "Expected namespace to be max length of %s"
-msgstr ""
+msgstr "想定される名前空間の最大長は %s です"
 
 #: galaxy_ng/app/api/utils.py:58
 #, python-format
 msgid "Expected name to be max length of %s"
-msgstr ""
+msgstr "想定される名前の最大長は %s です"
 
 #: galaxy_ng/app/api/utils.py:60
 #, python-format
 msgid "Expected version to be max length of %s"
-msgstr ""
+msgstr "想定されるバージョンの最大長は %s です"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:60
 #, python-format
 msgid "'%s' is not a valid url."
-msgstr ""
+msgstr "「%s」は有効な URL ではありません"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:88
 msgid "Attribute 'name' is required"
-msgstr ""
+msgstr "属性「名」が必要です。"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:91
 msgid "Name can only contain lower case letters, underscores and numbers"
-msgstr ""
+msgstr "名前に使用できる値は小文字、アンダースコア、数字のみです"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:94
 msgid "Name must be longer than 2 characters"
-msgstr ""
+msgstr "名前は 2 文字以上にする必要があります"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:97
 msgid "Name cannot begin with '_'"
-msgstr ""
+msgstr "名前は '_' で開始できません"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:85
 msgid "Password for proxy authentication."
-msgstr ""
+msgstr "プロキシー認証のパスワード。"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:92
 msgid "User for proxy authentication."
-msgstr ""
+msgstr "プロキシー認証のユーザー。"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:105
 msgid "Remote password."
-msgstr ""
+msgstr "リモートパスワード。"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:112
 msgid "Remote user."
-msgstr ""
+msgstr "リモートユーザー。"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:161
 msgid ""
 "Syncing content from community domains without specifying a requirements "
 "file is not allowed."
-msgstr ""
+msgstr "要件ファイルを指定せずに、コミュニティードメインからのコンテンツを同期することはできません。"
 
 #: galaxy_ng/app/api/v3/views/sync.py:29
 #, python-format
 msgid "The %s distribution does not have any remotes associated with it."
-msgstr ""
+msgstr "%s ディストリビューションには、リモートが関連付けられていません。"
 
 #: galaxy_ng/app/api/v3/views/sync.py:40
 msgid ""
 "Syncing content from galaxy.ansible.com without specifying a requirements "
 "file is not allowed."
-msgstr ""
+msgstr "要件ファイルを指定せずに galaxy.ansible.com からコンテンツを同期することはできません。"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:172
 #, python-format
 msgid "Path does not match: \"%s\""
-msgstr ""
+msgstr "パスが一致しません: \"%s\""
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:186
 #, python-brace-format
 msgid "Namespace \"{0}\" does not exist."
-msgstr ""
+msgstr "名前空間 \"{0}\" は存在しません。"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:279
 #, python-format
 msgid "Unexpected response from content app. Code: %s."
-msgstr ""
+msgstr "コンテンツアプリからの予期しない応答。コード: %s"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:301
 #, python-format
 msgid "Collection %s not found"
-msgstr ""
+msgstr "コレクション %s が見つかりません"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:309
 #, python-format
 msgid "Repo(s) for moving collection %s not found"
-msgstr ""
+msgstr "コレクション %s を移動するためのリポジトリーが見つかりません"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:313
 #, python-format
 msgid "Collection %s not found in source repo"
-msgstr ""
+msgstr "ソースリポジトリーでコレクション %s が見つかりません"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:317
 #, python-format
 msgid "Collection %s already found in destination repo"
-msgstr ""
+msgstr "宛先リポジトリーでコレクション %s がすでに見つかっています"
 
 #: galaxy_ng/app/api/v3/viewsets/namespace.py:61
 #, python-format
 msgid "A namespace named %s already exists."
-msgstr ""
+msgstr "%s という名前の名前空間はすでに存在します。"
 
 #: galaxy_ng/app/exceptions.py:8
 msgid "Data conflicts with existing entity."
-msgstr ""
+msgstr "データは既存のエンティティーと競合します。"
 
 #: galaxy_ng/app/tasks/publishing.py:54 galaxy_ng/app/tasks/publishing.py:84
 #, python-format
 msgid "Could not find staging repository: \"%s\""
-msgstr ""
+msgstr "ステージングリポジトリーが見つかりませんでした: \"%s\""
 
 #: galaxy_ng/app/tasks/synclist.py:45
 #, python-format
 msgid "Curating all synclists repos that curate from %s"
-msgstr ""
+msgstr "%s から再帰的にすべての同期リストをキュレート中"
 
 #: galaxy_ng/app/tasks/synclist.py:56
 msgid "Synclists curating upstream repo"
-msgstr ""
+msgstr "キュレート中のアップストリームリポジトリーの同期リスト"
 
 #: galaxy_ng/app/tasks/synclist.py:63
 msgid "Synclists curating upstream repo task"
-msgstr ""
+msgstr "キュレート中のアップストリームのリポジトリータスクの同期リスト"
 
 #: galaxy_ng/app/tasks/synclist.py:91
 #, python-format
 msgid "Finishing curating %s synclist repos based on %s update"
-msgstr ""
+msgstr "%s 更新に基づく %s 同期リストリポジトリーの級レートの完了"
 
 #: galaxy_ng/app/tasks/synclist.py:120
 #, python-format
 msgid ""
 "Applying synclist \"%s\" with policy=%s to curate repo \"%s\" from upstream "
 "repo \"%s\""
-msgstr ""
+msgstr "アップストリームのリポジトリーから \"%s\" リポジトリー \"%s\" をキュレーとする policy=%s で同期リスト \"%s\" を適用中"
 
 #: galaxy_ng/app/tasks/synclist.py:162
 msgid "Unexpected synclist policy {}"
-msgstr ""
+msgstr "予期せぬ同期リストポリシー {}"

--- a/galaxy_ng/locale/zh/LC_MESSAGES/django.po
+++ b/galaxy_ng/locale/zh/LC_MESSAGES/django.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -19,92 +18,92 @@ msgstr ""
 
 #: galaxy_ng/app/access_control/access_policy.py:69
 msgid "Namespace in filename not found."
-msgstr ""
+msgstr "未找到文件名中的命名空间。"
 
 #: galaxy_ng/app/access_control/fields.py:17
 msgid "object_permissions field is required"
-msgstr ""
+msgstr "object_permissions 字段是必需的"
 
 #: galaxy_ng/app/access_control/fields.py:21
 msgid "id or name field is required"
-msgstr ""
+msgstr "id 或 name 字段是必需的"
 
 #: galaxy_ng/app/access_control/fields.py:27
 msgid "object_permissions must be a list of strings"
-msgstr ""
+msgstr "object_permissions 必须是一个字符串列表"
 
 #: galaxy_ng/app/access_control/fields.py:41
 msgid "Permission {} does not exist"
-msgstr ""
+msgstr "权限 {} 不存在"
 
 #: galaxy_ng/app/access_control/fields.py:56
 msgid "Groups must be a list of group objects"
-msgstr ""
+msgstr "组必须是一个组对象的列表"
 
 #: galaxy_ng/app/access_control/fields.py:71
 #, python-format
 msgid "Group name=%s, id=%s does not exist"
-msgstr ""
+msgstr "组名=%s，id=%s 不存在"
 
 #: galaxy_ng/app/access_control/fields.py:75
 #: galaxy_ng/app/api/ui/serializers/user.py:118
 msgid "Invalid group name or ID"
-msgstr ""
+msgstr "无效的组名称或 ID。"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:41
 #, python-brace-format
 msgid "Repository \"{pulp_id}\" not found while creating synclist"
-msgstr ""
+msgstr "创建同步列表时未找到存储库 \"{pulp_id}\""
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:96
 #, python-format
 msgid "Synclist already exists: %s"
-msgstr ""
+msgstr "同步类别已存在：%s"
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:104
 #, python-brace-format
 msgid ""
 "Collection \"{namespace}.{name}\" not found while creating synclist "
 "{synclist}"
-msgstr ""
+msgstr "创建同步列表 {synclist} 时找不到集合 \"{namespace}.{name}\""
 
 #: galaxy_ng/app/api/ui/serializers/synclist.py:143
 #, python-brace-format
 msgid ""
 "Collection \"{namespace}.{name}\" not found while updating synclist "
 "{synclist}"
-msgstr ""
+msgstr "更新同步列表 {synclist} 时找不到集合 \"{namespace}.{name}\""
 
 #: galaxy_ng/app/api/ui/serializers/user.py:60
 msgid ""
 "'galaxy.change_group' permission is required to change a users group that "
 "the requesting user is not in."
-msgstr ""
+msgstr "更改请求用户不在的用户组需要具有 'galaxy.change_group' 权限。"
 
 #: galaxy_ng/app/api/ui/serializers/user.py:71
 msgid "Must be a super user to grant super user permissions."
-msgstr ""
+msgstr "必须是超级用户才能授予超级用户权限。"
 
 #: galaxy_ng/app/api/ui/serializers/user.py:114
 #, python-format
 msgid "Group name=%(name)s, id=%(id)s does not exist"
-msgstr ""
+msgstr "组 name=%(name)s, id=%(id)s 不存在"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:57
 msgid "Distribution base path is required"
-msgstr ""
+msgstr "发布基础路径是必需的"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:155
 msgid "Retrieve collection version"
-msgstr ""
+msgstr "检索集合版本"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:166
 msgid "Collection version not found for: {}"
-msgstr ""
+msgstr "未找到集合版本：{}"
 
 #: galaxy_ng/app/api/ui/viewsets/collection.py:222
 msgid "Retrieve collection import"
-msgstr ""
+msgstr "检索集合导入"
 
 #: galaxy_ng/app/api/ui/viewsets/group.py:45
 #, python-format
@@ -115,158 +114,158 @@ msgstr "名为 %s 的组已存在。"
 #, python-brace-format
 msgid ""
 "Invalid filename {filename}. Expected format: namespace-name-version.tar.gz"
-msgstr ""
+msgstr "无效的文件名 {filename}。预期的格式：namespace-name-version.tar.gz"
 
 #: galaxy_ng/app/api/utils.py:52
 #, python-brace-format
 msgid ""
 "Invalid version string {version} from filename {filename}. Expected semantic "
 "version format."
-msgstr ""
+msgstr "文件名 {filename} 中的无效版本字符串 {version}。预期语义版本格式。"
 
 #: galaxy_ng/app/api/utils.py:56
 #, python-format
 msgid "Expected namespace to be max length of %s"
-msgstr ""
+msgstr "预期命名空间最大长度为 %s"
 
 #: galaxy_ng/app/api/utils.py:58
 #, python-format
 msgid "Expected name to be max length of %s"
-msgstr ""
+msgstr "预期名称最大长度为 %s"
 
 #: galaxy_ng/app/api/utils.py:60
 #, python-format
 msgid "Expected version to be max length of %s"
-msgstr ""
+msgstr "预期版本的最大长度为 %s"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:60
 #, python-format
 msgid "'%s' is not a valid url."
-msgstr ""
+msgstr "'%s' 不是一个有效字符串。"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:88
 msgid "Attribute 'name' is required"
-msgstr ""
+msgstr "需要 'name' 属性"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:91
 msgid "Name can only contain lower case letters, underscores and numbers"
-msgstr ""
+msgstr "名称只能包含小写字母、下划线和数字"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:94
 msgid "Name must be longer than 2 characters"
-msgstr ""
+msgstr "名称必须大于 2 个字符"
 
 #: galaxy_ng/app/api/v3/serializers/namespace.py:97
 msgid "Name cannot begin with '_'"
-msgstr ""
+msgstr "名称不能以 '_' 开头"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:85
 msgid "Password for proxy authentication."
-msgstr ""
+msgstr "用于代理身份验证的密码。"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:92
 msgid "User for proxy authentication."
-msgstr ""
+msgstr "用于代理身份验证的用户。"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:105
 msgid "Remote password."
-msgstr ""
+msgstr "远程密码。"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:112
 msgid "Remote user."
-msgstr ""
+msgstr "远程用户。"
 
 #: galaxy_ng/app/api/v3/serializers/sync.py:161
 msgid ""
 "Syncing content from community domains without specifying a requirements "
 "file is not allowed."
-msgstr ""
+msgstr "不允许从社区域同步内容而不指定要求文件。"
 
 #: galaxy_ng/app/api/v3/views/sync.py:29
 #, python-format
 msgid "The %s distribution does not have any remotes associated with it."
-msgstr ""
+msgstr "%s 发行版没有任何与之关联的远程设备。"
 
 #: galaxy_ng/app/api/v3/views/sync.py:40
 msgid ""
 "Syncing content from galaxy.ansible.com without specifying a requirements "
 "file is not allowed."
-msgstr ""
+msgstr "在不指定要求文件的情况下，不允许从 galaxy.ansible.com 同步内容。"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:172
 #, python-format
 msgid "Path does not match: \"%s\""
-msgstr ""
+msgstr "路径不匹配：\"%s\""
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:186
 #, python-brace-format
 msgid "Namespace \"{0}\" does not exist."
-msgstr ""
+msgstr "命名空间 \"{0}\" 不存在。"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:279
 #, python-format
 msgid "Unexpected response from content app. Code: %s."
-msgstr ""
+msgstr "来自内容应用的意外响应。代码：%s。"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:301
 #, python-format
 msgid "Collection %s not found"
-msgstr ""
+msgstr "未找到集合 %s"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:309
 #, python-format
 msgid "Repo(s) for moving collection %s not found"
-msgstr ""
+msgstr "未找到用于移动集合的存储库 %s"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:313
 #, python-format
 msgid "Collection %s not found in source repo"
-msgstr ""
+msgstr "源仓库中没有找到集合 %s"
 
 #: galaxy_ng/app/api/v3/viewsets/collection.py:317
 #, python-format
 msgid "Collection %s already found in destination repo"
-msgstr ""
+msgstr "目标仓库中已找到集合 %s"
 
 #: galaxy_ng/app/api/v3/viewsets/namespace.py:61
 #, python-format
 msgid "A namespace named %s already exists."
-msgstr ""
+msgstr "已存在名为 %s 的命名空间。"
 
 #: galaxy_ng/app/exceptions.py:8
 msgid "Data conflicts with existing entity."
-msgstr ""
+msgstr "数据与现有实体冲突。"
 
 #: galaxy_ng/app/tasks/publishing.py:54 galaxy_ng/app/tasks/publishing.py:84
 #, python-format
 msgid "Could not find staging repository: \"%s\""
-msgstr ""
+msgstr "无法找到 staging存储库：\"%s\""
 
 #: galaxy_ng/app/tasks/synclist.py:45
 #, python-format
 msgid "Curating all synclists repos that curate from %s"
-msgstr ""
+msgstr "策展从 %s 中策展的所有同步列表"
 
 #: galaxy_ng/app/tasks/synclist.py:56
 msgid "Synclists curating upstream repo"
-msgstr ""
+msgstr "Synclists 策展上游存储库"
 
 #: galaxy_ng/app/tasks/synclist.py:63
 msgid "Synclists curating upstream repo task"
-msgstr ""
+msgstr "Synclists 策展上游存储库任务"
 
 #: galaxy_ng/app/tasks/synclist.py:91
 #, python-format
 msgid "Finishing curating %s synclist repos based on %s update"
-msgstr ""
+msgstr "根据 %s 更新完成策展 %s 同步列表存储库"
 
 #: galaxy_ng/app/tasks/synclist.py:120
 #, python-format
 msgid ""
 "Applying synclist \"%s\" with policy=%s to curate repo \"%s\" from upstream "
 "repo \"%s\""
-msgstr ""
+msgstr "使用 policy=%s 应用同步列表 \"%s\" 以从上游仓库 \"%s\" 中策展存储库 \"%s\""
 
 #: galaxy_ng/app/tasks/synclist.py:162
 msgid "Unexpected synclist policy {}"
-msgstr ""
+msgstr "意外同步列表策略 {}"

--- a/galaxy_ng/tests/unit/api/test_localization.py
+++ b/galaxy_ng/tests/unit/api/test_localization.py
@@ -117,7 +117,7 @@ class TestLocalization(BaseTestCase):
             response = self._switch_lang_post('ja')
             self.assertEqual(
                 response,
-                'test_groupという名前のグループはすでに存在します。'
+                'test_group という名前のグループはすでに存在します。'
             )
 
             response = self._switch_lang_post('zh')


### PR DESCRIPTION
Signed-off-by: Christian M. Adams <chadams@redhat.com>

Thanks to all of the hard work from @himdel and @jerabekjiri, we now have a translated Automation Hub UI! 

Related UI Localization PR - https://github.com/ansible/ansible-hub-ui/pull/1052

Links
----------------

Related PR's
* https://github.com/ansible/galaxy_ng/pull/882
* https://github.com/ansible/galaxy_ng/wiki/l10n-guide


To check this out for yourself, stand up the galaxy_ng & ansible-hub-ui dev environment, navigate to it in the browser, and select a different language in your browser settings.  Then refresh the page.  
