### PR TITLE
Fix last_sync_task field on sync_all_repos_in_registry task

### DIFF
--- a/CHANGES/1094.bugfix
+++ b/CHANGES/1094.bugfix
@@ -1,0 +1,1 @@
+Remote registry sync status not shown on registry page

--- a/galaxy_ng/app/api/ui/views/sync.py
+++ b/galaxy_ng/app/api/ui/views/sync.py
@@ -72,5 +72,6 @@ class ContainerSyncRegistryView(api_base.APIView):
             kwargs={
                 "registry_pk": str(registry.pk),
             },
+            exclusive_resources=[registry]
         )
         return OperationPostponedResponse(result, request)


### PR DESCRIPTION
Issue: [AAH-1094](https://issues.redhat.com/browse/AAH-1094)

This fixes the API part of issue AAH-1094.

Task field `reserved_resources_record` doesn't get populated on `galaxy_ng.app.tasks.registry_sync.sync_all_repos_in_registry` action. But we still can get the value from `kwargs` field and return `last_sync_field` which is needed for Registry sync status on UI.

![Screenshot from 2021-11-15 16-00-25](https://user-images.githubusercontent.com/19647757/141803971-1d0dccec-8a67-4f6b-ab70-3deb604df929.png)