### PR TITLE
Add standalone integration testing to CI

### DIFF
--- a/.compose.env.example
+++ b/.compose.env.example
@@ -13,6 +13,9 @@ DEV_SOURCE_PATH='galaxy_ng'
 # and unpin galaxy_ng/setup.py requirements
 LOCK_REQUIREMENTS=1
 
+## Reinstall checkouts on every container launch
+WITH_DEV_INSTALL=1
+
 # If you want to run the UI, clone https://github.com/ansible/ansible-hub-ui
 # and set this to the path for the UI
 # ANSIBLE_HUB_UI_PATH='/absolute/path/to/ansible-hub-ui'

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -1,0 +1,55 @@
+---
+name: Galaxy CI
+on: {pull_request: {branches: ['*']}, push: {branches: ['*']}}
+jobs:
+
+  standalone_integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install docker-compose
+        run: pip3 install --upgrade docker-compose
+
+      - name: collect system info
+        run: whoami; id; pwd; ls -al; uname -a ; df -h .; mount ; cat /etc/issue; docker --version ; ps aux | fgrep -i docker; ls -al /var/run/containerd/containerd.sock
+
+      - name: clone the hub ui repo
+        run: git clone https://github.com/ansible/ansible-hub-ui /tmp/ansible-hub-ui 
+
+      - name: create the .compose.env file
+        run: rm -f .compose.env; cp .compose.env.example .compose.env
+
+      - name: workaround github worker permissions issues
+        run: sed -i.bak 's/PIP_EDITABLE_INSTALL=1/PIP_EDITABLE_INSTALL=0/' .compose.env
+
+      - name: workaround github worker permissions issues
+        run: sed -i.bak 's/WITH_DEV_INSTALL=1/WITH_DEV_INSTALL=0/' .compose.env
+
+      - name: set the hub ui path in .compose.env
+        run: echo "ANSIBLE_HUB_UI_PATH='/tmp/ansible-hub-ui'" >> .compose.env
+
+      - name: disable approval setting override
+        run: sed -i.bak 's/PULP_GALAXY_REQUIRE_CONTENT_APPROVAL/#PULP_GALAXY_REQUIRE_CONTENT_APPROVAL/' dev/standalone/galaxy_ng.env
+
+      - name: build stack and populate data
+        run: make docker/all
+
+      - name: add an api token
+        run: make docker/loadtoken
+
+      - name: add test data
+        run: make docker/load_test_data
+
+      - name: start the compose stack
+        run: ./compose up -d
+
+      - name: give stack some time to spin up
+        run: sleep 120
+
+      - name: run the integration tests
+        run: HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,11 @@ docker/loaddata:  ## Load initial data from fixtures
 
 .PHONY: docker/loadtoken
 docker/loadtoken: 
-	./compose run api manage shell < dev/standalone/create_admin_token.py
+	./compose run --rm api manage shell < dev/standalone/create_admin_token.py
+
+.PHONY: docker/load_test_data
+docker/load_test_data: 
+	./compose run --rm api manage shell < dev/ephemeral/create_objects.py
 
 .PHONY: docker/makemigrations
 docker/makemigrations:   ## Run django migrations

--- a/compose
+++ b/compose
@@ -49,5 +49,6 @@ declare -xr ENABLE_SIGNING="${ENABLE_SIGNING:-1}"
 declare -xr DEV_IMAGE_SUFFIX="${DEV_IMAGE_SUFFIX:-}"
 declare -xr DEV_VOLUME_SUFFIX="${DEV_VOLUME_SUFFIX:-${DEV_IMAGE_SUFFIX}}"
 declare -xr COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-galaxy_ng${DEV_IMAGE_SUFFIX:-}}"
+declare -xr WITH_DEV_INSTALL="${WITH_DEV_INSTALL:-1}"
 
 exec docker-compose "${compose_args[@]}" "$@"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         DEV_VOLUME_SUFFIX: "${DEV_VOLUME_SUFFIX:-${DEV_IMAGE_SUFFIX:-}}"
     image: "localhost/galaxy_ng/galaxy_ng:base${DEV_IMAGE_SUFFIX:-}"
     environment:
-      - "WITH_DEV_INSTALL=1"
+      - "WITH_DEV_INSTALL=${WITH_DEV_INSTALL}"
       - "LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS}"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
       - "COMPOSE_PROFILE=${COMPOSE_PROFILE}"
@@ -38,7 +38,7 @@ services:
     ports:
       - "5001:8000"
     environment:
-      - "WITH_DEV_INSTALL=1"
+      - "WITH_DEV_INSTALL=${WITH_DEV_INSTALL}"
       - "LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS}"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
       - "COMPOSE_PROFILE=${COMPOSE_PROFILE}"
@@ -61,7 +61,7 @@ services:
     image: "localhost/galaxy_ng/galaxy_ng:${COMPOSE_PROFILE}${DEV_IMAGE_SUFFIX:-}"
     command: ['run', 'worker']
     environment:
-      - "WITH_DEV_INSTALL=1"
+      - "WITH_DEV_INSTALL=${WITH_DEV_INSTALL}"
       - "LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS}"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
       - "COMPOSE_PROFILE=${COMPOSE_PROFILE}"
@@ -86,7 +86,7 @@ services:
     ports:
       - "24816:24816"
     environment:
-      - "WITH_DEV_INSTALL=1"
+      - "WITH_DEV_INSTALL=${WITH_DEV_INSTALL}"
       - "LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS}"
       - "DEV_SOURCE_PATH=${DEV_SOURCE_PATH}"
       - "COMPOSE_PROFILE=${COMPOSE_PROFILE}"

--- a/galaxy_ng/tests/integration/api/test_openapi.py
+++ b/galaxy_ng/tests/integration/api/test_openapi.py
@@ -124,7 +124,7 @@ def test_openapi_bindings_generation(ansible_config):
 
         properties = '--additional-properties=packageName=pulpcore.client.galaxy_ng'
         properties += ',projectName=galaxy_ng-client'
-        properties += f',packageVersion={version}',
+        properties += f',packageVersion={version}'
 
         cmd = [
             'docker',


### PR DESCRIPTION
# Description 🛠
Runs integration tests against the standalone stack.

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
