### PR TITLE
settings.py LANGUAGES: add korean

### DIFF
--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -137,6 +137,7 @@ LANGUAGES = [
     # Django 3.0+ requires the language defined in LANGUAGE_CODE to be in this list
     ('en-us', 'English (USA)'),
     ('ja', 'Japanese'),
+    ('ko', 'Korean'),
     ('nl', 'Dutch'),
     ('fr', 'French'),
     ('es', 'Spanish'),


### PR DESCRIPTION
To go with https://github.com/ansible/ansible-hub-ui/pull/2030 & https://github.com/ansible/galaxy_ng/pull/1244,
which add the translations.. enabling in the list of available languages.

(also https://github.com/ansible/ansible-hub-ui/pull/2031)