### PR TITLE
Add waits for task moves to integration tests

### DIFF
--- a/galaxy_ng/tests/integration/api/test_artifact_upload.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_upload.py
@@ -9,7 +9,8 @@ from urllib.parse import urljoin
 import pytest
 from orionutils.generator import build_collection, randstr
 
-from ..constants import USERNAME_PUBLISHER
+from galaxy_ng.tests.integration.constants import SLEEP_SECONDS_POLLING, USERNAME_PUBLISHER
+
 from ..utils import (
     CapturingGalaxyError,
     get_client,
@@ -335,7 +336,7 @@ def test_ansible_lint_exception(ansible_config, upload_artifact):
     while not ready:
         resp = api_client(url)
         ready = resp["state"] not in ("running", "waiting")
-        time.sleep(5)
+        time.sleep(SLEEP_SECONDS_POLLING)
 
     log_messages = [item["message"] for item in resp["messages"]]
 
@@ -382,7 +383,7 @@ def test_api_publish_log_missing_ee_deps(ansible_config, upload_artifact):
     while not ready:
         resp = api_client(url)
         ready = resp["state"] not in ("running", "waiting")
-        time.sleep(5)
+        time.sleep(SLEEP_SECONDS_POLLING)
 
     log_messages = [item["message"] for item in resp["messages"]]
 
@@ -424,7 +425,7 @@ def test_api_publish_ignore_files_logged(ansible_config, upload_artifact):
     while not ready:
         resp = api_client(url)
         ready = resp["state"] not in ("running", "waiting")
-        time.sleep(5)
+        time.sleep(SLEEP_SECONDS_POLLING)
 
     log_messages = [item["message"] for item in resp["messages"]]
 
@@ -461,7 +462,7 @@ def test_publish_fail_required_tag(ansible_config, upload_artifact):
     while not ready:
         resp = api_client(url)
         ready = resp["state"] not in ("running", "waiting")
-        time.sleep(5)
+        time.sleep(SLEEP_SECONDS_POLLING)
 
     assert resp["state"] == "failed"
     assert (

--- a/galaxy_ng/tests/integration/api/test_collection_delete.py
+++ b/galaxy_ng/tests/integration/api/test_collection_delete.py
@@ -3,16 +3,19 @@
 See: https://issues.redhat.com/browse/AAH-1303
 
 """
-import pytest
 import time
 
+import pytest
 from ansible.galaxy.api import GalaxyError
 
-from ..utils import get_client
-from ..utils import get_all_collections_by_repo
-from ..utils import get_all_repository_collection_versions
-from ..utils import wait_for_task
+from galaxy_ng.tests.integration.constants import SLEEP_SECONDS_ONETIME
 
+from ..utils import (
+    get_all_collections_by_repo,
+    get_all_repository_collection_versions,
+    get_client,
+    wait_for_task,
+)
 
 pytestmark = pytest.mark.qa  # noqa: F821
 
@@ -51,7 +54,7 @@ def test_delete_collection(ansible_config, uncertifiedv2):
     except GalaxyError as ge:
         # FIXME - pulp tasks do not seem to accept token auth
         if ge.http_code in [403, 404]:
-            time.sleep(5)
+            time.sleep(SLEEP_SECONDS_ONETIME)
         else:
             raise Exception(ge)
 
@@ -115,7 +118,7 @@ def test_delete_collection_version(ansible_config, upload_artifact, uncertifiedv
             except GalaxyError as ge:
                 # FIXME - pulp tasks do not seem to accept token auth
                 if ge.http_code in [403, 404]:
-                    time.sleep(5)
+                    time.sleep(SLEEP_SECONDS_ONETIME)
                 else:
                     raise Exception(ge)
 

--- a/galaxy_ng/tests/integration/api/test_collection_delete.py
+++ b/galaxy_ng/tests/integration/api/test_collection_delete.py
@@ -1,8 +1,6 @@
-"""test_namespace_management.py - Test related to namespaces.
-
-See: https://issues.redhat.com/browse/AAH-1303
-
+"""test_collection_delete.py - Tests related to collection deletion.
 """
+
 import time
 
 import pytest

--- a/galaxy_ng/tests/integration/api/test_collection_signing.py
+++ b/galaxy_ng/tests/integration/api/test_collection_signing.py
@@ -4,15 +4,17 @@ See: https://issues.redhat.com/browse/AAH-312
 """
 
 import logging
-import tarfile
-import requests
 import os
-from tempfile import TemporaryDirectory
+import tarfile
 import time
+from tempfile import TemporaryDirectory
 from urllib.parse import urljoin
 
 import pytest
+import requests
 from orionutils.generator import build_collection
+
+from galaxy_ng.tests.integration.constants import SLEEP_SECONDS_ONETIME, SLEEP_SECONDS_POLLING
 
 from ..utils import get_all_collections_by_repo, get_all_namespaces, get_client, set_certification
 
@@ -56,7 +58,7 @@ def import_and_wait(api_client, artifact, upload_artifact, config):
     while not ready:
         resp = api_client(url)
         ready = resp["state"] not in ("running", "waiting")
-        time.sleep(1)
+        time.sleep(SLEEP_SECONDS_POLLING)
     assert resp["state"] == "completed"
     return resp
 
@@ -68,7 +70,7 @@ def sign_on_demand(api_client, signing_service, sign_url=None, **payload):
     resp = api_client(sign_url, method="POST", args=sign_payload)
     log.info("Sign Task: %s", resp)
     # FIXME - pulp tasks do not seem to accept token auth, so no way to check task progress
-    time.sleep(3)
+    time.sleep(SLEEP_SECONDS_ONETIME)
     return resp
 
 
@@ -403,7 +405,7 @@ def test_upload_signature(api_client, config, settings, upload_artifact):
         )
         assert "task" in response.json()
 
-    time.sleep(5)  # wait for the task to finish
+    time.sleep(SLEEP_SECONDS_ONETIME)  # wait for the task to finish
 
     # Assert that the collection is signed on v3 api
     collection = api_client(

--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -67,6 +67,9 @@ def test_move_collection_version(ansible_config, upload_artifact):
         time.sleep(1)
     assert resp['state'] == 'completed'
 
+    # wait for move task from `inbound-<namespace>` repo to `staging` repo
+    time.sleep(3)
+
     # Make sure it ended up in staging but not in published ...
     before = get_all_collections()
     assert ckey in before['staging']

--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -3,15 +3,16 @@
 See: https://issues.redhat.com/browse/AAH-1268
 
 """
-import pytest
 import time
 from urllib.parse import urljoin
+
+import pytest
 from orionutils.generator import build_collection
 
-from ..constants import USERNAME_PUBLISHER
-from ..utils import get_client
-from ..utils import set_certification
+from galaxy_ng.tests.integration.constants import SLEEP_SECONDS_ONETIME, SLEEP_SECONDS_POLLING
 
+from ..constants import USERNAME_PUBLISHER
+from ..utils import get_client, set_certification
 
 pytestmark = pytest.mark.qa  # noqa: F821
 
@@ -64,11 +65,11 @@ def test_move_collection_version(ansible_config, upload_artifact):
     while not ready:
         resp = api_client(url)
         ready = resp["state"] not in ("running", "waiting")
-        time.sleep(1)
+        time.sleep(SLEEP_SECONDS_POLLING)
     assert resp['state'] == 'completed'
 
     # wait for move task from `inbound-<namespace>` repo to `staging` repo
-    time.sleep(3)
+    time.sleep(SLEEP_SECONDS_ONETIME)
 
     # Make sure it ended up in staging but not in published ...
     before = get_all_collections()

--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -84,6 +84,9 @@ def test_move_collection_version(ansible_config, upload_artifact):
     assert cert_result['href'] is not None
     assert cert_result['metadata']['tags'] == ['tools']
 
+    # wait for move task from `staging` repo to `published` repo
+    time.sleep(SLEEP_SECONDS_ONETIME)
+
     # Make sure it's moved to the right place ...
     after = get_all_collections()
     assert ckey not in after['staging']

--- a/galaxy_ng/tests/integration/cli/test_dependencies.py
+++ b/galaxy_ng/tests/integration/cli/test_dependencies.py
@@ -1,13 +1,13 @@
 """test_dependencies.py - Tests of collection dependency handling."""
 import logging
+import time
 
 import attr
 import pytest
 
-from ..utils import ansible_galaxy
-from ..utils import get_client
-from ..utils import set_certification
-from ..utils import build_collection
+from galaxy_ng.tests.integration.constants import SLEEP_SECONDS_ONETIME
+
+from ..utils import ansible_galaxy, build_collection, get_client, set_certification
 
 pytestmark = pytest.mark.qa  # noqa: F821
 
@@ -67,6 +67,9 @@ def test_collection_dependency_install(ansible_config, published, cleanup_collec
             return pytest.xfail()
         else:
             raise
+
+    # wait for move task from `inbound-<namespace>` repo to `staging` repo
+    time.sleep(SLEEP_SECONDS_ONETIME)
 
     if retcode == 0:
         config = ansible_config("ansible_insights")

--- a/galaxy_ng/tests/integration/cli/test_dependencies.py
+++ b/galaxy_ng/tests/integration/cli/test_dependencies.py
@@ -76,6 +76,9 @@ def test_collection_dependency_install(ansible_config, published, cleanup_collec
         client = get_client(config)
         set_certification(client, artifact2)
 
+        # wait for move task from `staging` repo to `published` repo
+        time.sleep(SLEEP_SECONDS_ONETIME)
+
         pid = ansible_galaxy(
             f"collection install -vvv --ignore-cert \
                 {artifact2.namespace}.{artifact2.name}:{artifact2.version} --server=automation_hub",

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import time
 
 import pytest
 # from orionutils.generator import build_collection
@@ -213,11 +214,16 @@ def uncertifiedv2(ansible_config, artifact):
         payload = {'name': artifact.namespace, 'groups': []}
         api_client('/api/automation-hub/v3/namespaces/', args=payload, method='POST')
 
-    # Publish and certify v1 ...
+    # publish
     ansible_galaxy(
         f"collection publish {artifact.filename}",
         ansible_config=ansible_config("ansible_partner", namespace=artifact.namespace)
     )
+
+    # wait for move task from `inbound-<namespace>` repo to `staging` repo
+    time.sleep(3)
+
+    # certify v1
     set_certification(api_client, artifact)
 
     # Increase collection version
@@ -234,6 +240,9 @@ def uncertifiedv2(ansible_config, artifact):
         f"collection publish {artifact2.filename}",
         ansible_config=ansible_config("ansible_partner", namespace=artifact.namespace)
     )
+
+    # wait for move task from `inbound-<namespace>` repo to `staging` repo
+    time.sleep(3)
 
     return (artifact, artifact2)
 

--- a/galaxy_ng/tests/integration/constants.py
+++ b/galaxy_ng/tests/integration/constants.py
@@ -3,3 +3,9 @@
 USERNAME_ADMIN = "ansible-insights"
 USERNAME_CONSUMER = "autohubtest3"
 USERNAME_PUBLISHER = "autohubtest2"
+
+# time.sleep() seconds for checks that poll in a loop
+SLEEP_SECONDS_POLLING = 1
+
+# time.sleep() seconds for checks that wait once
+SLEEP_SECONDS_ONETIME = 3


### PR DESCRIPTION
#### What is this PR doing:
Integration tests waited for publish (import) to finish but did not wait
for the move task from `inbound-<namespace>` repo to `staging` before
checking `staging` repo. This may be cause of intermittent testing
errors.

<!-- Add Jira issue link -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit