### PR TITLE
Update locks on synclist tasks

### DIFF
--- a/CHANGES/1395.bugfix
+++ b/CHANGES/1395.bugfix
@@ -1,0 +1,1 @@
+Update locks on synclist tasks so golden_repo will not be written to during tasks

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -455,16 +455,11 @@ class CollectionVersionMoveViewSet(api_base.ViewSet):
             ).repository
 
             if dest_repo == golden_repo or src_repo == golden_repo:
-                repo_name = golden_repo.name
-                locks = [golden_repo]
-                task_args = (repo_name,)
-                task_kwargs = {}
-
                 curate_task = dispatch(
                     curate_all_synclist_repository,
-                    exclusive_resources=locks,
-                    args=task_args,
-                    kwargs=task_kwargs
+                    shared_resources=[golden_repo],
+                    args=(golden_repo.name,),
+                    kwargs={},
                 )
                 curate_task_id = curate_task.pk
 

--- a/galaxy_ng/app/tasks/synclist.py
+++ b/galaxy_ng/app/tasks/synclist.py
@@ -79,6 +79,7 @@ def curate_all_synclist_repository(upstream_repository_name, **kwargs):
             dispatch(
                 curate_synclist_repository_batch,
                 args=(synclist_ids,),
+                shared_resources=[upstream_repository],
                 exclusive_resources=locks,
                 task_group=task_group,
             )


### PR DESCRIPTION
# Description 🛠
Use shared_resources on calling parent task `curate_all_synclist_repository`
and calling child task `curate_synclist_repository_batch`. This prevents
golden_repo from being written to by another task.

Issue: AAH-1395

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
