### PR TITLE
Insights dev mode (docker) UI update

### DIFF
--- a/dev/insights/docker-compose-ui.yaml
+++ b/dev/insights/docker-compose-ui.yaml
@@ -3,21 +3,6 @@ version: "3.7"
 services:
   ui:
     environment:
+      - "API_PROXY_HOST=api"
+      - "API_PROXY_PORT=8000"
       - "DEPLOYMENT_MODE=${COMPOSE_PROFILE}"
-
-  insights_proxy:
-    image: "docker.io/redhatinsights/insights-proxy"
-    environment:
-      - "CUSTOM_CONF=true"
-      - "PLATFORM="
-    volumes:
-      - "${ANSIBLE_HUB_UI_PATH}/profiles/galaxy-ng-compose.js:/config/spandx.config.js"
-    security_opt:
-      - label:disable
-    ports:
-      - "1337:1337"
-    extra_hosts:
-      - "ci.foo.redhat.com:127.0.0.1"
-      - "prod.foo.redhat.com:127.0.0.1"
-      - "qa.foo.redhat.com:127.0.0.1"
-      - "stage.foo.redhat.com:127.0.0.1"


### PR DESCRIPTION
Goes together with https://github.com/ansible/ansible-hub-ui/pull/1526

Removing support for insights_proxy and references to obsolete spandx configs,
and configuring to run the UI the same way as in standalone.

Once we can run the ui in insights mode, that will work,
for now, the UI pr changes the entryfile to show an error message in insights mode.
![20220428045623](https://user-images.githubusercontent.com/289743/165679375-62f90b73-f7ab-48cc-b951-6b2fc232e2b9.png)
(The problem is that the dev mode npm run start now involves a webpack plugin calling docker to set up the non-api insights dependencies in containers.)

---

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit