### PR TITLE
compose.env.example - fix pythonisms

### DIFF
--- a/.compose.env.example
+++ b/.compose.env.example
@@ -3,12 +3,12 @@
 # Set tp standalone-keycloak to enable the Social Auth Login
 COMPOSE_PROFILE=standalone
 
-# The following two variables were initally specified in the galaxy_ng.env file. 
-# When wanna reach the same environment for cypress testing as in CI
-# you should set PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=False in galaxy_ng/app/settings.py
-# otherwise cypress cannot change it. 
-# PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=False
-# PULP_GALAXY_AUTO_SIGN_COLLECTIONS=True
+# The following two variables were initally specified in the galaxy_ng.env file.
+# If you want the same environment for cypress testing as in CI
+# you should set GALAXY_REQUIRE_CONTENT_APPROVAL=False in galaxy_ng/app/settings.py
+# otherwise cypress cannot change it.
+# PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false
+# PULP_GALAXY_AUTO_SIGN_COLLECTIONS=true
 
 # Add extra paths to run project dependencies from local filesystem in editable mode
 # The order of repositories in the list is important, it is `:` separated.


### PR DESCRIPTION
The comment was added in #1268, but the example is using python True & False instad of true & false as the rest of the options.

And the note about changing settings.py mentions the name as it would be used in .compose.env, but not in settings.py. (PULP_ prefixed)

Cc @brumik @rochacbruno 