### PR TITLE
Make the ephemeral django scripts idempotent.

### DIFF
--- a/dev/ephemeral/create_objects.py
+++ b/dev/ephemeral/create_objects.py
@@ -2,5 +2,4 @@ from galaxy_ng.app.models import Namespace
 
 print('creating autohubtest2+3 namespace(s)')
 for nsname in ['autohubtest2', 'autohubtest3']:
-    ns = Namespace.objects.create(name=nsname)
-    ns.save()
+    ns, _ = Namespace.objects.get_or_create(name=nsname)


### PR DESCRIPTION
# Description 🛠
If anyone were to run these scripts against an ephemeral instance more than once, they'd see a traceback. That scenario probably won't happen often, but it'd be good for the scripts to be able to handle it.

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
