### PR TITLE
Serve all collections at synclist distro, stop curation

### DIFF
--- a/CHANGES/1540.feature
+++ b/CHANGES/1540.feature
@@ -1,0 +1,1 @@
+Serve all collections at synclist distro, stop curation

--- a/galaxy_ng/app/api/v3/views/excludes.py
+++ b/galaxy_ng/app/api/v3/views/excludes.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from galaxy_ng.app import models
 from galaxy_ng.app.access_control import access_policy
 from galaxy_ng.app.api import base as api_base
-from pulp_ansible.app.models import AnsibleDistribution
 from rest_framework.renderers import (
     BaseRenderer,
     BrowsableAPIRenderer,
@@ -17,10 +16,9 @@ from yaml.dumper import SafeDumper
 
 
 def get_synclist_excludes(base_path):
-    """Get Synclist from distro base_path"""
+    """Get SyncList that has same name as distro base_path"""
     try:
-        repo = AnsibleDistribution.objects.get(base_path=base_path).repository
-        synclist = models.SyncList.objects.get(repository=repo, policy="exclude")
+        synclist = models.SyncList.objects.get(name=base_path, policy="exclude")
         return synclist.collections.all()
     except ObjectDoesNotExist:
         return None

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -31,7 +31,6 @@ from galaxy_ng.app.common.parsers import AnsibleGalaxy29MultiPartParser
 from galaxy_ng.app.constants import INBOUND_REPO_NAME_FORMAT, DeploymentMode
 from galaxy_ng.app.tasks import (
     call_move_content_task,
-    curate_all_synclist_repository,
     call_sign_and_move_task,
     import_and_auto_approve,
     import_and_move_to_staging,
@@ -314,14 +313,5 @@ class CollectionVersionMoveViewSet(api_base.ViewSet):
             golden_repo = AnsibleDistribution.objects.get(
                 base_path=settings.GALAXY_API_DEFAULT_DISTRIBUTION_BASE_PATH
             ).repository
-
-            if dest_repo == golden_repo or src_repo == golden_repo:
-                curate_task = dispatch(
-                    curate_all_synclist_repository,
-                    shared_resources=[golden_repo],
-                    args=(golden_repo.name,),
-                    kwargs={},
-                )
-                response_data['curate_all_synclist_repository_task_id'] = curate_task.pk
 
         return Response(data=response_data, status='202')

--- a/galaxy_ng/app/management/commands/update-synclist-distros.py
+++ b/galaxy_ng/app/management/commands/update-synclist-distros.py
@@ -1,0 +1,74 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from pulp_ansible.app.models import AnsibleDistribution, AnsibleRepository
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """This command modifies AnsibleDistributions in format of #####-synclists
+    to change which repository they point to.
+
+    Example:
+
+    django-admin update-synclist-distros --point-each-to-default-repo
+    django-admin update-synclist-distros --point-each-to-synclist-repo
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--point-each-to-default-repo",
+            action="store_true",
+            help="Update all AnsibleDistribution in format of #####-synclists "
+            "to point to published repo",
+            default=False,
+            required=False,
+        )
+        parser.add_argument(
+            "--point-each-to-synclist-repo",
+            action="store_true",
+            help="Update all AnsibleDistribution in format of #####-synclists "
+            "to point to repo of the same name ('12345-synclist' for example)",
+            default=False,
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+        log.debug("options: %s", repr(options))
+
+        if options["point_each_to_default_repo"]:
+            log.info(
+                "Updating all AnsibleDistribution in format of #####-synclists "
+                "to point to published repo"
+            )
+
+            published_repo = AnsibleRepository.objects.get(name="published")
+
+            with transaction.atomic():
+                synclist_distros = AnsibleDistribution.objects.filter(
+                    base_path__endswith="-synclist"
+                )
+                for distro in synclist_distros:
+                    log.debug("distro: %s", distro)
+                    distro.repository = published_repo
+                    distro.save()
+
+        if options["point_each_to_synclist_repo"]:
+            log.info(
+                "Updating all AnsibleDistribution in format of #####-synclists "
+                "to point to repo of the same name"
+            )
+
+            with transaction.atomic():
+                synclist_distros = AnsibleDistribution.objects.filter(
+                    base_path__endswith="-synclist"
+                )
+                for distro in synclist_distros:
+                    log.debug("distro: %s", distro)
+                    synclist_repo, _ = AnsibleRepository.objects.get_or_create(
+                        name=distro.base_path
+                    )
+                    distro.repository = synclist_repo
+                    distro.save()

--- a/galaxy_ng/app/management/commands/update-synclist-distros.py
+++ b/galaxy_ng/app/management/commands/update-synclist-distros.py
@@ -8,67 +8,25 @@ log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    """This command modifies AnsibleDistributions in format of #####-synclists
-    to change which repository they point to.
+    """This command updates all AnsibleDistribution in the format of #####-synclists
+    to point to the published repo.
 
     Example:
-
-    django-admin update-synclist-distros --point-each-to-default-repo
-    django-admin update-synclist-distros --point-each-to-synclist-repo
+    django-admin update-synclist-distros
     """
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--point-each-to-default-repo",
-            action="store_true",
-            help="Update all AnsibleDistribution in format of #####-synclists "
-            "to point to published repo",
-            default=False,
-            required=False,
-        )
-        parser.add_argument(
-            "--point-each-to-synclist-repo",
-            action="store_true",
-            help="Update all AnsibleDistribution in format of #####-synclists "
-            "to point to repo of the same name ('12345-synclist' for example)",
-            default=False,
-            required=False,
-        )
-
     def handle(self, *args, **options):
-        log.debug("options: %s", repr(options))
+        log.info(
+            "Updating all AnsibleDistribution in the format of #####-synclists "
+            "to point to the published repo"
+        )
 
-        if options["point_each_to_default_repo"]:
-            log.info(
-                "Updating all AnsibleDistribution in format of #####-synclists "
-                "to point to published repo"
-            )
+        published_repo = AnsibleRepository.objects.get(name="published")
 
-            published_repo = AnsibleRepository.objects.get(name="published")
-
-            with transaction.atomic():
-                synclist_distros = AnsibleDistribution.objects.filter(
-                    base_path__endswith="-synclist"
-                )
-                for distro in synclist_distros:
-                    log.debug("distro: %s", distro)
+        with transaction.atomic():
+            synclist_distros = AnsibleDistribution.objects.filter(base_path__endswith="-synclist")
+            for distro in synclist_distros:
+                if distro.repository.pk != published_repo.pk:
                     distro.repository = published_repo
                     distro.save()
-
-        if options["point_each_to_synclist_repo"]:
-            log.info(
-                "Updating all AnsibleDistribution in format of #####-synclists "
-                "to point to repo of the same name"
-            )
-
-            with transaction.atomic():
-                synclist_distros = AnsibleDistribution.objects.filter(
-                    base_path__endswith="-synclist"
-                )
-                for distro in synclist_distros:
-                    log.debug("distro: %s", distro)
-                    synclist_repo, _ = AnsibleRepository.objects.get_or_create(
-                        name=distro.base_path
-                    )
-                    distro.repository = synclist_repo
-                    distro.save()
+                    log.info("distro edited: %s", distro.name)


### PR DESCRIPTION
# Description 🛠
galaxy_ng.app.models.SyncList will no longer be used to curate a
SyncList.repository based on an SyncList.upstream_repository.
This PR removes calls to the curate tasks,
which edit SyncList.repos based the published repo.

SyncList.collections will continue to be updated with
excluded content, and display that at the v3/excludes endpoint
of a distribution, i.e.
api/automation-hub/content/########-synclist/v3/excludes/
This lookup will be performed without first looking up SyncList.repository

We want the viewset api/automation-hub/content/########-synclist/v3/collections/
to display all collections. This will be done via a management command that
looks up all AnsibleDistribution named "/########-synclist" and point it
to the published repo.

Issue: AAH-1540

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
