### PR TITLE
Fix pulp_installer CI error

### DIFF
--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -54,8 +54,8 @@ class CollectionMetadataSerializer(Serializer):
     repository = serializers.CharField()
 
     description = serializers.CharField()
-    authors = serializers.ListField(serializers.CharField())
-    license = serializers.ListField(serializers.CharField())
+    authors = serializers.ListField(child=serializers.CharField())
+    license = serializers.ListField(child=serializers.CharField())
     tags = serializers.SerializerMethodField()
 
     @extend_schema_field(serializers.ListField)
@@ -74,7 +74,7 @@ class CollectionVersionBaseSerializer(Serializer):
     requires_ansible = serializers.CharField()
     created_at = serializers.DateTimeField(source='pulp_created')
     metadata = CollectionMetadataSerializer(source='*')
-    contents = serializers.ListField(ContentSerializer())
+    contents = serializers.ListField(child=ContentSerializer())
 
 
 class CollectionVersionSerializer(CollectionVersionBaseSerializer):


### PR DESCRIPTION
```
Traceback (most recent call last):
    File "/usr/local/lib/pulp/bin/pulpcore-manager", line 33, in <module>
      sys.exit(load_entry_point('pulpcore', 'console_scripts', 'pulpcore-manager')())
    File "/var/lib/pulp/devel/pulpcore/pulpcore/app/manage.py", line 11, in manage
      execute_from_command_line(sys.argv)
    File "/usr/local/lib/pulp/lib64/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
      utility.execute()
    File "/usr/local/lib/pulp/lib64/python3.8/site-packages/django/core/management/__init__.py", line 395, in execute
      django.setup()
    File "/usr/local/lib/pulp/lib64/python3.8/site-packages/django/__init__.py", line 24, in setup
      apps.populate(settings.INSTALLED_APPS)
    File "/usr/local/lib/pulp/lib64/python3.8/site-packages/django/apps/registry.py", line 122, in populate
      app_config.ready()
    File "/var/lib/pulp/devel/galaxy_ng/galaxy_ng/app/__init__.py", line 12, in ready
      super().ready()
    File "/var/lib/pulp/devel/pulpcore/pulpcore/app/apps.py", line 96, in ready
      self.import_viewsets()
    File "/var/lib/pulp/devel/pulpcore/pulpcore/app/apps.py", line 140, in import_viewsets
      self.viewsets_module = import_module(viewsets_module_name)
    File "/usr/lib64/python3.8/importlib/__init__.py", line 127, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 783, in exec_module
    File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
    File "/var/lib/pulp/devel/galaxy_ng/galaxy_ng/app/viewsets.py", line 6, in <module>
      from galaxy_ng.app.api.ui import serializers
    File "/var/lib/pulp/devel/galaxy_ng/galaxy_ng/app/api/ui/serializers/__init__.py", line 4, in <module>
      from .collection import (
    File "/var/lib/pulp/devel/galaxy_ng/galaxy_ng/app/api/ui/serializers/collection.py", line 46, in <module>
      class CollectionMetadataSerializer(Serializer):
    File "/var/lib/pulp/devel/galaxy_ng/galaxy_ng/app/api/ui/serializers/collection.py", line 57, in CollectionMetadataSerializer
      authors = serializers.ListField(serializers.CharField())
  TypeError: __init__() takes 1 positional argument but 2 were given
```
https://github.com/pulp/pulp_installer/runs/4590178588?check_suite_focus=true#step:7:1634
