### PR TITLE
Cloud: add post deploy tests template

### DIFF
--- a/CHANGES/1212.misc
+++ b/CHANGES/1212.misc
@@ -1,0 +1,1 @@
+Add post stage deploy tests template

--- a/openshift/clowder/deploy-acceptance.yaml
+++ b/openshift/clowder/deploy-acceptance.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: automation-hub-post-deploy-test
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: automation-hub-iqe-${IMAGE_TAG}-${JOBID}
+  spec:
+    appName: automation-hub
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_proxy
+        filter: ''
+        marker: 'stage_health'
+parameters:
+  - name: IMAGE_TAG
+    value: ""
+    required: true
+  - name: JOBID
+    generate: expression
+    from: "[0-9a-z]{5}"


### PR DESCRIPTION
Issue: AAH-1212

# Description 🛠
Add job template to be referenced by the post-deploy-test.yml saas file, which will run the job after a successful deploy to the stage environment.

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [x] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
