### PR TITLE
Makefile: fix bashism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCKER_IMAGE_NAME = localhost/galaxy_ng/galaxy_ng
 RUNNING = $(shell docker ps -q -f name=api)
 
 # if running is empty, then DJ_MANAGER = manage, else DJ_MANAGER = django-admin
-DJ_MANAGER = $(shell if [ "$(RUNNING)" == "" ]; then echo manage; else echo django-admin; fi)
+DJ_MANAGER = $(shell if [ "$(RUNNING)" = "" ]; then echo manage; else echo django-admin; fi)
 
 define exec_or_run
 	# Tries to run on existing container if it exists, otherwise starts a new one.


### PR DESCRIPTION
bash has it's own version of the test(1) command (`[`),
but sh will use `/bin/test`

`/bin/test` does not support `==` for string comparison, `=` is correct
bash test supports both

=> running make anything with non-bash /bin/sh causes:

    $ make dev/bumpversion-patch
    /bin/sh: 1: [: unexpected operator

fixing to use `=` and be sh compatible

No-Issue