### PR TITLE
Check for existing synclist obj before create in RH Auth

### DIFF
--- a/CHANGES/1399.bugfix
+++ b/CHANGES/1399.bugfix
@@ -1,0 +1,1 @@
+Check for existing synclist obj before create in RH Auth


### PR DESCRIPTION
# Description 🛠
Only attempt to create synclist object if it does not exist. This allows
a group to be associated with a synclist object that already exists.

Issue: AAH-1399

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
