### PR TITLE
Allow upload of signature for collection version.

### DIFF
--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -51,6 +51,9 @@ jobs:
       - name: give stack some time to spin up
         run: sleep 120
 
+      - name: set keyring on staging repo for signature upload
+        run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y
+
       - name: run the integration tests
         continue-on-error: true
         run: HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh

--- a/CHANGES/1055.feature
+++ b/CHANGES/1055.feature
@@ -1,0 +1,1 @@
+Allow signature upload, expose public_keys on API

--- a/dev/common/collection_sign.sh
+++ b/dev/common/collection_sign.sh
@@ -9,6 +9,7 @@ PASSWORD="Galaxy2022"
 # Create a detached signature
 gpg --quiet --batch --pinentry-mode loopback --yes --passphrase \
    $PASSWORD --homedir ~/.gnupg/ --detach-sign --default-key $ADMIN_ID \
+   --no-default-keyring --keyring /etc/pulp/certs/galaxy.kbx \
    --armor --output $SIGNATURE_PATH $FILE_PATH
 
 # Check the exit status

--- a/dev/common/collection_sign.sh
+++ b/dev/common/collection_sign.sh
@@ -9,7 +9,7 @@ PASSWORD="Galaxy2022"
 # Create a detached signature
 gpg --quiet --batch --pinentry-mode loopback --yes --passphrase \
    $PASSWORD --homedir ~/.gnupg/ --detach-sign --default-key $ADMIN_ID \
