### PR TITLE
Release 4.2.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ Changelog
 
 .. towncrier release notes start
 
+4.2.8 (2022-04-11)
+No significant changes.
+
+
+----
+
+
 4.2.7 (2021-12-02)
 ==================
 

--- a/galaxy_ng/__init__.py
+++ b/galaxy_ng/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.2.7"
+__version__ = "4.2.8"
 
 default_app_config = "galaxy_ng.app.PulpGalaxyPluginAppConfig"


### PR DESCRIPTION
(No non-UI changes in this release.)
UI release PR: https://github.com/ansible/ansible-hub-ui/pull/1889

previous: [4.2.7](https://github.com/ansible/galaxy_ng/pull/1068)