### PR TITLE
Add command to set retain repo versions on repos

### DIFF
--- a/galaxy_ng/app/management/commands/set-retain-repo-versions.py
+++ b/galaxy_ng/app/management/commands/set-retain-repo-versions.py
@@ -1,0 +1,73 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from pulp_ansible.app.models import AnsibleRepository
+
+
+class Command(BaseCommand):
+    """This command sets retain repo versions for repositories
+
+    Example:
+
+    django-admin set-retain-repo-versions --value=1 --repository=<repo_name>
+    django-admin set-retain-repo-versions --value=1 --repository="*"
+    django-admin set-retain-repo-versions --value=1 --repository="*" --exclude=<repo_name>
+    """
+
+    def echo(self, message):
+        self.stdout.write(self.style.SUCCESS(message))
+
+    def add_arguments(self, parser):
+        parser.add_argument("--value", type=int, help="Value to set", required=True)
+        parser.add_argument("--repository", type=str, help="Repository name", required=True)
+        parser.add_argument(
+            "--exclude", type=str, help="Repository name to exclude", required=False, default=None
+        )
+        parser.add_argument(
+            "-y",
+            "--yes",
+            action="store_true",
+            help="Skip confirmation",
+            default=False,
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+
+        repository = options["repository"].split(",")
+        value = options["value"]
+        exclude = options["exclude"].split(",") if options["exclude"] else []
+
+        if "*" in repository:
+            repositories = AnsibleRepository.objects.all()
+        else:
+            repositories = AnsibleRepository.objects.filter(name__in=repository)
+
+        if exclude:
+            repositories = repositories.exclude(name__in=exclude)
+
+        repo_list = repositories.values_list("name", flat=True)
+
+        if not options["yes"]:
+            confirm = input(
+                f"This will set retain_repo_versions to {value} for {len(repo_list)} repositories, "
+                f"repo_list[:20]={repo_list[:20]}\n"
+                "Proceed? (Y/n)"
+            ).lower()
+            while True:
+                if confirm not in ("y", "n", "yes", "no"):
+                    confirm = input('Please enter either "y/yes" or "n/no": ')
+                    continue
+                if confirm in ("y", "yes"):
+                    break
+                else:
+                    self.echo("Process canceled.")
+                    return
+
+        with transaction.atomic():
+            for repo in repositories:
+                repo.retain_repo_versions = value
+                repo.save()
+
+        self.echo(
+            f"Successfully set retain repo versions to {value} for {len(repo_list)} repositories"
+        )

--- a/galaxy_ng/tests/unit/app/management/commands/test_set_retain_repo_versions.py
+++ b/galaxy_ng/tests/unit/app/management/commands/test_set_retain_repo_versions.py
@@ -1,0 +1,68 @@
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+from pulp_ansible.app.models import AnsibleRepository
+
+
+CMD = "set-retain-repo-versions"
+
+
+class TestSetRetainRepoVersionsCommand(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.original_data = list(
+            AnsibleRepository.objects.all().values("name", "retain_repo_versions")
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        for data in cls.original_data:
+            repo = AnsibleRepository.objects.get(name=data["name"])
+            repo.retain_repo_versions = data["retain_repo_versions"]
+            repo.save()
+
+    def test_command_output(self):
+        with self.assertRaisesMessage(
+            CommandError, "Error: the following arguments are required: --value, --repository"
+        ):
+            call_command(CMD, "--yes")
+
+    def test_set_all_to_2(self):
+        """All the repos gets retain_repo_versions set to 2"""
+        call_command(CMD, "--yes", "--value", "2", "--repository", "*")
+        for repo in AnsibleRepository.objects.all():
+            self.assertEqual(repo.retain_repo_versions, 2)
+
+    def test_set_only_published_to_1000(self):
+        """Only published is set to 1000"""
+        repo = AnsibleRepository.objects.get(name="published")
+        repo.retain_repo_versions = 1
+        repo.save()
+        call_command(CMD, "--yes", "--value", "1000", "--repository", "published")
+        repo = AnsibleRepository.objects.get(name="published")
+
+        self.assertEqual(repo.retain_repo_versions, 1000)
+
+        for repo in AnsibleRepository.objects.exclude(name="published"):
+            self.assertNotEqual(repo.retain_repo_versions, 1000)
+
+    def test_set_only_published_and_stating_to_2000(self):
+        """Only published,staging is set to 2000"""
+        AnsibleRepository.objects.filter(name__in=["published", "staging"]).update(
+            retain_repo_versions=1
+        )
+        call_command(CMD, "--yes", "--value", "2000", "--repository", "published,staging")
+
+        for repo in AnsibleRepository.objects.filter(name__in=["published", "staging"]):
+            self.assertEqual(repo.retain_repo_versions, 2000)
+
+        for repo in AnsibleRepository.objects.exclude(name__in=["published", "staging"]):
+            self.assertNotEqual(repo.retain_repo_versions, 2000)
+
+    def test_set_all_to_10_excluding_published(self):
+        """All the repos gets retain_repo_versions set to 10 except published"""
+        call_command(CMD, "--yes", "--value", "10", "--repository", "*", "--exclude", "published")
+        for repo in AnsibleRepository.objects.exclude(name="published"):
+            self.assertEqual(repo.retain_repo_versions, 10)
+        published = AnsibleRepository.objects.get(name="published")
+        self.assertNotEqual(published.retain_repo_versions, 10)


### PR DESCRIPTION
NoIssue

# Description 🛠
```bash
[galaxy@468674a141e5 /]$ django-admin set-retain-repo-versions
Usage: django-admin set-retain-repo-versions [-h] --value VALUE --repository REPOSITORY [--exclude EXCLUDE] [-y] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH]
                                             [--traceback] [--no-color] [--force-color] [--skip-checks]
django-admin set-retain-repo-versions: error: the following arguments are required: --value, --repository

[galaxy@468674a141e5 /]$ django-admin set-retain-repo-versions --value=2 --repository="*"
This will set the retain repo versions  to 2 for <QuerySet ['published', 'rejected', 'community', 'rh-certified', 'staging', 'inbound-test', 'inbound-footest']>
Proceed? (Y/n)n
Process canceled.

[galaxy@468674a141e5 /]$ django-admin set-retain-repo-versions --value=2 --repository="*" --exclude=published
This will set the retain repo versions  to 2 for <QuerySet ['rejected', 'community', 'rh-certified', 'staging', 'inbound-test', 'inbound-footest']>
Proceed? (Y/n)n
Process canceled.

[galaxy@468674a141e5 /]$ django-admin set-retain-repo-versions --value=2 --repository="published,staging"
This will set the retain repo versions  to 2 for <QuerySet ['published', 'staging']>
Proceed? (Y/n)n
Process canceled.

[galaxy@468674a141e5 /]$ django-admin set-retain-repo-versions --value=2 --repository="*" --exclude=published
This will set the retain repo versions  to 2 for <QuerySet ['rejected', 'community', 'rh-certified', 'staging', 'inbound-test', 'inbound-footest']>
Proceed? (Y/n)y
Successfully set retain repo versions to 2 for <QuerySet ['rejected', 'community', 'rh-certified', 'staging', 'inbound-test', 'inbound-footest']>
```


# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
