### PR TITLE
Keep logs for nightly latest

### DIFF
--- a/.github/workflows/nightly_latest.yml
+++ b/.github/workflows/nightly_latest.yml
@@ -117,11 +117,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
 
-      - name: After failure
-        if: failure()
+      - name: Logs
+        if: always()
         run: |
           echo "Need to debug? Please check: https://github.com/marketplace/actions/debugging-with-tmate"
-          http --timeout 30 --check-status --pretty format --print hb http://pulp/pulp/api/v3/status/ || true
+          http --timeout 30 --check-status --pretty format --print hb https://pulp/pulp/api/v3/status/ || true
           docker images || true
           docker ps -a || true
           docker logs pulp || true


### PR DESCRIPTION
I'm investigating why pulp_installer CI raises errors while nightly latest workflow don't

https://github.com/ansible/galaxy_ng/pull/1086#issuecomment-1005604275

Keeping the logs for successful runs will help with the investigation