### PR TITLE
Release 4.3.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,19 @@ Changelog
 
 .. towncrier release notes start
 
+4.3.4 (2022-04-01)
+Bugfixes
+--------
+
+- Consume proxy authentication fix in pulp_ansible 0.7.4
+  `AAH-840 <https://issues.redhat.com/browse/AAH-840>`_
+- Combine the copy and remove tasks
+  `AAH-1349 <https://issues.redhat.com/browse/AAH-1349>`_
+
+
+----
+
+
 4.3.3 (2021-09-16)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Changelog
 Bugfixes
 --------
 
-- Consume proxy authentication fix in pulp_ansible 0.7.4
+- Update to pulp_ansible 0.7.4 to backport AAH-840 bugfix, which did not resolve the issue for 4.3.
   `AAH-840 <https://issues.redhat.com/browse/AAH-840>`_
 - Combine the copy and remove tasks
   `AAH-1349 <https://issues.redhat.com/browse/AAH-1349>`_

--- a/CHANGES/1349.bugfix
+++ b/CHANGES/1349.bugfix
@@ -1,1 +1,0 @@
-Combine the copy and remove tasks

--- a/CHANGES/840.bugfix
+++ b/CHANGES/840.bugfix
@@ -1,1 +1,0 @@
-Consume proxy authentication fix in pulp_ansible 0.7.4

--- a/galaxy_ng/__init__.py
+++ b/galaxy_ng/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.3.3"
+__version__ = "4.3.4"
 
 default_app_config = "galaxy_ng.app.PulpGalaxyPluginAppConfig"

--- a/galaxy_ng/app/__init__.py
+++ b/galaxy_ng/app/__init__.py
@@ -8,7 +8,7 @@ class PulpGalaxyPluginAppConfig(PulpPluginAppConfig):
 
     name = "galaxy_ng.app"
     label = "galaxy"
-    version = "4.3.3"
+    version = "4.3.4"
 
     def ready(self):
         super().ready()

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,3 @@ replace = version = "{new_version}"
 [bumpversion:file:./galaxy_ng/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
-
-[bumpversion:file:.travis/VERSION]
-search = {current_version}
-replace = {new_version}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.3
+current_version = 4.3.4
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+))?((?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools.command.build_py import build_py as _BuildPyCommand
 from setuptools.command.sdist import sdist as _SDistCommand
 
 package_name = os.environ.get("GALAXY_NG_ALTERNATE_NAME", "galaxy-ng")
-version = "4.3.3"
+version = "4.3.4"
 
 
 class PrepareStaticCommand(Command):


### PR DESCRIPTION
4.3.4 (2022-04-01)
Bugfixes
--------

- Consume proxy authentication fix in pulp_ansible 0.7.4
  `AAH-840 <https://issues.redhat.com/browse/AAH-840>`_
- Combine the copy and remove tasks
  `AAH-1349 <https://issues.redhat.com/browse/AAH-1349>`_

UI release PR: https://github.com/ansible/ansible-hub-ui/pull/1835

[API PRs](https://github.com/ansible/galaxy_ng/pulls?q=is%3Apr+base%3Astable-4.3+is%3Amerged+-author%3Aapp%2Fdependabot+merged%3A2021-09-17..2022-03-31)
[UI PRs](https://github.com/ansible/ansible-hub-ui/pulls?q=is%3Apr+base%3Astable-4.3+is%3Amerged+-author%3Aapp%2Fdependabot+merged%3A2021-09-17..2022-03-31)

previous: [4.3.3](https://github.com/ansible/galaxy_ng/pull/970)

---

Also removes a `.travis/VERSION` reference from `setup.cfg`, the file was removed in #1129 and causes bump2version to blow up with:

```
Attempting to increment part 'patch'
Values are now: build=0, major=4, minor=3, patch=4, release=stable
New version will be '4.3.4'
Asserting files setup.py, ./galaxy_ng/app/__init__.py, ./galaxy_ng/__init__.py, .travis/VERSION contain the version string...
Traceback (most recent call last):
  File "/home/himdel/.local/bin/bump2version", line 8, in <module>
    sys.exit(main())
  File "/home/himdel/.local/lib/python3.9/site-packages/bumpversion/cli.py", line 124, in main
    _check_files_contain_version(files, current_version, context)
  File "/home/himdel/.local/lib/python3.9/site-packages/bumpversion/cli.py", line 618, in _check_files_contain_version
    f.should_contain_version(current_version, context)
  File "/home/himdel/.local/lib/python3.9/site-packages/bumpversion/utils.py", line 51, in should_contain_version
    if self.contains(search_expression):
  File "/home/himdel/.local/lib/python3.9/site-packages/bumpversion/utils.py", line 78, in contains
    with open(self.path, "rt", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: '.travis/VERSION'
make: *** [Makefile:96: dev/bumpversion-patch] Error 1
```