### PR TITLE
Small fixes for CI code

### DIFF
--- a/dev/ephemeral/create_objects.py
+++ b/dev/ephemeral/create_objects.py
@@ -2,5 +2,7 @@ from galaxy_ng.app.models import Namespace
 
 print('creating autohubtest2+3 namespace(s)')
 for nsname in ['autohubtest2', 'autohubtest3']:
-    ns = Namespace.objects.create(name=nsname)
-    ns.save()
+    ns = Namespace.objects.filter(name=nsname).first()
+    if not ns:
+        ns = Namespace.objects.create(name=nsname)
+        ns.save()

--- a/dev/ephemeral/create_objects.py
+++ b/dev/ephemeral/create_objects.py
@@ -2,4 +2,4 @@ from galaxy_ng.app.models import Namespace
 
 print('creating autohubtest2+3 namespace(s)')
 for nsname in ['autohubtest2', 'autohubtest3']:
-    ns = Namespace.objects.get_or_create(name=nsname)
+    ns, _ = Namespace.objects.get_or_create(name=nsname)

--- a/dev/ephemeral/create_objects.py
+++ b/dev/ephemeral/create_objects.py
@@ -2,7 +2,4 @@ from galaxy_ng.app.models import Namespace
 
 print('creating autohubtest2+3 namespace(s)')
 for nsname in ['autohubtest2', 'autohubtest3']:
-    ns = Namespace.objects.filter(name=nsname).first()
-    if not ns:
-        ns = Namespace.objects.create(name=nsname)
-        ns.save()
+    ns = Namespace.objects.get_or_create(name=nsname)

--- a/dev/ephemeral/fixuser.py
+++ b/dev/ephemeral/fixuser.py
@@ -1,9 +1,12 @@
 from galaxy_ng.app.models.auth import User
 
-user = User.objects.filter(username='jdoe').first()
-if user is None:
-    user = User.objects.create_user('jdoe', password='bar')
-
+user = User.objects.get_or_create(
+    username='jdoe',
+    defaults=dict(
+        username='jdoe',
+        password='bar'
+    )
+)
 user.is_superuser = True
 user.is_staff = True
 user.save()

--- a/dev/ephemeral/fixuser.py
+++ b/dev/ephemeral/fixuser.py
@@ -1,6 +1,9 @@
 from galaxy_ng.app.models.auth import User
 
-user = User.objects.create_user('jdoe', password='bar')
+user = User.objects.filter(username='jdoe').first()
+if user is None:
+    user = User.objects.create_user('jdoe', password='bar')
+
 user.is_superuser = True
 user.is_staff = True
 user.save()

--- a/dev/ephemeral/fixuser.py
+++ b/dev/ephemeral/fixuser.py
@@ -1,6 +1,6 @@
 from galaxy_ng.app.models.auth import User
 
-user = User.objects.get_or_create(
+user, _ = User.objects.get_or_create(
     username='jdoe',
     defaults=dict(
         username='jdoe',

--- a/galaxy_ng/tests/integration/api/test_openapi.py
+++ b/galaxy_ng/tests/integration/api/test_openapi.py
@@ -129,6 +129,7 @@ def test_openapi_bindings_generation(ansible_config):
         cmd = [
             'docker',
             'run',
+            '--ulimit', 'nofile=122880:122880',
             '-u',
             my_id,
             '--rm',


### PR DESCRIPTION
# Description 🛠
If anyone were to run these scripts against an ephemeral instance more than once, they'd see a traceback. That scenario probably won't happen often, but it'd be good for the scripts to be able to handle it.

The openapi test container was exceeding open file handle quotas when run local, so I also bumped those up for the container ...
```
>           assert docker_pid.returncode == 0, docker_pid.stderr.decode('utf-8')                                                                                                                                                                                                                   E           AssertionError: library initialization failed - unable to allocate file descriptor table - out of memory                                                                                                                                                                               E           assert 139 == 0
E            +  where 139 = CompletedProcess(args='docker run -u 1000 --rm -v /tmp/galaxy-bindings-pczzw7q1/pulp-openapi-generator:/local openapitools/openapi-generator-cli:v4.3.1 generate -i /local/api.json -g python -o /local/galaxy_ng-client --additional-properties=packageName=pulpcore.client.galaxy_ng,projectName=galaxy_ng-client,packageVersion=4.6.0dev -t /local/templates/python --skip-validate-spec --strict-spec=false', returncode=139, stdout=b'', stderr=b'library initialization failed - unable to allocate file descriptor table - out of memory').returncode
```


# Reviewer Checklists  👀
Developer reviewer:
- [x] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [x] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [x] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
