### PR TITLE
Stop running the synclist curate all task

### DIFF
--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -294,18 +294,4 @@ class CollectionVersionMoveViewSet(api_base.ViewSet):
 
         response_data['copy_task_id'] = response_data['remove_task_id'] = move_task.pk
 
-        if settings.GALAXY_DEPLOYMENT_MODE == DeploymentMode.INSIGHTS.value:
-            golden_repo = AnsibleDistribution.objects.get(
-                base_path=settings.GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH
-            ).repository
-
-            if dest_repo == golden_repo or src_repo == golden_repo:
-                curate_task = dispatch(
-                    curate_all_synclist_repository,
-                    shared_resources=[golden_repo],
-                    args=(golden_repo.name,),
-                    kwargs={},
-                )
-                response_data['curate_all_synclist_repository_task_id'] = curate_task.pk
-
         return Response(data=response_data, status='202')


### PR DESCRIPTION
# Description 🛠
Previously, any changes to the upstream / golden
repo would cause the 'curate_all_synclist_repository'
task to run. This updates _all_ synclists to reflect
the upstream repo and that was too much.

In combination with changes to private automation hub,
the synclist curation is no longer needed so this change
stops it from running.

Issue: AHA-1556

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
