### PR TITLE
Fix URL for download auth in insighs mode

### DIFF
--- a/dev/insights/galaxy_ng.env
+++ b/dev/insights/galaxy_ng.env
@@ -5,5 +5,5 @@ PULP_GALAXY_AUTHENTICATION_CLASSES=['galaxy_ng.app.auth.auth.RHIdentityAuthentic
 PULP_GALAXY_DEPLOYMENT_MODE=insights
 PULP_RH_ENTITLEMENT_REQUIRED=insights
 
-PULP_ANSIBLE_API_HOSTNAME=http://localhost:5001
+PULP_ANSIBLE_API_HOSTNAME=http://localhost:8002
 PULP_ANSIBLE_CONTENT_HOSTNAME=http://localhost:24816/api/automation-hub/v3/artifacts/collections


### PR DESCRIPTION
# Description 🛠
The updated insights mode uses the 8002 port to authenticate and therefore trying to download a collection fails since for the galaxy_ng it sends on the 5001 port. This PR fixes that issue. Thanks @newswangerd for finding this.

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
