### PR TITLE
Dump the container logs at the end of integration tests

### DIFF
--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -52,4 +52,11 @@ jobs:
         run: sleep 120
 
       - name: run the integration tests
+        continue-on-error: true
         run: HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh
+
+      - name: dump the api logs
+        run: docker logs galaxy_ng_api_1
+
+      - name: dump the worker logs
+        run: docker logs galaxy_ng_worker_1


### PR DESCRIPTION
No-Issue

Signed-off-by: James Tanner <tanner.jc@gmail.com>

# Description 🛠
_Add PR description here_

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
