### PR TITLE
add missing service_name for cloudwatch logs

### DIFF
--- a/galaxy_ng/contrib/cloudwatch.py
+++ b/galaxy_ng/contrib/cloudwatch.py
@@ -18,6 +18,7 @@ class CloudWatchHandler(watchtower.CloudWatchLogHandler):
 
     def __init__(self):
         boto3_logs_client = boto3.client(
+            "logs",
             aws_access_key_id=AWS_ACCESS_KEY_ID,
             aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
             region_name=AWS_REGION_NAME,


### PR DESCRIPTION
# Description 🛠
add missing service_name for cloudwatch logs

No-Issue


# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
