### PR TITLE
Fix insights dev mode ui failing to write /hub/app/node_modules/.cache

### DIFF
--- a/dev/common/docker-compose-ui.yaml
+++ b/dev/common/docker-compose-ui.yaml
@@ -8,11 +8,9 @@ services:
       - "8002:8002"
     volumes:
       - "${ANSIBLE_HUB_UI_PATH}:/hub/app/"
-      # Forces npm to ignore the node_node modules in the volume and look
-      # for it in ../node_modules instead
-      - "nodata:/hub/app/node_modules:ro"
+    tmpfs:
+      # Forces npm to ignore the node_modules in the volume and look
+      # for it in ../node_modules instead, while still being able to write .cache
+      - "/hub/app/node_modules"
     depends_on:
       - api
-
-volumes:
-  nodata: {}

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -114,7 +114,6 @@ services:
 
   swagger-ui:
    image: swaggerapi/swagger-ui
-   container_name: swagger_ui_container
    ports:
       - "8003:8080"
   #  volumes:


### PR DESCRIPTION
`swagger_ui`: remove `container_name` to fix clashes when using `DEV_IMAGE_SUFFIX`:

    ERROR: for swagger-ui  Cannot create container for service swagger-ui: Conflict. The container name "/swagger_ui_container" is already in use by container "ecabb771316cbcdc7310a2329ceda2e9a38680f998f45a4e3fd9332d973b1377". You have to remove (or rename) that container to be able to reuse that name.
    ERROR: Encountered errors while bringing up the project.
￼
and mount `/hub/app/node_modules` as tmpfs, instead of a readonly volume, to let npm write .cache to fix:

    ui_1              | [webpack-cli] [Error: ENOENT: no such file or directory, mkdir '/hub/app/node_modules/.cache'] {
    ui_1              |   errno: -2,
    ui_1              |   code: 'ENOENT',
    ui_1              |   syscall: 'mkdir',
    ui_1              |   path: '/hub/app/node_modules/.cache'
    ui_1              | }
    ui_1              | npm ERR! code ELIFECYCLE
    ui_1              | npm ERR! errno 2
    ui_1              | npm ERR! ansible-hub-ui@0.1.0 start: `NODE_ENV=development webpack serve --host 0.0.0.0 --config config/insights.dev.webpack.config.js`
    ui_1              | npm ERR! Exit status 2
￼
---

With this, I can load https://prod.foo.redhat.com:1337/ansible/automation-hub (but not ci(502)/stage(akamai)).

(TODO for later, the menu is still a bit broken in this model; and Partners are not loading; `Firefox can’t establish a connection to the server at wss://prod.foo.redhat.com:8002/ws`. (no autoreload))