### PR TITLE
Combine the copy and remove tasks

### DIFF
--- a/CHANGES/1349.bugfix
+++ b/CHANGES/1349.bugfix
@@ -1,0 +1,1 @@
+Combine copy and remove tasks into single task

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -36,8 +36,7 @@ from galaxy_ng.app.common import metrics
 from galaxy_ng.app.common.parsers import AnsibleGalaxy29MultiPartParser
 from galaxy_ng.app.constants import INBOUND_REPO_NAME_FORMAT, DeploymentMode
 from galaxy_ng.app.tasks import (
-    call_copy_task,
-    call_remove_task,
+    call_move_content_task,
     curate_all_synclist_repository,
     delete_collection,
     delete_collection_version,
@@ -447,8 +446,7 @@ class CollectionVersionMoveViewSet(api_base.ViewSet):
         if collection_version in dest_versions:
             raise NotFound(_('Collection %s already found in destination repo') % version_str)
 
-        copy_task = call_copy_task(collection_version, src_repo, dest_repo)
-        remove_task = call_remove_task(collection_version, src_repo)
+        move_task = call_move_content_task(collection_version, src_repo, dest_repo)
 
         curate_task_id = None
         if settings.GALAXY_DEPLOYMENT_MODE == DeploymentMode.INSIGHTS.value:
@@ -472,8 +470,8 @@ class CollectionVersionMoveViewSet(api_base.ViewSet):
 
         return Response(
             data={
-                'copy_task_id': copy_task.pk,
-                'remove_task_id': remove_task.pk,
+                "copy_task_id": move_task.pk,
+                "remove_task_id": move_task.pk,
                 "curate_all_synclist_repository_task_id": curate_task_id,
             },
             status='202'

--- a/galaxy_ng/app/tasks/__init__.py
+++ b/galaxy_ng/app/tasks/__init__.py
@@ -1,8 +1,8 @@
-from .registry_sync import launch_container_remote_sync, sync_all_repos_in_registry  # noqa: F401
 from .deletion import delete_collection, delete_collection_version  # noqa: F401
-from .promotion import call_copy_task, call_remove_task  # noqa: F401
-from .publishing import import_and_auto_approve, import_and_move_to_staging  # noqa: F401
-from .synclist import curate_all_synclist_repository, curate_synclist_repository  # noqa: F401
 from .index_registry import index_execution_environments_from_redhat_registry  # noqa: F401
+from .promotion import call_move_content_task  # noqa: F401
+from .publishing import import_and_auto_approve, import_and_move_to_staging  # noqa: F401
+from .registry_sync import launch_container_remote_sync, sync_all_repos_in_registry  # noqa: F401
+from .synclist import curate_all_synclist_repository, curate_synclist_repository  # noqa: F401
 
 # from .synchronizing import synchronize  # noqa

--- a/galaxy_ng/app/tasks/promotion.py
+++ b/galaxy_ng/app/tasks/promotion.py
@@ -1,43 +1,39 @@
-from pulpcore.plugin.tasking import dispatch
-from pulp_ansible.app.models import AnsibleRepository, CollectionVersion
-from pulp_ansible.app.tasks.copy import copy_content
+from pulpcore.plugin.tasking import add_and_remove, dispatch
 
 
-def call_copy_task(collection_version, source_repo, dest_repo):
-    """Calls pulp_ansible task to copy content from source to destination repo."""
-    locks = [source_repo, dest_repo]
-    config = [{
-        'source_repo_version': source_repo.latest_version().pk,
-        'dest_repo': dest_repo.pk,
-        'content': [collection_version.pk],
-    }]
+def call_move_content_task(collection_version, source_repo, dest_repo):
+    """Dispatches the move content task
+
+    This is a wrapper to group copy_content and remove_content tasks
+    because those 2 must run in sequence ensuring the same locks.
+
+    """
     return dispatch(
-        copy_content,
-        args=[config],
-        kwargs={},
-        exclusive_resources=locks,
+        move_content,
+        exclusive_resources=[source_repo, dest_repo],
+        kwargs=dict(
+            collection_version_pk=collection_version.pk,
+            source_repo_pk=source_repo.pk,
+            dest_repo_pk=dest_repo.pk,
+        ),
     )
 
 
-def call_remove_task(collection_version, repository):
-    """Calls task to remove content from repo."""
-    remove_task_args = (collection_version.pk, repository.pk)
-    return dispatch(
-        _remove_content_from_repository,
-        args=remove_task_args,
-        kwargs={},
-        exclusive_resources=[repository],
+def move_content(collection_version_pk, source_repo_pk, dest_repo_pk):
+    """Move collection version from one repository to another"""
+
+    content = [collection_version_pk]
+
+    # add content to the destination repo
+    add_and_remove(
+        dest_repo_pk,
+        add_content_units=content,
+        remove_content_units=[],
     )
 
-
-def _remove_content_from_repository(collection_version_pk, repository_pk):
-    """
-    Remove a CollectionVersion from a repository.
-    Args:
-        collection_version_pk: The pk of the CollectionVersion to remove from repository.
-        repository_pk: The pk of the AnsibleRepository to remove the CollectionVersion from.
-    """
-    repository = AnsibleRepository.objects.get(pk=repository_pk)
-    qs = CollectionVersion.objects.filter(pk=collection_version_pk)
-    with repository.new_version() as new_version:
-        new_version.remove_content(qs)
+    # remove content from source repo
+    add_and_remove(
+        source_repo_pk,
+        add_content_units=[],
+        remove_content_units=content,
+    )

--- a/galaxy_ng/app/tasks/publishing.py
+++ b/galaxy_ng/app/tasks/publishing.py
@@ -7,7 +7,7 @@ from pulp_ansible.app.models import AnsibleDistribution, AnsibleRepository, Coll
 from pulp_ansible.app.tasks.collections import import_collection
 from pulpcore.plugin.models import Task
 
-from .promotion import call_copy_task, call_remove_task
+from .promotion import call_move_content_task
 
 log = logging.getLogger(__name__)
 
@@ -57,8 +57,7 @@ def import_and_move_to_staging(temp_file_pk, **kwargs):
     created_collection_versions = get_created_collection_versions()
 
     for collection_version in created_collection_versions:
-        call_copy_task(collection_version, inbound_repo, staging_repo)
-        call_remove_task(collection_version, inbound_repo)
+        call_move_content_task(collection_version, inbound_repo, staging_repo)
 
         if settings.GALAXY_ENABLE_API_ACCESS_LOG:
             _log_collection_upload(
@@ -95,8 +94,7 @@ def import_and_auto_approve(temp_file_pk, **kwargs):
     created_collection_versions = get_created_collection_versions()
 
     for collection_version in created_collection_versions:
-        call_copy_task(collection_version, inbound_repo, golden_repo)
-        call_remove_task(collection_version, inbound_repo)
+        call_move_content_task(collection_version, inbound_repo, golden_repo)
 
         log.info('Imported and auto approved collection artifact %s to repository %s',
                  collection_version.relative_path,


### PR DESCRIPTION
# Description 🛠

For copying and removing content from a repository, currently 2 tasks
are called. Changing to be 1 task so lock and transaction can occur in
a single task. Pulls work done by @rochacbruno from https://github.com/ansible/galaxy_ng/pull/1076.

Issue: AAH-1349

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [x] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [x] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
