### PR TITLE
backported-labels workflow: run on stable-* watching for merges, add backported-* label to backported PRs

### DIFF
--- a/.github/workflows/backported-labels.yml
+++ b/.github/workflows/backported-labels.yml
@@ -1,0 +1,32 @@
+name: 'Add backported-* labels'
+
+on:
+  # allow running manually
+  workflow_dispatch:
+  push:
+    branches: [ 'stable-*' ]
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Set $LABEL from branch name'
+      run: |
+        VERSION=`sed 's/^refs\/heads\/stable-//' <<< $GITHUB_REF`
+        LABEL="backported-${VERSION}"
+        echo "LABEL=${LABEL}" >> $GITHUB_ENV
+
+    - uses: actions/checkout@v2
+
+    - name: 'Set $PR to PR number'
+      run: |
+        git log -1 --oneline
+        echo PR=`git log -1 --oneline | perl -ne 'print if s/^.*?\(#(\d+)\).*\(#\d+\).*$/$1/'` >> $GITHUB_ENV
+
+    - name: "Add ${{ env.LABEL }} to #${{ env.PR }}"
+      if: ${{ env.PR }}
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        labels: ${{ env.LABEL }}
+        number: ${{ env.PR }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding a workflow that updates a backported PR with a backported-* label once merged in a stable-* branch.
It's watching for commit messages ending with `foo (#123) (#456)`, and using the penultimate PR number, the format patchback uses.

Identical to the UI version ( https://github.com/ansible/ansible-hub-ui/pull/428 )

Cc @newswangerd 