### PR TITLE
Reorder lint_po to be before longer pulp checks

### DIFF
--- a/.github/post-job-template.yml.j2
+++ b/.github/post-job-template.yml.j2
@@ -17,14 +17,3 @@
           MANIFEST_PASSPHRASE: {{ "${{ secrets.MANIFEST_PASSPHRASE }}" }}
         run: .github/workflows/scripts/update_manifest.sh
         shell: bash
-
-  lint_po:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - run: |
-          pip install lint-po
-          lint-po ./galaxy_ng/locale/*/LC_MESSAGES/*.po

--- a/.github/pre-job-template.yml.j2
+++ b/.github/pre-job-template.yml.j2
@@ -16,3 +16,14 @@ check_commit:
           END_COMMIT: {{ "${{ github.event.after }}" }}
         run: |
           python .ci/scripts/validate_commit_message_custom.py
+
+  lint_po:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - run: |
+          pip install lint-po
+          lint-po ./galaxy_ng/locale/*/LC_MESSAGES/*.po

--- a/.github/pre-job-template.yml.j2
+++ b/.github/pre-job-template.yml.j2
@@ -19,7 +19,6 @@ check_commit:
 
   lint_po:
     runs-on: ubuntu-latest
-    needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,17 @@ jobs:
         run: |
           python .ci/scripts/validate_commit_message_custom.py
 
+  lint_po:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - run: |
+          pip install lint-po
+          lint-po ./galaxy_ng/locale/*/LC_MESSAGES/*.po
+
   lint:
     runs-on: ubuntu-latest
     needs: check_commit
@@ -222,14 +233,3 @@ jobs:
           MANIFEST_PASSPHRASE: ${{ secrets.MANIFEST_PASSPHRASE }}
         run: .github/workflows/scripts/update_manifest.sh
         shell: bash
-
-  lint_po:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - run: |
-          pip install lint-po
-          lint-po ./galaxy_ng/locale/*/LC_MESSAGES/*.po

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
 
   lint_po:
     runs-on: ubuntu-latest
-    needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Move `lint_po` ci check before checks such as `test (pulp)`, since linting issues fail `test (pulp)` before `lint_po` can run.