### PR TITLE
Reroute pulp api under api/automation-hub

### DIFF
--- a/CHANGES/1554.feature
+++ b/CHANGES/1554.feature
@@ -1,0 +1,1 @@
+Reroute pulp api under api/automation-hub

--- a/dev/common/galaxy_ng.env
+++ b/dev/common/galaxy_ng.env
@@ -10,3 +10,5 @@ PULP_REDIS_HOST=redis
 PULP_CONTENT_ORIGIN="http://localhost:5001"
 
 PULP_X_PULP_CONTENT_HOST=content-app
+
+PULP_API_ROOT = "/api/automation-hub/pulp/"

--- a/dev/common/galaxy_ng.env
+++ b/dev/common/galaxy_ng.env
@@ -10,5 +10,4 @@ PULP_REDIS_HOST=redis
 PULP_CONTENT_ORIGIN="http://localhost:5001"
 
 PULP_X_PULP_CONTENT_HOST=content-app
-
 PULP_API_ROOT = "/api/automation-hub/pulp/"

--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -114,6 +114,8 @@ objects:
             value: '10000'
           - name: PULP_REDIS_SSL
             value: ${REDIS_SSL}
+          - name: PULP_API_ROOT
+            value: '/api/automation-hub/pulp/'
           - name: prometheus_multiproc_dir
             value: ${PROMETHEUS_DIR}
           - name: ENABLE_SIGNING


### PR DESCRIPTION
# Description 🛠
Serve the pulp api at `/api/automation-hub/pulp/api/v3/`

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
