### PR TITLE
ci workflow: add a lint-po task to run gettext linter

### DIFF
--- a/.github/post-job-template.yml.j2
+++ b/.github/post-job-template.yml.j2
@@ -1,12 +1,10 @@
-update_manifest:
 
+  update_manifest:
     runs-on: ubuntu-latest
     needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # include all history
 
       - name: "Set GITHUB_BRANCH"
         run: |
@@ -19,3 +17,14 @@ update_manifest:
           MANIFEST_PASSPHRASE: {{ "${{ secrets.MANIFEST_PASSPHRASE }}" }}
         run: .github/workflows/scripts/update_manifest.sh
         shell: bash
+
+  lint_po:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - run: |
+          pip install lint-po
+          lint-po ./galaxy_ng/locale/*/LC_MESSAGES/*.po

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,15 +193,13 @@ jobs:
           docker exec pulp pip3 list
 
 
+  
   update_manifest:
-
     runs-on: ubuntu-latest
     needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # include all history
 
       - name: "Set GITHUB_BRANCH"
         run: |
@@ -214,3 +212,14 @@ jobs:
           MANIFEST_PASSPHRASE: ${{ secrets.MANIFEST_PASSPHRASE }}
         run: .github/workflows/scripts/update_manifest.sh
         shell: bash
+
+  lint_po:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - run: |
+          pip install lint-po
+          lint-po ./galaxy_ng/locale/*/LC_MESSAGES/*.po

--- a/CHANGES/804.misc
+++ b/CHANGES/804.misc
@@ -1,0 +1,1 @@
+enable lint-po on gettext *.po files


### PR DESCRIPTION
Issue AAH-804
Related to https://github.com/ansible/ansible-hub-ui/pull/1144

lint-po is released as https://pypi.org/project/lint-po/,
so just adding a task to install and run it (and re-running `plugin-template --github galaxy_ng`) :)