### PR TITLE
Force the compose script to exit if the checkout path is wrong

### DIFF
--- a/compose
+++ b/compose
@@ -3,6 +3,18 @@
 set -o nounset
 set -o errexit
 
+# the internal mechanisms for installing and testing do not
+# work if the checkout path is not named "galaxy_ng", so
+# this script should -always- abort if that is not the case.
+CWD=$(basename $(pwd))
+if [[ "${CWD}" != "galaxy_ng" ]]; then
+    cat >&2 <<EOF
+ERROR: The checkout directory -must- be named galaxy_ng. A different
+       name can cause many unintended behaviors inside the containers
+EOF
+    exit 1
+fi
+
 if [[ -f '.compose.env' ]]; then
   # export variables from .compose.env but only if the var is not already set.
   eval "$(grep -v '^#' .compose.env | sed -E 's|^(.+)=(.*)$|export \1=${\1:-\2}|g' | xargs -L 1)"


### PR DESCRIPTION
# Description 🛠

entrypoint.sh makes assumptions about the checkout path inside the volume mounts. If the underlying host galaxy_ng checkout is not named "galaxy_ng" (galaxy_ng.foobar for example) but you also have a folder named "galaxy_ng", the script will not use the galaxy_ng.foobar folder for pip installs. That makes it seem like your code edits aren't being reflected inside the containers and it's not very obvious why.

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
