### PR TITLE
Collection Detail Api -  Add Deprecated info

### DIFF
--- a/CHANGES/1025.misc
+++ b/CHANGES/1025.misc
@@ -1,0 +1,1 @@
+Add deprecated to the CollectionVersionDetailSerializer 

--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -99,7 +99,8 @@ class CollectionVersionSerializer(CollectionVersionBaseSerializer):
 
 class CollectionVersionDetailSerializer(CollectionVersionBaseSerializer):
     docs_blob = serializers.JSONField()
-
+    deprecated = serializers.BooleanField()
+    
 
 class CollectionVersionSummarySerializer(Serializer):
     version = serializers.CharField()

--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -100,7 +100,7 @@ class CollectionVersionSerializer(CollectionVersionBaseSerializer):
 class CollectionVersionDetailSerializer(CollectionVersionBaseSerializer):
     docs_blob = serializers.JSONField()
     deprecated = serializers.BooleanField()
-    
+
 
 class CollectionVersionSummarySerializer(Serializer):
     version = serializers.CharField()


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1025

Current serializer for Collection detail lacks information about deprecation. This PR adds it.