### PR TITLE
Removing hardcoded environment variables from dev

### DIFF
--- a/.compose.env.example
+++ b/.compose.env.example
@@ -3,6 +3,13 @@
 # Set tp standalone-keycloak to enable the Social Auth Login
 COMPOSE_PROFILE=standalone
 
+# The following two variables were initally specified in the galaxy_ng.env file. 
+# When wanna reach the same environment for cypress testing as in CI
+# you should set PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=False in galaxy_ng/app/settings.py
+# otherwise cypress cannot change it. 
+# PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=False
+# PULP_GALAXY_AUTO_SIGN_COLLECTIONS=True
+
 # Add extra paths to run project dependencies from local filesystem in editable mode
 # The order of repositories in the list is important, it is `:` separated.
 # DEV_SOURCE_PATH='pulpcore:pulp_ansible:galaxy_ng'

--- a/dev/standalone/galaxy_ng.env
+++ b/dev/standalone/galaxy_ng.env
@@ -3,8 +3,12 @@ PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
 PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
 PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication', 'rest_framework.authentication.BasicAuthentication']
 PULP_GALAXY_DEPLOYMENT_MODE=standalone
-PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false
-PULP_GALAXY_AUTO_SIGN_COLLECTIONS=true
+
+# Commenting this out so local cypress can pass.
+# If needed can be specified in the `.compose.env` file.
+# PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false
+# PULP_GALAXY_AUTO_SIGN_COLLECTIONS=true
+
 PULP_GALAXY_COLLECTION_SIGNING_SERVICE=ansible-default
 PULP_RH_ENTITLEMENT_REQUIRED=insights
 


### PR DESCRIPTION
No-Issue

#### What is this PR doing:
Removing the two hardcoded env variables from the dev setup for standalone so [cypress test](https://github.com/ansible/ansible-hub-ui/pull/2069/files) can pass locally. If needed they can be added back in the `.compose.env`

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit