### PR TITLE
Add make command to snapshot database.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 # Editors
 .vscode/
 .idea/
+
+# Galaxy NG
+db_snapshots/

--- a/Makefile
+++ b/Makefile
@@ -132,14 +132,14 @@ docker/resetdb:   ## Cleans database
 
 .PHONY: docker/db_snapshot
 NAME ?= galaxy
-docker/db_snapshot:   ## Snapshot database. Example: make docker/db_snapshot NAME=my_special_backup
+docker/db_snapshot:   ## Snapshot database with optional NAME param. Example: make docker/db_snapshot NAME=my_special_backup
 	docker exec galaxy_ng_postgres_1 pg_dump -U galaxy_ng -F c -b -f "/galaxy.backup" galaxy_ng
 	mkdir -p db_snapshots/
 	docker cp galaxy_ng_postgres_1:/galaxy.backup db_snapshots/$(NAME).backup
 
 .PHONY: docker/db_restore
 NAME ?= galaxy
-docker/db_restore:   ## Restore database from a snapshot. Example: make docker/db_restore NAME=my_special_backup
+docker/db_restore:   ## Restore database from a snapshot with optional NAME param. Example: make docker/db_restore NAME=my_special_backup
 	docker cp db_snapshots/$(NAME).backup galaxy_ng_postgres_1:/galaxy.backup
 	docker exec galaxy_ng_postgres_1 pg_restore --clean -U galaxy_ng -d galaxy_ng "/galaxy.backup"
 


### PR DESCRIPTION
Usage:

`make docker/db_snapshot` -> create a database dump and save it to db_snapshots/galaxy.backup
`make docker/db_restore` -> restore the database from db_snapshots/galaxy.backup

Multiple snapshots can be made by passing in `NAME=`

`make docker/db_snapshot NAME=pre-migration` -> creates db_snapshots/pre-migration.backup
`make docker/db_restore NAME=pre-migration` -> restores db_snapshots/pre-migration.backup

This command was originally created to help debug the permissions to roles migration, however I have found it to be useful for cleaning up after tests run as well and wanted to share it.