### PR TITLE
Allowing unauth access when the settings is set

### DIFF
--- a/CHANGES/1386.bugfix
+++ b/CHANGES/1386.bugfix
@@ -1,0 +1,1 @@
+Fixes forbidden message when installing from ansible-galaxy a public collection and the settings has enable unautheticated download.

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -166,6 +166,10 @@ class AccessPolicyBase(AccessPolicyFromDB):
         return settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS
 
 
+class AppRootAccessPolicy(AccessPolicyBase):
+    NAME = "AppRootViewSet"
+
+
 class NamespaceAccessPolicy(AccessPolicyBase):
     NAME = "NamespaceViewSet"
 

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -98,7 +98,28 @@ STANDALONE_STATEMENTS = {
             "action": "*",
             "principal": "authenticated",
             "effect": "allow",
+        },
+
+        # we need the redirect in order to support anonymous downloads when the options are enabled
+        {
+            "action": "*",
+            "principal": "anonymous",
+            "effect": "allow",
         }
+    ],
+
+    "AppRootViewSet": [
+        {
+            "action": ["retrieve"],
+            "principal": "authenticated",
+            "effect": "allow",
+        },
+        {
+            "action": ["retrieve"],
+            "principal": "anonymous",
+            "effect": "allow",
+            "condition": "unauthenticated_collection_download_enabled",
+        },
     ],
 
     'NamespaceViewSet': [

--- a/galaxy_ng/app/api/views.py
+++ b/galaxy_ng/app/api/views.py
@@ -7,10 +7,10 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from pulp_ansible.app.models import AnsibleDistribution
 
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
+from galaxy_ng.app.access_control import access_policy
 from galaxy_ng.app.api import base as api_base
 
 
@@ -31,7 +31,8 @@ VERSIONS = {
 
 
 class ApiRootView(api_base.APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [access_policy.AppRootAccessPolicy]
+    action = "retrieve"
 
     def get(self, request, *args, **kwargs):
         """
@@ -50,7 +51,8 @@ class ApiRootView(api_base.APIView):
 
 
 class ApiRedirectView(api_base.APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [access_policy.AppRootAccessPolicy]
+    action = "retrieve"
 
     """Redirect requests to /api/automation-hub/api/ to /api/automation-hub/
 

--- a/galaxy_ng/tests/functional/cli/test_collection_install.py
+++ b/galaxy_ng/tests/functional/cli/test_collection_install.py
@@ -2,6 +2,7 @@
 from os import path
 import subprocess
 import tempfile
+import pytest
 
 from galaxy_ng.tests.functional.utils import TestCaseUsingBindings
 from galaxy_ng.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -10,11 +11,11 @@ from galaxy_ng.tests.functional.utils import set_up_module as setUpModule  # noq
 class InstallCollectionTestCase(TestCaseUsingBindings):
     """Test whether ansible-galaxy can install a Collection hosted by Pulp."""
 
-    def install_collection(self, collection_name, repo_name="community"):
+    def install_collection(self, collection_name, auth=True, repo_name="community"):
         """Install given collection."""
 
         # Preapare ansible.cfg for ansible-galaxy CLI
-        self.update_ansible_cfg(repo_name)
+        self.update_ansible_cfg(repo_name, auth)
 
         # In a temp dir, install a collection using ansible-galaxy CLI
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -40,3 +41,14 @@ class InstallCollectionTestCase(TestCaseUsingBindings):
         # Sync the repository.
         self.sync_repo(f"collections:\n  - {collection_name}")
         self.install_collection(collection_name)
+
+    def test_install_collection_unauthenticated(self):
+        """Test whether ansible-galaxy can download a Collection without auth."""
+
+        pytest.skip(
+            "GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD is not configurable yet.")
+
+        collection_name = "ansible.posix"
+        # Sync the repository.
+        self.sync_repo(f"collections:\n  - {collection_name}")
+        self.install_collection(collection_name, auth=False)

--- a/galaxy_ng/tests/functional/utils.py
+++ b/galaxy_ng/tests/functional/utils.py
@@ -212,9 +212,9 @@ class TestCaseUsingBindings(PulpTestCase):
         with open("ansible.cfg", "r") as f:
             cls.previous_ansible_cfg = f.read()
 
-    def update_ansible_cfg(self, base_path):
+    def update_ansible_cfg(self, base_path, auth=True):
         """Update ansible.cfg to use the given base_path."""
-        token = self.get_token()
+        token = f"token={self.get_token()}" if auth else ""
         ansible_cfg = (
             f"{self.previous_ansible_cfg}\n"
             "[galaxy]\n"
@@ -223,7 +223,7 @@ class TestCaseUsingBindings(PulpTestCase):
             "[galaxy_server.community_repo]\n"
             f"url={self.cfg.get_base_url()}"
             f"{self.galaxy_api_prefix}/content/{base_path}/\n"
-            f"token={token}"
+            f"{token}"
         )
         with open("ansible.cfg", "w") as f:
             f.write(ansible_cfg)


### PR DESCRIPTION
Issue: AAH-1386

# Description 🛠
The settings flag `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD` only affected the UI until now. So the `ansible-galaxy` installs were failing as the could not access the `/content/...` path without authentication. This PR aims to fix that.

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
