### PR TITLE
Ephemeral: patch sso url through mocks restart

### DIFF
--- a/dev/common/RUN_INTEGRATION.sh
+++ b/dev/common/RUN_INTEGRATION.sh
@@ -3,7 +3,7 @@
 if [[ -z $HUB_LOCAL ]]; then
     export NAMESPACE="ephemeral-1riioj"
     export HUB_API_ROOT="https://front-end-aggregator-${NAMESPACE}.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/api/automation-hub/"
-    export HUB_AUTH_URL="https://keycloak-${NAMESPACE}.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/auth/realms/redhat-external/protocol/openid-connect/token"
+    export HUB_AUTH_URL="https://mocks-keycloak-${NAMESPACE}.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/auth/realms/redhat-external/protocol/openid-connect/token"
     export HUB_USERNAME="jdoe"
     export HUB_PASSWORD="redhat"
     export HUB_USE_MOVE_ENDPOINT="true"

--- a/dev/ephemeral/smoke_test.sh
+++ b/dev/ephemeral/smoke_test.sh
@@ -39,7 +39,7 @@ export HUB_USE_MOVE_ENDPOINT="true"
 # What is the api root?
 export HUB_API_ROOT="https://front-end-aggregator-${NAMESPACE}.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/api/automation-hub/"
 echo "HUB_API_ROOT: ${HUB_API_ROOT}"
-export HUB_AUTH_URL="https://keycloak-${NAMESPACE}.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/auth/realms/redhat-external/protocol/openid-connect/token"
+export HUB_AUTH_URL="https://mocks-keycloak-${NAMESPACE}.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/auth/realms/redhat-external/protocol/openid-connect/token"
 echo "HUB_AUTH_URL: ${HUB_AUTH_URL}"
 
 echo "Creating virtualenv for testing ..."

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -45,11 +45,11 @@ echo "patching the frontend-aggregator to use ${UI_REF}"
 oc patch cm aggregator-app-config --type merge --patch "{\"data\": {\"app-config.yml\": \"${COMPONENT_NAME}:\n  commit: ${UI_REF}\n\"}}"
 oc rollout restart deployment/front-end-aggregator
 oc rollout status deployment/front-end-aggregator
-sleep 5
+oc rollout restart deployment/mocks
+oc rollout status deployment/mocks
 FE_POD=$(oc get pod -l app=front-end-aggregator -o json | jq -r '.items[] | select( .metadata.deletionTimestamp == null ) | .metadata.name')
 oc exec ${FE_POD} -- /bin/bash -c "sed -i 's/--omit-dir-times/--omit-dir-times --omit-link-times/' /www/src/git_helper.sh"
 oc exec ${FE_POD} -- /bin/bash -c "/www/src/git_helper.sh config https://github.com/RedHatInsights/cloud-services-config prod-beta"
-oc exec ${FE_POD} -- /bin/bash -c 'cd /all/code/chrome/js && for f in $(ls *.js); do sed -i s/sso.qa.redhat.com/keycloak-"'"${NAMESPACE}"'".apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/g $f && rm -f $f.gz && gzip --keep $f; done'
 
 # Fix the routing for minio and artifact urls
 oc create route edge minio --service=env-${NAMESPACE}-minio --insecure-policy=Redirect


### PR DESCRIPTION
# Description 🛠
* patches chrome js to fix SSO url by restarting mocks instead of exec in frontend-aggregator pod
* update keycloak URL in smoke/integration scripts

Required due to a recent change in the keycloak URL in ephemeral environments

No-Issue

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
