### PR TITLE
flake8.cfg ignore the .venv path per vscode convention

### DIFF
--- a/flake8.cfg
+++ b/flake8.cfg
@@ -8,6 +8,7 @@ exclude =
     */migrations/*,
     .ci/scripts/*,
     .github/workflows/scripts/*,
+    .venv/*,
 
 ignore = BLK,W503,Q000,D,D100,D101,D102,D103,D104,D105,D106,D107,D200,D401,D402,E203
 max-line-length = 100


### PR DESCRIPTION
#### What is this PR doing:
vscode has a convention for invoking a .venv path in the project folder. Unfortunately that path is subject to flake8 and will cause a bunch of errors. I know the venv path is a convention with no standards, but we can expand over time if needed.

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit