### PR TITLE
Clowder: parameterize ENABLE_SIGNING and GNUPGHOME

### DIFF
--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -117,9 +117,9 @@ objects:
           - name: prometheus_multiproc_dir
             value: ${PROMETHEUS_DIR}
           - name: ENABLE_SIGNING
-            value: "1"
+            value: ${ENABLE_SIGNING}
           - name: GNUPGHOME
-            value: '/tmp/ansible/.gnupg'
+            value: ${GNUPGHOME}
         volumeMounts:
           - name: pulp-key
             mountPath: /etc/pulp/certs
@@ -171,9 +171,9 @@ objects:
           - name: PULP_REDIS_SSL
             value: ${REDIS_SSL}
           - name: ENABLE_SIGNING
-            value: "1"
+            value: ${ENABLE_SIGNING}
           - name: GNUPGHOME
-            value: '/tmp/ansible/.gnupg'
+            value: ${GNUPGHOME}
         volumeMounts:
           - name: pulp-key
             mountPath: /etc/pulp/certs
@@ -238,9 +238,9 @@ objects:
           - name: PULP_REDIS_SSL
             value: ${REDIS_SSL}
           - name: ENABLE_SIGNING
-            value: "1"
+            value: ${ENABLE_SIGNING}
           - name: GNUPGHOME
-            value: '/tmp/ansible/.gnupg'
+            value: ${GNUPGHOME}
         volumeMounts:
           - name: importer-config
             mountPath: /etc/galaxy-importer
@@ -311,6 +311,10 @@ parameters:
   value: "false"
 - name: PROMETHEUS_DIR
   value: "/tmp"
+- name: ENABLE_SIGNING
+  value: "1"
+- name: GNUPGHOME
+  value: "/tmp/ansible/.gnupg"
 
 # nginx resource requirements
 - name: NGINX_REPLICAS


### PR DESCRIPTION
No-issue

# Description 🛠
parameterize ENABLE_SIGNING and GNUPGHOME envvars in the clowder config to allow ephemeral to be deployed differently from stage and prod

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
