### PR TITLE
[WIP] Add coverage to the compose stack

### DIFF
--- a/.compose.env.example
+++ b/.compose.env.example
@@ -63,3 +63,6 @@ ENABLE_SIGNING=1
 
 ## Enable automated logging to be written to /var/log/galaxy_api_access.log
 # PULP_GALAXY_ENABLE_API_ACCESS_LOG=true
+
+## Hack the gunicorn and pulp worker processes to capture coverage data
+ENABLE_COVERAGE=1

--- a/dev/standalone/collect_coverage.sh
+++ b/dev/standalone/collect_coverage.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+CONTAINERS="galaxy_ng_api_1 galaxy_ng_worker_1"
+
+for CONTAINER in $CONTAINERS; do
+    echo $CONTAINER
+    docker exec -u root -it $CONTAINER /bin/bash -c 'kill -HUP 1'
+    docker exec -u root -it $CONTAINER /bin/bash -c 'kill 1'
+done
+
+rm -rf /tmp/coverage_results
+mkdir -p /tmp/coverage_results/data
+cp dev/standalone/.coverage* /tmp/coverage_results/data/.
+cd /tmp/coverage_results
+
+coverage combine data
+coverage report -i

--- a/dev/standalone/hack_coverage.sh
+++ b/dev/standalone/hack_coverage.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "HACKING COVERAGE!!!"
+
+# /venv/bin/python -c 'from pulpcore.app import wsgi; print(wsgi.__file__)'
+#   /venv/lib64/python3.8/site-packages/pulpcore/app/wsgi.py
+WSGI_FILE=/venv/lib64/python3.8/site-packages/pulpcore/app/wsgi.py
+rm -f ${WSGI_FILE}
+cp /src/galaxy_ng/dev/standalone/wsgi_coverage.py ${WSGI_FILE}
+
+# /usr/local/bin/start-worker
+#   exec pulpcore-worker
+#       /venv/bin/pulpcore-worker
+WORKER_SCRIPT=/venv/bin/pulpcore-worker
+rm -f ${WORKER_SCRIPT}
+cp /src/galaxy_ng/dev/standalone/worker_coverage.py ${WORKER_SCRIPT}
+chmod +x ${WORKER_SCRIPT}
+
+/venv/bin/pip install --upgrade coverage

--- a/dev/standalone/worker_coverage.py
+++ b/dev/standalone/worker_coverage.py
@@ -1,0 +1,30 @@
+#!/venv/bin/python3
+# -*- coding: utf-8 -*-
+
+import atexit
+import os
+import re
+import socket
+import sys
+import coverage
+
+from pulpcore.tasking.entrypoint import worker
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+
+    pid = os.getpid()
+    hostname = socket.gethostname()
+    data_file = f'/src/galaxy_ng/dev/standalone/.coverage.{hostname}.{pid}'
+
+    cov = coverage.coverage(data_file=data_file)
+    cov.start()
+
+    def save_coverage():
+        print('saving coverage!')
+        cov.stop()
+        cov.save()
+
+    atexit.register(save_coverage)
+
+    sys.exit(worker())

--- a/dev/standalone/wsgi_coverage.py
+++ b/dev/standalone/wsgi_coverage.py
@@ -1,0 +1,38 @@
+"""
+WSGI config for pulp project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
+"""
+
+import atexit
+import os
+import socket
+import sys
+import coverage
+
+from django.core.wsgi import get_wsgi_application  # noqa
+
+pid = os.getpid()
+hostname = socket.gethostname()
+data_file = f'/src/galaxy_ng/dev/standalone/.coverage.{hostname}.{pid}'
+
+cov = coverage.coverage(
+    data_file=data_file,
+    #concurrency='multiprocessing',
+    #config_file=False
+)
+cov.start()
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
+
+application = get_wsgi_application()
+
+def save_coverage():
+    print('saving coverage!')
+    cov.stop()
+    cov.save()
+
+atexit.register(save_coverage)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -57,6 +57,12 @@ process_init_files() {
     done
 }
 
