### PR TITLE
Support IMPORTER_IMAGE_TAG to be defined in config (#1060)

### DIFF
--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -168,6 +168,8 @@ objects:
             value: ${{API_DOMAIN}}
           - name: IMPORTER_JOB_NAMESPACE
             value: ${{IMPORTER_JOB_NAMESPACE}}
+          - name: IMPORTER_IMAGE_TAG
+            value: ${{IMPORTER_IMAGE_TAG}}
           - name: IMPORTER_MEMORY_REQUEST
             value: 1Gi
           - name: IMPORTER_MEMORY_LIMIT
@@ -218,6 +220,8 @@ parameters:
 
 - name: IMPORTER_JOB_NAMESPACE
   required: true
+- name: IMPORTER_IMAGE_TAG
+  value: 'latest'
 - name: CONTENT_ORIGIN
   value: 'localhost'
 - name: API_DOMAIN


### PR DESCRIPTION
The galaxy-importer uses a quay image to run ansible-test sanity as an
openshift job. This change allows this image tag to be set in our
config.

No-Issue