### PR TITLE
Add missing proxy_password to the request on update

### DIFF
--- a/CHANGES/1254.bugfix
+++ b/CHANGES/1254.bugfix
@@ -1,0 +1,1 @@
+Add missing proxy_password if field is set on CollectionRemote update


### PR DESCRIPTION
Issue: [AAH-1254](https://issues.redhat.com/browse/AAH-1254)

# Description 🛠
On authenticating with proxy credentials, if in `write_only_fields` `proxy_password` is set to True and `proxy_password` is empty in update request (`api/automation-hub/content/community/v3/sync/config/`), there is an error from pulp, because of missing `proxy_password`, so we add the existing `proxy_password` from DB to the request.

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [x] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
