### PR TITLE
Fix 500 error when listing Roles for a Group

### DIFF
--- a/CHANGES/1595.bugfix
+++ b/CHANGES/1595.bugfix
@@ -1,0 +1,1 @@
+Fix 500 error when listing Group Roles

--- a/galaxy_ng/app/viewsets.py
+++ b/galaxy_ng/app/viewsets.py
@@ -4,6 +4,7 @@ from rest_framework import mixins
 from galaxy_ng.app import models
 from galaxy_ng.app.access_control import access_policy
 from galaxy_ng.app.api.ui import serializers
+from galaxy_ng.app.api.v3.serializers import NamespaceSerializer
 
 # This file is necesary to prevent the DRF web API browser from breaking on all of the
 # pulp/api/v3/repositories/ endpoints.
@@ -45,3 +46,14 @@ class AuthViewSet(
 ):
     queryset = models.auth.Group.objects.all()
     endpoint_name = "auth"
+
+
+class NamespaceViewSet(
+    pulp_viewsets.NamedModelViewSet,
+    mixins.RetrieveModelMixin,
+    mixins.DestroyModelMixin,
+):
+    queryset = models.Namespace.objects.all()
+    serializer_class = NamespaceSerializer
+    permission_classes = [access_policy.NamespaceAccessPolicy]
+    endpoint_name = "namespace"

--- a/galaxy_ng/tests/integration/api/test_groups.py
+++ b/galaxy_ng/tests/integration/api/test_groups.py
@@ -1,0 +1,53 @@
+"""test_namespace_management.py - Test related to namespaces.
+
+See: https://issues.redhat.com/browse/AAH-1303
+
+"""
+import random
+import string
+import uuid
+
+import pytest
+
+from ..utils import get_client
+
+pytestmark = pytest.mark.qa  # noqa: F821
+
+
+@pytest.mark.group
+@pytest.mark.role
+def test_group_role_listing(ansible_config):
+    """Tests ability to list roles assigned to a namespace."""
+
+    config = ansible_config("ansible_partner")
+    api_client = get_client(config, request_token=True, require_auth=True)
+
+    # Create Group
+    group_name = str(uuid.uuid4())
+    payload = {"name": group_name}
+    group_response = api_client("/api/automation-hub/_ui/v1/groups/", args=payload, method="POST")
+    assert group_response["name"] == group_name
+
+    # Create Namespace
+    ns_name = "".join(random.choices(string.ascii_lowercase, k=10))
+    payload = {
+        "name": ns_name,
+        "groups": [
+            {
+                "name": f"{group_response['name']}",
+                "object_roles": ["galaxy.namespace_owner"],
+                "object_permissions": ["galaxy.upload_to_namespace"],
+            }
+        ],
+    }
+    ns_response = api_client("/api/automation-hub/v3/namespaces/", args=payload, method="POST")
+    assert ns_response["name"] == ns_name
+    assert ns_response["groups"][0]["name"] == group_response["name"]
+
+    # List Group's Roles
+    group_roles_response = api_client(
+        f'/pulp/api/v3/groups/{group_response["id"]}/roles/', method="GET"
+    )
+    assert group_roles_response["count"] == 1
+    assert group_roles_response["results"][0]["role"] == "galaxy.namespace_owner"
+    assert f'/groups/{group_response["id"]}/' in group_roles_response["results"][0]["pulp_href"]

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -36,6 +36,7 @@ synclist: Related to synclist object and synclist repo.
 openapi: Checks the openapi schema and routes.
 openapi_generate_bindings: Verifies pulp client bindings generator
 role: Related to RBAC Roles
+group: Related to Groups
 """
 
 


### PR DESCRIPTION
# Description 🛠
Fixes 500 error experienced when listing a Groups Roles.  The Group should be added to a Namespace (along with adding a Role to the Group).

# Reviewer Checklists  👀
Developer reviewer:
- [ ] Code looks sound, good architectural decisions, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/)
- [ ] There is a Jira issue associated (note that "No-Issue" should be rarely used)
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed

QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)):
- [ ] Tests are included in `galaxy_ng/tests/integration` or `galaxy_ng/tests/functional`, and they fully cover necessary test scenarios… or tests not needed
- [ ] PR meets applicable Acceptance Criteria for associated Jira issue

Note: when merging, include the Jira issue link in the squashed commit
