### PR TITLE
Set signing keyring for c.rh.c environments

### DIFF
--- a/CHANGES/1371.misc
+++ b/CHANGES/1371.misc
@@ -1,0 +1,1 @@
+Set signing keyring for c.rh.c environments

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -36,6 +36,7 @@ RUN set -ex; \
     PULP_CONTENT_ORIGIN=x django-admin collectstatic && \
     install -dm 0775 -o galaxy /var/lib/pulp/artifact \
                                /var/lib/pulp/tmp \
+                               /etc/pulp/certs \
                                /tmp/ansible && \
     install -Dm 0644 /app/ansible.cfg /etc/ansible/ansible.cfg && \
     install -Dm 0644 /app/docker/etc/settings.py /etc/pulp/settings.py && \

--- a/dev/Dockerfile.base
+++ b/dev/Dockerfile.base
@@ -86,10 +86,12 @@ RUN set -ex; \
              /var/lib/pulp/artifact \
              /var/lib/pulp/tmp \
              /var/lib/pulp/scripts \
+             /etc/pulp/certs/ \
              /tmp/ansible \
     && chown ${USER_NAME}:${USER_GROUP} /var/lib/pulp/artifact \
     && chown ${USER_NAME}:${USER_GROUP} /var/lib/pulp/tmp \
     && chown ${USER_NAME}:${USER_GROUP} /var/lib/pulp/scripts \
+    && chown ${USER_NAME}:${USER_GROUP} /etc/pulp/certs \
     && chown ${USER_NAME}:${USER_GROUP} \
         /tmp/ansible \
         /etc/ansible \

--- a/dev/common/collection_sign.sh
+++ b/dev/common/collection_sign.sh
@@ -9,6 +9,7 @@ PASSWORD="Galaxy2022"
 # Create a detached signature
 gpg --quiet --batch --pinentry-mode loopback --yes --passphrase \
    $PASSWORD --homedir ~/.gnupg/ --detach-sign --default-key $ADMIN_ID \
+   --no-default-keyring --keyring /etc/pulp/certs/galaxy.kbx \
    --armor --output $SIGNATURE_PATH $FILE_PATH
 
 # Check the exit status

--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -28,7 +28,7 @@ objects:
     namespace: automation-hub
   data:
     collection_sign.sh: |
-      IyEvYmluL2Jhc2gKCkZJTEVfUEFUSD0kMQpTSUdOQVRVUkVfUEFUSD0iJDEuYXNjIgoKQURNSU5fSUQ9ImdhbGF4eTNAYW5zaWJsZS5jb20iClBBU1NXT1JEPSJHYWxheHkyMDIyIgoKIyBDcmVhdGUgYSBkZXRhY2hlZCBzaWduYXR1cmUKZ3BnIC0tcXVpZXQgLS1iYXRjaCAtLXBpbmVudHJ5LW1vZGUgbG9vcGJhY2sgLS15ZXMgLS1wYXNzcGhyYXNlICAgJFBBU1NXT1JEIC0taG9tZWRpciAvdG1wL2Fuc2libGUvLmdudXBnIC0tZGV0YWNoLXNpZ24gLS1kZWZhdWx0LWtleSAkQURNSU5fSUQgICAtLWFybW9yIC0tb3V0cHV0ICRTSUdOQVRVUkVfUEFUSCAkRklMRV9QQVRICgojIENoZWNrIHRoZSBleGl0IHN0YXR1cwpTVEFUVVM9JD8KaWYgWyAkU1RBVFVTIC1lcSAwIF07IHRoZW4KICBlY2hvIHtcImZpbGVcIjogXCIkRklMRV9QQVRIXCIsIFwic2lnbmF0dXJlXCI6IFwiJFNJR05BVFVSRV9QQVRIXCJ9CmVsc2UKICBleGl0ICRTVEFUVVMKZmkK
+      IyEvYmluL2Jhc2gKCkZJTEVfUEFUSD0kMQpTSUdOQVRVUkVfUEFUSD0iJDEuYXNjIgoKQURNSU5fSUQ9ImdhbGF4eTNAYW5zaWJsZS5jb20iClBBU1NXT1JEPSJHYWxheHkyMDIyIgpLRVlSSU5HPSIvZXRjL3B1bHAvY2VydHMvZ2FsYXh5LmtieCIKR05VUEdIT01FPSIvdG1wL2Fuc2libGUvLmdudXBnIgoKIyBDcmVhdGUgYSBkZXRhY2hlZCBzaWduYXR1cmUKZ3BnIC0tcXVpZXQgLS1iYXRjaCAtLW5vLWRlZmF1bHQta2V5cmluZyAtLWtleXJpbmcgJEtFWVJJTkcgLS1waW5lbnRyeS1tb2RlIGxvb3BiYWNrIC0teWVzIC0tcGFzc3BocmFzZSAgICRQQVNTV09SRCAtLWhvbWVkaXIgJEdOVVBHSE9NRSAtLWRldGFjaC1zaWduIC0tZGVmYXVsdC1rZXkgJEFETUlOX0lEICAgLS1hcm1vciAtLW91dHB1dCAkU0lHTkFUVVJFX1BBVEggJEZJTEVfUEFUSAoKIyBDaGVjayB0aGUgZXhpdCBzdGF0dXMKU1RBVFVTPSQ/CmlmIFsgJFNUQVRVUyAtZXEgMCBdOyB0aGVuCiAgZWNobyB7XCJmaWxlXCI6IFwiJEZJTEVfUEFUSFwiLCBcInNpZ25hdHVyZVwiOiBcIiRTSUdOQVRVUkVfUEFUSFwifQplbHNlCiAgZXhpdCAkU1RBVFVTCmZpCg==
 
 - apiVersion: v1
   kind: ConfigMap
@@ -122,7 +122,8 @@ objects:
             value: ${GNUPGHOME}
         volumeMounts:
           - name: pulp-key
-            mountPath: /etc/pulp/certs
+            mountPath: /etc/pulp/certs/database_fields.symmetric.key
+            subPath: database_fields.symmetric.key
             readOnly: true
           - name: signing-gpg-key
             mountPath: /tmp/ansible-sign.key
@@ -176,7 +177,8 @@ objects:
             value: ${GNUPGHOME}
         volumeMounts:
           - name: pulp-key
-            mountPath: /etc/pulp/certs
+            mountPath: /etc/pulp/certs/database_fields.symmetric.key
+            subPath: database_fields.symmetric.key
             readOnly: true
           - name: signing-gpg-key
             mountPath: /tmp/ansible-sign.key
@@ -245,7 +247,8 @@ objects:
           - name: importer-config
             mountPath: /etc/galaxy-importer
           - name: pulp-key
-            mountPath: /etc/pulp/certs
+            mountPath: /etc/pulp/certs/database_fields.symmetric.key
+            subPath: database_fields.symmetric.key
             readOnly: true
           - name: signing-gpg-key
             mountPath: /tmp/ansible-sign.key


### PR DESCRIPTION
# Description 🛠
* create `/etc/pulp/certs` directory with proper permissions in dockerfile
* set keyring to /etc/pulp/certs/galaxy.kbx in entrypoint.sh and collection_sign.sh
* split setup_signing_service to separate keyring generation
* utilize `ENABLE_SIGNING` variable with additional option to setup keyring independently of setting up signing
* update pulp-key volume mounts to allow sharing /etc/pulp/certs

Issue: AAH-1371

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