+
+enable_coverage() {
+    bash -x /src/galaxy_ng/dev/standalone/hack_coverage.sh
+}
+
+
 run_service() {
     if [[ "$#" -eq 0 ]]; then
         log_message 'ERROR: Missing service name parameter.'
@@ -96,6 +102,10 @@ run_service() {
 
     if [[ "$ENABLE_SIGNING" -eq "1" ]]; then
         setup_signing_service
+    fi
+
+    if [[ "$ENABLE_COVERAGE" -eq "1" ]]; then
+        enable_coverage
     fi
 
     exec "${service_path}" "$@"


### PR DESCRIPTION
No-Issue

Signed-off-by: James Tanner <tanner.jc@gmail.com>

# Description 🛠

```
(galaxydev) [jtanner@p1 galaxy_ng]$ ./dev/standalone/collect_coverage.sh 
galaxy_ng_api_1
Error response from daemon: Container 668ed401ccf2434c9f9ce0307c957bf95ecb0ce4e66f2a3b4e641ec926d5f558 is not running
Error response from daemon: Container 668ed401ccf2434c9f9ce0307c957bf95ecb0ce4e66f2a3b4e641ec926d5f558 is not running
galaxy_ng_worker_1
Error response from daemon: Container 01f9b1b8139abac6d7039862833e928f63a6d803d924c00b8aba35d10651b2a3 is not running
Error response from daemon: Container 01f9b1b8139abac6d7039862833e928f63a6d803d924c00b8aba35d10651b2a3 is not running
Combined data file data/.coverage.668ed401ccf2.99
Combined data file data/.coverage.668ed401ccf2.64
Combined data file data/.coverage.668ed401ccf2.63
Combined data file data/.coverage.668ed401ccf2.62
Combined data file data/.coverage.668ed401ccf2.61
Combined data file data/.coverage.668ed401ccf2.102
Combined data file data/.coverage.668ed401ccf2.101
Combined data file data/.coverage.668ed401ccf2.100
Combined data file data/.coverage.01f9b1b8139a.1
/home/jtanner/venvs/galaxydev/lib64/python3.10/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/etc/pulp/settings.py': No source for code: '/etc/pulp/settings.py'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
Name                                                                        Stmts   Miss  Cover
-----------------------------------------------------------------------------------------------
/src/galaxy_ng/galaxy_ng/__init__.py                                            2      2     0%
/src/galaxy_ng/galaxy_ng/app/__init__.py                                        8      8     0%
/src/galaxy_ng/galaxy_ng/app/access_control/__init__.py                         0      0   100%
/src/galaxy_ng/galaxy_ng/app/access_control/access_policy.py                  145    145     0%
/src/galaxy_ng/galaxy_ng/app/access_control/fields.py                          58     58     0%
/src/galaxy_ng/galaxy_ng/app/access_control/mixins.py                          30     30     0%
/src/galaxy_ng/galaxy_ng/app/access_control/statements/__init__.py              5      5     0%
/src/galaxy_ng/galaxy_ng/app/access_control/statements/insights.py              1      1     0%
/src/galaxy_ng/galaxy_ng/app/access_control/statements/pulp_container.py        1      1     0%
/src/galaxy_ng/galaxy_ng/app/access_control/statements/roles.py                 1      1     0%
/src/galaxy_ng/galaxy_ng/app/access_control/statements/standalone.py            1      1     0%
/src/galaxy_ng/galaxy_ng/app/api/__init__.py                                    0      0   100%
/src/galaxy_ng/galaxy_ng/app/api/base.py                                       42     42     0%
/src/galaxy_ng/galaxy_ng/app/api/exceptions.py                                 36     36     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/__init__.py                                 0      0   100%
/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/__init__.py                     8      8     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/auth.py                         5      5     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/base.py                        12     12     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/collection.py                 126    126     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/distribution.py                14     14     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/execution_environment.py      203    203     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/imports.py                     20     20     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/synclist.py                   102    102     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/user.py                        99     99     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/urls.py                                    29     29     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/versioning.py                               4      4     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/views/__init__.py                           9      9     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/views/auth.py                              64     64     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/views/controller.py                        18     18     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/views/feature_flags.py                      8      8     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/views/index_execution_environments.py      30     30     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/views/landing_page.py                      22     22     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/views/settings.py                          11     11     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/views/signing.py                           53     53     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/views/sync.py                              44     44     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/__init__.py                       12     12     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/collection.py                    154    154     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/distribution.py                   18     18     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/execution_environment.py         163    163     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/group.py                          32     32     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/my_namespace.py                    6      6     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/my_synclist.py                    21     21     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/namespace.py                       6      6     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/root.py                            8      8     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/synclist.py                       10     10     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/tags.py                           15     15     0%
/src/galaxy_ng/galaxy_ng/app/api/ui/viewsets/user.py                           27     27     0%
/src/galaxy_ng/galaxy_ng/app/api/urls.py                                       11     11     0%
/src/galaxy_ng/galaxy_ng/app/api/utils.py                                      73     73     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/__init__.py                                 0      0   100%
/src/galaxy_ng/galaxy_ng/app/api/v3/serializers/__init__.py                     5      5     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/serializers/collection.py                  81     81     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/serializers/group.py                        4      4     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/serializers/namespace.py                   79     79     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/serializers/sync.py                        57     57     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/serializers/task.py                        33     33     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/urls.py                                     9      9     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/views/__init__.py                           4      4     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/views/auth.py                              19     19     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/views/excludes.py                          36     36     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/views/sync.py                              27     27     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/viewsets/__init__.py                        5      5     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/viewsets/collection.py                    220    220     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/viewsets/namespace.py                      53     53     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/viewsets/sync.py                           14     14     0%
/src/galaxy_ng/galaxy_ng/app/api/v3/viewsets/task.py                           13     13     0%
/src/galaxy_ng/galaxy_ng/app/api/views.py                                      27     27     0%
/src/galaxy_ng/galaxy_ng/app/common/__init__.py                                 0      0   100%
/src/galaxy_ng/galaxy_ng/app/common/metrics.py                                  7      7     0%
/src/galaxy_ng/galaxy_ng/app/common/parsers.py                                 17     17     0%
/src/galaxy_ng/galaxy_ng/app/constants.py                                       8      8     0%
/src/galaxy_ng/galaxy_ng/app/customadmin.py                                     5      5     0%
/src/galaxy_ng/galaxy_ng/app/dynaconf_hooks.py                                 66     66     0%
/src/galaxy_ng/galaxy_ng/app/exceptions.py                                      7      7     0%
/src/galaxy_ng/galaxy_ng/app/models/__init__.py                                 7      7     0%
/src/galaxy_ng/galaxy_ng/app/models/auth.py                                    27     27     0%
/src/galaxy_ng/galaxy_ng/app/models/collectionimport.py                        17     17     0%
/src/galaxy_ng/galaxy_ng/app/models/container.py                               36     36     0%
/src/galaxy_ng/galaxy_ng/app/models/contentguard.py                            42     42     0%
/src/galaxy_ng/galaxy_ng/app/models/namespace.py                               59     59     0%
/src/galaxy_ng/galaxy_ng/app/models/synclist.py                                14     14     0%
/src/galaxy_ng/galaxy_ng/app/settings.py                                       43     43     0%
/src/galaxy_ng/galaxy_ng/app/signals/__init__.py                                0      0   100%
/src/galaxy_ng/galaxy_ng/app/signals/handlers.py                               43     43     0%
/src/galaxy_ng/galaxy_ng/app/tasks/__init__.py                                  7      7     0%
/src/galaxy_ng/galaxy_ng/app/tasks/deletion.py                                 37     37     0%
/src/galaxy_ng/galaxy_ng/app/tasks/index_registry.py                           72     72     0%
/src/galaxy_ng/galaxy_ng/app/tasks/promotion.py                                11     11     0%
/src/galaxy_ng/galaxy_ng/app/tasks/publishing.py                               60     60     0%
/src/galaxy_ng/galaxy_ng/app/tasks/registry_sync.py                            15     15     0%
/src/galaxy_ng/galaxy_ng/app/tasks/signing.py                                  17     17     0%
/src/galaxy_ng/galaxy_ng/app/tasks/synclist.py                                 53     53     0%
/src/galaxy_ng/galaxy_ng/app/urls.py                                           15     15     0%
/src/galaxy_ng/galaxy_ng/app/views.py                                           3      3     0%
/src/galaxy_ng/galaxy_ng/app/viewsets.py                                       18     18     0%
/src/galaxy_ng/galaxy_ng/openapi/__init__.py                                   32     32     0%
/src/galaxy_ng/galaxy_ng/ui/__init__.py                                         0      0   100%
/src/galaxy_ng/galaxy_ng/ui/urls.py                                             3      3     0%
-----------------------------------------------------------------------------------------------
TOTAL                                                                        3194   3194     0%
```

