### PR TITLE
Use simple string splitting to remove the requirements versions.

### DIFF
--- a/CHANGES/1545.bugfix
+++ b/CHANGES/1545.bugfix
@@ -1,0 +1,1 @@
+Use simple string splitting to remove the requirements versions

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -35,6 +35,7 @@ move: Related to the move api.
 synclist: Related to synclist object and synclist repo.
 openapi: Checks the openapi schema and routes.
 openapi_generate_bindings: Verifies pulp client bindings generator
+package: tests for the pip packaging
 """
 
 

--- a/galaxy_ng/tests/integration/package/test_package_install.py
+++ b/galaxy_ng/tests/integration/package/test_package_install.py
@@ -1,0 +1,56 @@
+"""test_package.py - Tests related to setup.py
+
+See: https://issues.redhat.com/browse/AAH-1545
+
+"""
+
+import pytest
+import subprocess
+import tempfile
+
+
+pytestmark = pytest.mark.qa  # noqa: F821
+
+
+@pytest.mark.standalone_only
+@pytest.mark.package
+@pytest.mark.parametrize(
+    "env_vars",
+    [
+        {},
+        {'LOCK_REQUIREMENTS': '0'}
+    ]
+)
+def test_package_install(env_vars):
+    """smoktest setup.py"""
+
+    with tempfile.TemporaryDirectory(prefix='galaxy_ng_testing_') as basedir:
+
+        # make a venv
+        pid = subprocess.run(f'python3 -m venv {basedir}/venv', shell=True)
+        assert pid.returncode == 0
+
+        # install the package
+        cmd = f'{basedir}/venv/bin/pip install .'
+        if env_vars:
+            for k, v in env_vars.items():
+                cmd = f'{k}={v} {cmd}'
+        pid = subprocess.run(cmd, shell=True)
+        assert pid.returncode == 0
+
+        # check the installed packages
+        cmd = f'{basedir}/venv/bin/pip list'
+        pid = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE)
+        assert pid.returncode == 0
+
+        package_list = pid.stdout.decode('utf-8')
+        package_list = package_list.split('\n')
+        package_list = [x.strip() for x in package_list if x.strip()]
+        package_list = [x for x in package_list if not x.startswith('Package')]
+        package_list = [x for x in package_list if not x.startswith('-')]
+        package_names = [x.split()[0] for x in package_list]
+
+        assert 'pulpcore' in package_names
+        assert 'pulp-ansible' in package_names
+        assert 'pulp-container' in package_names
+        assert 'galaxy-ng' in package_names

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import re
 import tempfile
 import tarfile
 import shutil
@@ -100,6 +99,16 @@ requirements = [
     "dynaconf>=3.1.7",  # 3.1.7 contains support for dynaconf_hooks.
 ]
 
+
+# https://softwareengineering.stackexchange.com/questions/223634/what-is-meant-by-now-you-have-two-problems
+def strip_package_name(spec):
+    operators = ['=', '>', '<', '~', '!', '^']
+    for idc, char in enumerate(spec):
+        if char in operators:
+            return spec[:idc]
+    return spec
+
+
 # next line can be replaced via sed in ci scripts/post_before_install.sh
 unpin_requirements = os.getenv("LOCK_REQUIREMENTS") == "0"
 if unpin_requirements:
@@ -117,7 +126,7 @@ if unpin_requirements:
     ).split(":")
     DEV_SOURCE_PATH += [path.replace("_", "-") for path in DEV_SOURCE_PATH]
     requirements = [
-        re.sub(r"""(=|^|~|<|>|!)([\S]+)""", "", req)
+        strip_package_name(req)
         if req.lower().startswith(tuple(DEV_SOURCE_PATH)) else req
         for req in requirements
     ]


### PR DESCRIPTION
# Description 🛠
https://issues.redhat.com/browse/AAH-1545

```
(venv) [jtanner@jtw530 galaxy_ng]$ python -c 'import re; newstr = re.sub(r"""(=|^|~|<|>|!)([\S]+)""", "", "pulpcore"); print(f"newstr: {newstr}")'
newstr: 
(venv) [jtanner@jtw530 galaxy_ng]$
```

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
