### PR TITLE
Increase file handles in openapi test container

### DIFF
--- a/galaxy_ng/tests/integration/api/test_openapi.py
+++ b/galaxy_ng/tests/integration/api/test_openapi.py
@@ -129,6 +129,7 @@ def test_openapi_bindings_generation(ansible_config):
         cmd = [
             'docker',
             'run',
+            '--ulimit', 'nofile=122880:122880',
             '-u',
             my_id,
             '--rm',


### PR DESCRIPTION
# Description 🛠
The openapi test container was exceeding open file handle quotas when run local, so I also bumped those up for the container ...
```
>           assert docker_pid.returncode == 0, docker_pid.stderr.decode('utf-8')                                                                                                                                                                                                                   E           AssertionError: library initialization failed - unable to allocate file descriptor table - out of memory                                                                                                                                                                               E           assert 139 == 0
E            +  where 139 = CompletedProcess(args='docker run -u 1000 --rm -v /tmp/galaxy-bindings-pczzw7q1/pulp-openapi-generator:/local openapitools/openapi-generator-cli:v4.3.1 generate -i /local/api.json -g python -o /local/galaxy_ng-client --additional-properties=packageName=pulpcore.client.galaxy_ng,projectName=galaxy_ng-client,packageVersion=4.6.0dev -t /local/templates/python --skip-validate-spec --strict-spec=false', returncode=139, stdout=b'', stderr=b'library initialization failed - unable to allocate file descriptor table - out of memory').returncode
```

# Reviewer Checklists  👀
Developer reviewer:
- [x] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [x] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [x] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
