### PR TITLE
settings.py LANGUAGES: add korean (#1245)

### DIFF
--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -137,6 +137,7 @@ LANGUAGES = [
     # Django 3.0+ requires the language defined in LANGUAGE_CODE to be in this list
     ('en-us', 'English (USA)'),
     ('ja', 'Japanese'),
+    ('ko', 'Korean'),
     ('nl', 'Dutch'),
     ('fr', 'French'),
     ('es', 'Spanish'),


### PR DESCRIPTION
This landed for 4.5.0 in #1245, to go with #1248 / #1249 which add the translations.

Making sure we have it in master as well.