### PR TITLE
Maintain partner engineering group in insights mode

### DIFF
--- a/CHANGES/1361.misc
+++ b/CHANGES/1361.misc
@@ -1,0 +1,1 @@
+Maintain partner engineering group in insights mode

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,6 +10,7 @@ readonly DEV_SOURCE_PATH="${DEV_SOURCE_PATH:-}"
 readonly LOCK_REQUIREMENTS="${LOCK_REQUIREMENTS:-1}"
 readonly WAIT_FOR_MIGRATIONS="${WAIT_FOR_MIGRATIONS:-0}"
 readonly ENABLE_SIGNING="${ENABLE_SIGNING:-0}"
+readonly PULP_GALAXY_DEPLOYMENT_MODE="${PULP_GALAXY_DEPLOYMENT_MODE:-}"
 
 
 log_message() {
@@ -89,6 +90,10 @@ run_service() {
 
     process_init_files /entrypoints.d/*
 
+    if [[ "$PULP_GALAXY_DEPLOYMENT_MODE" = "insights" ]]; then
+        django-admin maintain-pe-group
+    fi
+
     if [[ "$ENABLE_SIGNING" -eq "1" ]]; then
         setup_signing_service
     fi
@@ -105,7 +110,7 @@ run_manage() {
     if [[ "$ENABLE_SIGNING" -eq "1" ]]; then
         setup_signing_service
     fi
-    
+
     exec django-admin "$@"
 }
 

--- a/galaxy_ng/app/management/commands/maintain-pe-group.py
+++ b/galaxy_ng/app/management/commands/maintain-pe-group.py
@@ -1,0 +1,51 @@
+from django.core.management import BaseCommand
+from guardian.shortcuts import assign_perm
+
+from galaxy_ng.app.models.auth import Group
+
+PE_GROUP_NAME = "system:partner-engineers"
+
+
+class Command(BaseCommand):
+    """
+    This command creates or updates a partner engineering group
+    with a standard set of permissions. Intended to be used for
+    settings.GALAXY_DEPLOYMENT_MODE==insights.
+
+    $ django-admin maintain-pe-group
+    """
+
+    help = "Creates/updates partner engineering group with permissions"
+
+    def handle(self, *args, **options):
+        pe_group, created = Group.objects.get_or_create(name=PE_GROUP_NAME)
+        if created:
+            self.stdout.write(f"Created group '{PE_GROUP_NAME}'")
+        else:
+            self.stdout.write(f"Group '{PE_GROUP_NAME}' already exists")
+
+        pe_perms = [
+            # groups
+            "galaxy.view_group",
+            "galaxy.delete_group",
+            "galaxy.add_group",
+            "galaxy.change_group",
+            # users
+            "galaxy.view_user",
+            "galaxy.delete_user",
+            "galaxy.add_user",
+            "galaxy.change_user",
+            # collections
+            "ansible.modify_ansible_repo_content",
+            "ansible.delete_collection",
+            # namespaces
+            "galaxy.add_namespace",
+            "galaxy.change_namespace",
+            "galaxy.upload_to_namespace",
+            "galaxy.delete_namespace",
+        ]
+
+        for perm in pe_perms:
+            assign_perm(perm, pe_group)
+
+        self.stdout.write(f"Permissions assigned to '{PE_GROUP_NAME}'")


### PR DESCRIPTION
# Description 🛠
On container setup, after migrations are run, run a
django management command to create or update a
partner engineering group with a standard set of permissions.

Issue: AAH-1361

# Reviewer Checklists  👀
Developer reviewer:
- [x] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [x] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