-   --no-default-keyring --keyring /etc/pulp/certs/galaxy.kbx \
+   --no-default-keyring --keyring ${KEYRING:-/etc/pulp/certs/galaxy.kbx} \
    --armor --output $SIGNATURE_PATH $FILE_PATH
 
 # Check the exit status

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -96,7 +96,10 @@ run_service() {
     # fi
 
     if [[ "$ENABLE_SIGNING" -eq "1" ]]; then
+        setup_signing_keyring
         setup_signing_service
+    elif [[ "$ENABLE_SIGNING" -eq "2" ]]; then
+        setup_signing_keyring
     fi
 
     exec "${service_path}" "$@"
@@ -109,20 +112,29 @@ run_manage() {
     fi
 
     if [[ "$ENABLE_SIGNING" -eq "1" ]]; then
+        setup_signing_keyring
         setup_signing_service
+    elif [[ "$ENABLE_SIGNING" -eq "2" ]]; then
+        setup_signing_keyring
     fi
 
     exec django-admin "$@"
 }
 
-setup_signing_service() {
-    log_message "Setting up signing service."
+
+setup_signing_keyring() {
+    log_message "Setting up signing keyring."
     export KEY_FINGERPRINT=$(gpg --show-keys --with-colons --with-fingerprint /tmp/ansible-sign.key | awk -F: '$1 == "fpr" {print $10;}' | head -n1)
     export KEY_ID=${KEY_FINGERPRINT: -16}
-    gpg --batch --import /tmp/ansible-sign.key &>/dev/null
-    echo "${KEY_FINGERPRINT}:6:" | gpg --import-ownertrust &>/dev/null
+    gpg --batch --no-default-keyring --keyring /etc/pulp/certs/galaxy.kbx --import /tmp/ansible-sign.key &>/dev/null
+    echo "${KEY_FINGERPRINT}:6:" | gpg --batch --no-default-keyring --keyring /etc/pulp/certs/galaxy.kbx --import-ownertrust &>/dev/null
+}
 
+setup_signing_service() {
+    log_message "Setting up signing service."
     HAS_SIGNING=$(django-admin shell -c 'from pulpcore.app.models import SigningService;print(SigningService.objects.filter(name="ansible-default").count())' 2>/dev/null || true)
+    export KEY_FINGERPRINT=$(gpg --show-keys --with-colons --with-fingerprint /tmp/ansible-sign.key | awk -F: '$1 == "fpr" {print $10;}' | head -n1)
+    export KEY_ID=${KEY_FINGERPRINT: -16}
     if [[ "$HAS_SIGNING" -eq "0" ]]; then
         log_message "Creating signing service. using key ${KEY_ID}"
         django-admin add-signing-service ansible-default /var/lib/pulp/scripts/collection_sign.sh ${KEY_ID} 2>/dev/null || true
@@ -130,6 +142,22 @@ setup_signing_service() {
         log_message "Signing service already exists."
     fi
 }
+
+# setup_signing_service() {
+#     log_message "Setting up signing service."
+#     export KEY_FINGERPRINT=$(gpg --show-keys --with-colons --with-fingerprint /tmp/ansible-sign.key | awk -F: '$1 == "fpr" {print $10;}' | head -n1)
+#     export KEY_ID=${KEY_FINGERPRINT: -16}
+#     gpg --batch --import /tmp/ansible-sign.key &>/dev/null
+#     echo "${KEY_FINGERPRINT}:6:" | gpg --import-ownertrust &>/dev/null
+
+#     HAS_SIGNING=$(django-admin shell -c 'from pulpcore.app.models import SigningService;print(SigningService.objects.filter(name="ansible-default").count())' 2>/dev/null || true)
+#     if [[ "$HAS_SIGNING" -eq "0" ]]; then
+#         log_message "Creating signing service. using key ${KEY_ID}"
+#         django-admin add-signing-service ansible-default /var/lib/pulp/scripts/collection_sign.sh ${KEY_ID} 2>/dev/null || true
+#     else
+#         log_message "Signing service already exists."
+#     fi
+# }
 
 redis_connection_hack() {
     redis_host="${PULP_REDIS_HOST:-}"

--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -67,7 +67,7 @@ class CollectionMetadataSerializer(Serializer):
             sig = {}
             sig["signature"] = bytes(signature.data).decode("utf-8")
             sig["pubkey_fingerprint"] = signature.pubkey_fingerprint
-            sig["signing_service"] = signature.signing_service.name
+            sig["signing_service"] = getattr(signature.signing_service, "name", None)
             data.append(sig)
         return data
 

--- a/galaxy_ng/app/api/ui/serializers/distribution.py
+++ b/galaxy_ng/app/api/ui/serializers/distribution.py
@@ -4,6 +4,7 @@ from pulp_ansible.app import models as pulp_models
 
 class RepositorySerializer(serializers.ModelSerializer):
     content_count = serializers.SerializerMethodField()
+    keyring = serializers.CharField(source="ansible_ansiblerepository.keyring")
 
     class Meta:
         model = pulp_models.AnsibleRepository
@@ -12,7 +13,8 @@ class RepositorySerializer(serializers.ModelSerializer):
             'description',
             'pulp_id',
             'pulp_last_updated',
-            'content_count'
+            'content_count',
+            'keyring',
         )
 
     def get_content_count(self, repo) -> int:

--- a/galaxy_ng/app/api/ui/views/__init__.py
+++ b/galaxy_ng/app/api/ui/views/__init__.py
@@ -39,4 +39,5 @@ __all__ = (
 
     # Signing
     "CollectionSignView",
+
 )

--- a/galaxy_ng/app/api/ui/views/settings.py
+++ b/galaxy_ng/app/api/ui/views/settings.py
@@ -18,6 +18,8 @@ class SettingsView(api_base.APIView):
             "GALAXY_REQUIRE_CONTENT_APPROVAL",
             "GALAXY_COLLECTION_SIGNING_SERVICE",
             "GALAXY_AUTO_SIGN_COLLECTIONS",
+            "GALAXY_SIGNATURE_UPLOAD_ENABLED",
+            "GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL",
         ]
         data = {key: settings.as_dict().get(key, None) for key in keyset}
         return Response(data)

--- a/galaxy_ng/app/management/commands/set-repo-keyring.py
+++ b/galaxy_ng/app/management/commands/set-repo-keyring.py
@@ -1,0 +1,96 @@
+import os
+import sys
+import time
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from pulp_ansible.app.models import AnsibleRepository
+from pulpcore.plugin.constants import TASK_FINAL_STATES, TASK_STATES
+from pulpcore.plugin.tasking import dispatch
+
+
+class Command(BaseCommand):
+    """This command sets keyring to repository.
+
+    Keyring must be a GPG keyring on the filesystem, default path: /etc/pulp/certs/
+
+    Example:
+
+    django-admin set-repo-keyring --keyring=galaxy.kbx --repository=<repo_name>
+    """
+
+    def echo(self, message, style=None):
+        style = style or self.style.SUCCESS
+        self.stdout.write(style(message))
+
+    def add_arguments(self, parser):
+        parser.add_argument("--keyring", type=str, help="Keyring", required=True)
+        parser.add_argument("--repository", type=str, help="Repository name", required=True)
+        parser.add_argument(
+            "-y",
+            "--yes",
+            action="store_true",
+            help="Skip confirmation",
+            default=False,
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+
+        repository = options["repository"].strip()
+        keyring = options["keyring"].strip()
+
+        try:
+            repo = AnsibleRepository.objects.get(name=repository)
+        except AnsibleRepository.DoesNotExist:
+            self.echo(f"Repository {repository} does not exist", self.style.ERROR)
+            sys.exit(1)
+
+        certs_dir = settings.get("ANSIBLE_CERTS_DIR", "/etc/pulp/certs")
+        keyring_path = os.path.join(certs_dir, keyring)
+        if not os.path.exists(keyring_path):
+            self.echo(f"Keyring {keyring_path} does not exist", self.style.ERROR)
+            sys.exit(1)
+
+        if not options["yes"]:
+            confirm = input(
+                f"This will set keyring to {keyring} for {repository} repository, " "Proceed? (Y/n)"
+            ).lower()
+            while True:
+                if confirm not in ("y", "n", "yes", "no"):
+                    confirm = input('Please enter either "y/yes" or "n/no": ')
+                    continue
+                if confirm in ("y", "yes"):
+                    break
+                else:
+                    self.echo("Process canceled.")
+                    return
+
+        task = dispatch(
+            set_repo_keyring,
+            kwargs={"repo_id": repo.pk, "keyring": keyring},
+            exclusive_resources=[repo],
+        )
+
+        while task.state not in TASK_FINAL_STATES:
+            time.sleep(1)
+            task.refresh_from_db()
+
+        self.echo(f"Process {task.state}")
+
+        if task.state == TASK_STATES.FAILED:
+            self.echo(f"Task failed with error: {task.error}", self.style.ERROR)
+            sys.exit(1)
+
+        if AnsibleRepository.objects.get(pk=repo.pk).keyring == keyring:
+            self.echo(f"Keyring {keyring} set successfully to {repository} repository")
+
+
+def set_repo_keyring(repo_id, keyring):
+    """Set keyring for repository"""
+
+    with transaction.atomic():
+        repo = AnsibleRepository.objects.get(pk=repo_id)
+        repo.keyring = keyring
+        repo.save()

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -176,3 +176,21 @@ KEYCLOAK_REALM = None
 #   set automation hub will use the CA certs in the file to validate
 #   the keycloak's SSL certificate.
 GALAXY_VERIFY_KEYCLOAK_SSL_CERTS = False
+
+# Default values for signing feature
+# Turn this on to enable the upload of signature
+# UI looks for this setting to add the upload controls.
+# this does't affect the API, upload is handled by pulp api directly
+GALAXY_SIGNATURE_UPLOAD_ENABLED = False
+
+# Turn this on to require at least one signature to be present
+# on the /move/ endpoint to be able to move/approve
+# to GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH (published)
+# This can only be set to True if GALAXY_REQUIRE_CONTENT_APPROVAL is also True
+GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL = False
+
+# With this set to True, all the approved collections will be also signed
+GALAXY_AUTO_SIGN_COLLECTIONS = False
+
+# This sets the name of the signing service to be used for signing
+GALAXY_COLLECTION_SIGNING_SERVICE = None

--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -28,7 +28,7 @@ objects:
     namespace: automation-hub
   data:
     collection_sign.sh: |
-      IyEvYmluL2Jhc2gKCkZJTEVfUEFUSD0kMQpTSUdOQVRVUkVfUEFUSD0iJDEuYXNjIgoKQURNSU5fSUQ9ImdhbGF4eTNAYW5zaWJsZS5jb20iClBBU1NXT1JEPSJHYWxheHkyMDIyIgoKIyBDcmVhdGUgYSBkZXRhY2hlZCBzaWduYXR1cmUKZ3BnIC0tcXVpZXQgLS1iYXRjaCAtLXBpbmVudHJ5LW1vZGUgbG9vcGJhY2sgLS15ZXMgLS1wYXNzcGhyYXNlICAgJFBBU1NXT1JEIC0taG9tZWRpciAvdG1wL2Fuc2libGUvLmdudXBnIC0tZGV0YWNoLXNpZ24gLS1kZWZhdWx0LWtleSAkQURNSU5fSUQgICAtLWFybW9yIC0tb3V0cHV0ICRTSUdOQVRVUkVfUEFUSCAkRklMRV9QQVRICgojIENoZWNrIHRoZSBleGl0IHN0YXR1cwpTVEFUVVM9JD8KaWYgWyAkU1RBVFVTIC1lcSAwIF07IHRoZW4KICBlY2hvIHtcImZpbGVcIjogXCIkRklMRV9QQVRIXCIsIFwic2lnbmF0dXJlXCI6IFwiJFNJR05BVFVSRV9QQVRIXCJ9CmVsc2UKICBleGl0ICRTVEFUVVMKZmkK
+      IyEvYmluL2Jhc2gKCkZJTEVfUEFUSD0kMQpTSUdOQVRVUkVfUEFUSD0iJDEuYXNjIgoKQURNSU5fSUQ9ImdhbGF4eTNAYW5zaWJsZS5jb20iClBBU1NXT1JEPSJHYWxheHkyMDIyIgpLRVlSSU5HPSIvZXRjL3B1bHAvY2VydHMvZ2FsYXh5LmtieCIKR05VUEdIT01FPSIvdG1wL2Fuc2libGUvLmdudXBnIgoKIyBDcmVhdGUgYSBkZXRhY2hlZCBzaWduYXR1cmUKZ3BnIC0tcXVpZXQgLS1iYXRjaCAtLW5vLWRlZmF1bHQta2V5cmluZyAtLWtleXJpbmcgJEtFWVJJTkcgLS1waW5lbnRyeS1tb2RlIGxvb3BiYWNrIC0teWVzIC0tcGFzc3BocmFzZSAgICRQQVNTV09SRCAtLWhvbWVkaXIgJEdOVVBHSE9NRSAtLWRldGFjaC1zaWduIC0tZGVmYXVsdC1rZXkgJEFETUlOX0lEICAgLS1hcm1vciAtLW91dHB1dCAkU0lHTkFUVVJFX1BBVEggJEZJTEVfUEFUSAoKIyBDaGVjayB0aGUgZXhpdCBzdGF0dXMKU1RBVFVTPSQ/CmlmIFsgJFNUQVRVUyAtZXEgMCBdOyB0aGVuCiAgZWNobyB7XCJmaWxlXCI6IFwiJEZJTEVfUEFUSFwiLCBcInNpZ25hdHVyZVwiOiBcIiRTSUdOQVRVUkVfUEFUSFwifQplbHNlCiAgZXhpdCAkU1RBVFVTCmZpCg==
 
 - apiVersion: v1
   kind: ConfigMap
@@ -122,7 +122,8 @@ objects:
             value: ${GNUPGHOME}
         volumeMounts:
           - name: pulp-key
-            mountPath: /etc/pulp/certs
+            mountPath: /etc/pulp/certs/database_fields.symmetric.key
+            subPath: database_fields.symmetric.key
             readOnly: true
           - name: signing-gpg-key
             mountPath: /tmp/ansible-sign.key
@@ -176,7 +177,8 @@ objects:
             value: ${GNUPGHOME}
         volumeMounts:
           - name: pulp-key
-            mountPath: /etc/pulp/certs
+            mountPath: /etc/pulp/certs/database_fields.symmetric.key
+            subPath: database_fields.symmetric.key
             readOnly: true
           - name: signing-gpg-key
             mountPath: /tmp/ansible-sign.key
@@ -245,7 +247,8 @@ objects:
           - name: importer-config
             mountPath: /etc/galaxy-importer
           - name: pulp-key
-            mountPath: /etc/pulp/certs
+            mountPath: /etc/pulp/certs/database_fields.symmetric.key
+            subPath: database_fields.symmetric.key
             readOnly: true
           - name: signing-gpg-key
             mountPath: /tmp/ansible-sign.key


### PR DESCRIPTION
# Description 🛠

Allow upload of signature for collection version.
    
- To upload a signature the endpoint is `/pulp/api/v3/content/ansible/collection_signatures/`
        The above endpoint expects:
         
        file: path/to/namespace.collection-version.asc (or any filename)
        signed_collection: href to CollectionVersion being signed
        repository:  href of the repository where that signature must be added

- To set a keyring to a repository

  `django-admin set-repo-keyring --repository=staging --keyring=/etc/pulp/certs/galaxy.kbx`

- To set the system to require a signature on approval

  `GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL=True`

then move endpoint will require at least one signature to allow approval.

Issue: AAH-1055




# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
