### PR TITLE
Ensure that container remotes exclude source images by default.

### DIFF
--- a/CHANGES/1557.bugfix
+++ b/CHANGES/1557.bugfix
@@ -1,0 +1,1 @@
+Ensure that container remotes exclude source images by default to prevent networking errors when syncing.

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -414,7 +414,12 @@ class ContainerRemoteSerializer(
 
         validated_data = {**registry.get_connection_fields(), **validated_data}
 
-        # validated_data['url'] = registry.url
+        # Exclude source tags by default since they don't provide much value to customers and
+        # can cause network issues when syncing.
+        validated_data["exclude_tags"] = validated_data.get("exclude_tags", [])
+        if "*-source" not in validated_data["exclude_tags"]:
+            validated_data["exclude_tags"].append("*-source")
+
         request = self.context['request']
 
         # Create the remote instances using data from the registry


### PR DESCRIPTION
Issue: AAH-1557

# Description 🛠
Fixes: https://issues.redhat.com/browse/AAH-1557

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
