### PR TITLE
[dev env] Reload API when .compose.env is changed

### DIFF
--- a/dev/common/dynaconf_hooks.py
+++ b/dev/common/dynaconf_hooks.py
@@ -1,0 +1,18 @@
+from dynaconf.utils.parse_conf import parse_conf_data
+from dynaconf.vendor.dotenv import dotenv_values
+
+
+def post(settings):
+    """This is file is meant to be used only on dev environment
+
+    The main goal is to:
+    - load `.compose.env` file values and override the settings with those values
+      whenever the application restarts
+    - The docker API container is set to restart when .compose.env changes.
+    """
+    data = {
+        k[5:]: parse_conf_data(v, tomlfy=True, box_settings=settings)
+        for k, v in dotenv_values("/src/galaxy_ng/.compose.env").items()
+        if k.startswith("PULP_")
+    }
+    return data

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - './common/galaxy_ng.env'
     volumes:
       - "./common/settings.py:/etc/pulp/settings.py:z"
+      - "./common/dynaconf_hooks.py:/etc/pulp/dynaconf_hooks.py:z"
       - "./common/collection_sign.sh:/var/lib/pulp/scripts/collection_sign.sh:z"
       - "${COMPOSE_CONTEXT}/..:/src:z"
       - "pulp:/var/lib/pulp"

--- a/docker/bin/start-api-reload
+++ b/docker/bin/start-api-reload
@@ -16,6 +16,9 @@ readonly APP_MODULE='pulpcore.app.wsgi:application'
 GUNICORN_OPTIONS=(
   --bind "${BIND_HOST}:${BIND_PORT}"
   --workers "${GUNICORN_WORKERS}"
+  --reload-extra-file /etc/pulp/settings.py 
+  --reload-extra-file /etc/pulp/dynaconf_hooks.py 
+  --reload-extra-file /src/galaxy_ng/.compose.env
   --access-logfile -
   --reload
 )


### PR DESCRIPTION
When developer makes changes on `.compose.env` or `dev/common/settings.py`
the API container reloads the gunicorn process and settings are reflected immediately.

Affects: Docker based dev environment only

No-Issue