### PR TITLE
deduplicate AWS_S3 bucket name

### DIFF
--- a/docker/etc/settings.py
+++ b/docker/etc/settings.py
@@ -60,9 +60,7 @@ def _make_aws_endpoint(config):
         global AWS_S3_ADDRESSING_STYLE, AWS_S3_SIGNATURE_VERSION
         AWS_S3_ADDRESSING_STYLE = "virtual"
         AWS_S3_SIGNATURE_VERSION = "s3v4"
-        netloc = f"{config.buckets[0].name}.{config.hostname}"
-    else:
-        netloc = config.hostname
+    netloc = config.hostname
     if ((scheme == 'http' and port != 80)
             or (scheme == 'https' and port != 443)):
         netloc = f"{netloc}:{port}"


### PR DESCRIPTION
# Description 🛠
deduplicate AWS_S3 bucket name when using virtual-hosted addressing style

Issue: AAH-1468

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
