### PR TITLE
Rename standalone job

### DIFF
--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -1,9 +1,17 @@
 ---
-name: Galaxy CI
-on: {pull_request: {branches: ['*']}, push: {branches: ['*']}}
+name: Standalone
+on: 
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - '*'
+  workflow_dispatch:
+
 jobs:
 
-  standalone_integration:
+  integration:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There is already another job named `Galaxy CI` and it is confusing
to have the duplicated name on the list.

![Screenshot_2022-04-16_12-49-36](https://user-images.githubusercontent.com/458654/163674613-7d421309-579e-468d-97a0-cffdd5d7f72f.png)


Also added `workflow_dispatch` to be able to run workflow manually

No-Issue

# Description 🛠
_Add PR description here_

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
