### PR TITLE
Fix dispatch call for synclist curate to use new param

### DIFF
--- a/galaxy_ng/app/api/ui/viewsets/my_synclist.py
+++ b/galaxy_ng/app/api/ui/viewsets/my_synclist.py
@@ -40,7 +40,7 @@ class MySyncListViewSet(SyncListViewSet):
         synclist = get_object_or_404(models.SyncList, pk=pk)
         synclist_task = dispatch(
             curate_synclist_repository,
-            resources=[synclist.repository],
+            exclusive_resources=[synclist.repository],
             args=(pk, )
         )
 


### PR DESCRIPTION
# Description 🛠
Fix dispatch call for synclist curate to use new param

No-Issue

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

Note: when merging, include the Jira issue link in the squashed commit