### PR TITLE
update_manifest: set MANIFEST_GIT_EMAIL, MANIFEST_GIT_USER

### DIFF
--- a/.github/workflows/scripts/update_manifest.sh
+++ b/.github/workflows/scripts/update_manifest.sh
@@ -8,8 +8,8 @@ set -o errexit
 readonly GITHUB_PULL_REQUEST="${GITHUB_PULL_REQUEST:-}"
 readonly GITHUB_BRANCH="${GITHUB_BRANCH:-}"
 
-readonly MANIFESTS_GIT_USER="${MANIFESTS_GIT_USER:-}"
-readonly MANIFESTS_GIT_EMAIL="${MANIFESTS_GIT_EMAIL:-}"
+readonly MANIFESTS_GIT_USER="${MANIFESTS_GIT_USER:-rh-galaxy-droid}"
+readonly MANIFESTS_GIT_EMAIL="${MANIFESTS_GIT_EMAIL:-galaxy_ng+manifests@example.com}"
 readonly MANIFESTS_GIT_URL="git@github.com:RedHatInsights/manifests.git"
 
 readonly MANIFESTS_DIR='/tmp/manifests'


### PR DESCRIPTION
Follow-up to #1033 

The `update_manifest` script gets further now, but [fails](https://github.com/ansible/galaxy_ng/runs/4001929746?check_suite_focus=true) on missing git user/email config... adding default values.

(the values are arbitrary, the UI [uses](https://github.com/ansible/ansible-hub-ui/blob/master/.github/workflows/update-manifest.yml#L12-L13) the same username and ansible-hub-ui+manifest instead of galaxy_ng+manifest as the email)

No-Issue