### PR TITLE
dev/: use UID, GID instead of hardcoding 1000; drop USER_ID

### DIFF
--- a/dev/Dockerfile.base
+++ b/dev/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8
 
-ARG USER_ID=1000
+ARG UID=1000
+ARG GID=1000
 ARG USER_NAME=galaxy
 ARG USER_GROUP=galaxy
 ARG COMPOSE_PROFILE
@@ -21,9 +22,9 @@ ENV LANG=en_US.UTF-8 \
 
 RUN set -ex; \
     id --group "${USER_GROUP}" &>/dev/null \
-    || groupadd --gid "${USER_ID}" "${USER_GROUP}"; \
+    || groupadd --gid "${GID}" "${USER_GROUP}"; \
     \
-    useradd --uid ${USER_ID} --gid "${USER_GROUP}" "${USER_NAME}"
+    useradd --uid ${UID} --gid "${USER_GROUP}" "${USER_NAME}"
 
 # Install dependencies:
 #   * glibc-langpack-en: install missing en_US.UTF-8 locale

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - "${COMPOSE_CONTEXT}/..:/src:z"
       - "pulp:/var/lib/pulp"
     tmpfs:
-      - "/tmp/ansible:uid=1000,gid=1000"
+      - "/tmp/ansible:uid=${UID},gid=${GID}"
     depends_on:
       - _base
       - postgres
@@ -74,7 +74,7 @@ services:
       - "${COMPOSE_CONTEXT}/..:/src:z"
       - "pulp:/var/lib/pulp"
     tmpfs:
-      - "/tmp/ansible:uid=1000,gid=1000"
+      - "/tmp/ansible:uid=${UID},gid=${GID}"
     depends_on:
       - _base
       - postgres
@@ -99,7 +99,7 @@ services:
       - "${COMPOSE_CONTEXT}/..:/src:z"
       - "pulp:/var/lib/pulp"
     tmpfs:
-      - "/tmp/ansible:uid=1000,gid=1000"
+      - "/tmp/ansible:uid=${UID},gid=${GID}"
     depends_on:
       - _base
       - postgres


### PR DESCRIPTION
the problem: running as a user with uid=1001 and owning src/,
the dev environment doesn't work, failing with

    error: could not create 'galaxy_ng.egg-info': Permission denied

or

    running egg_info
    error: [Errno 13] Permission denied

because the docker files assume uid=1000 and gid=1000 for the galaxy user inside the container.

Changing to use the current user's uid & gid.