### PR TITLE
convert post-deploy-test to jenkins webhook

### DIFF
--- a/openshift/clowder/deploy-acceptance.yaml
+++ b/openshift/clowder/deploy-acceptance.yaml
@@ -4,18 +4,93 @@ kind: Template
 metadata:
   name: automation-hub-post-deploy-test
 objects:
-- apiVersion: cloud.redhat.com/v1alpha1
-  kind: ClowdJobInvocation
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: entrypoint
+  data:
+    run_iqe.sh: |
+      #!/bin/bash
+
+      # trigger build
+      BUILD_NUM=$(curl --silent ${JENKINS_JOB_URL}/api/json | jq '.nextBuildNumber')
+      curl -X POST -H "Authorization: Bearer ${JENKINS_TOKEN}" ${JENKINS_JOB_URL}/buildWithParameters
+
+      # verify build started
+      BUILD_STATUS=$(curl --silent ${JENKINS_JOB_URL}/${BUILD_NUM}/api/json | jq '.building')
+      if [ -n "${BUILD_STATUS}" ]; then
+        echo "Jenkins job triggered: ${JENKINS_JOB_URL}/${BUILD_NUM}/"
+        echo "waiting for build to complete..."
+      else
+        echo "Failed to trigger ${JENKINS_JOB_URL}"
+        exit 1
+      fi
+
+      # wait for build to complete
+      LAST_COMPLETE_BUILD=$(curl --silent ${JENKINS_JOB_URL}/api/json | jq '.lastCompletedBuild.number')
+      while [ ${LAST_COMPLETE_BUILD} -lt ${BUILD_NUM} ]; do
+        sleep 60
+        LAST_COMPLETE_BUILD=$(curl --silent ${JENKINS_JOB_URL}/api/json | jq '.lastCompletedBuild.number')
+      done
+
+      # get build status
+      curl --silent ${JENKINS_JOB_URL}/${BUILD_NUM}/consoleText
+      BUILD_RESULT=$(curl --silent ${JENKINS_JOB_URL}/${BUILD_NUM}/api/json | jq '.result')
+      if [ "${BUILD_RESULT}" = "\"SUCCESS\"" ]; then
+        exit 0
+      else
+        exit 1
+      fi
+
+- apiVersion: batch/v1
+  kind: Job
   metadata:
     name: automation-hub-iqe-${IMAGE_TAG}-${JOBID}
   spec:
-    appName: automation-hub
-    testing:
-      iqe:
-        debug: false
-        dynaconfEnvName: stage_proxy
-        filter: ''
-        marker: 'stage_health'
+    backoffLimit: 5
+    template:
+      spec:
+        restartPolicy: Never
+        imagePullSecrets:
+          - name: quay-cloudservices-pull
+        containers:
+          - image: quay.io/cloudservices/iqe-tests:automation-hub
+            imagePullPolicy: Always
+            name: automation-hub-iqe
+            resources:
+              limits:
+                cpu: ${IQE_CPU_LIMIT}
+                memory: ${IQE_MEMORY_LIMIT}
+              requests:
+                cpu: ${IQE_CPU_REQUEST}
+                memory: ${IQE_MEMORY_REQUEST}
+            command:
+              - /run_iqe.sh
+            env:
+              - name: JENKINS_JOB_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: iqe-jenkins
+                    key: job-url
+              - name: JENKINS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: iqe-jenkins
+                    key: token
+            volumeMounts:
+            - name: entrypoint
+              mountPath: /run_iqe.sh
+              subPath: run_iqe.sh
+              readOnly: true
+        volumes:
+          - name: entrypoint
+            configMap:
+              name: entrypoint
+              items:
+                - key: run_iqe.sh
+                  path: run_iqe.sh
+              defaultMode: 0555
+
 parameters:
   - name: IMAGE_TAG
     value: ""
@@ -23,3 +98,11 @@ parameters:
   - name: JOBID
     generate: expression
     from: "[0-9a-z]{5}"
+  - name: IQE_MEMORY_REQUEST
+    value: 64Mi
+  - name: IQE_MEMORY_LIMIT
+    value: 128Mi
+  - name: IQE_CPU_REQUEST
+    value: 50m
+  - name: IQE_CPU_LIMIT
+    value: 200m


### PR DESCRIPTION
Issue: AAH-1212

# Description 🛠
Convert the post-deploy-test that runs after a stage deploy from a ClowdJobInvocation to a Job that issues a webhook to kick off the IQE tests via Jenkins.

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [x] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [x] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [x] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [x] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
