### PR TITLE
[dev env] reload pulpcore-worker when file changes

### DIFF
--- a/dev/Dockerfile.base
+++ b/dev/Dockerfile.base
@@ -39,6 +39,7 @@ RUN set -ex; \
         libpq \
         libpq-devel \
         pinentry \
+        make \
     && dnf clean all \
     && rm -rf /var/cache/dnf/ \
     && rm -f /var/lib/rpm/__db.* \
@@ -46,6 +47,13 @@ RUN set -ex; \
     && chown ${USER_NAME}:${USER_GROUP} /venv \
     && mkdir --mode=2775 /app \
     && chown ${USER_NAME}:${USER_GROUP} /app
+
+# Install entr so we can have reload on worker processes
+RUN git clone https://github.com/eradman/entr && \
+    cd entr && \
+    cp Makefile.linux Makefile && \
+    make && \
+    make install
 
 USER ${USER_NAME}:${USER_GROUP}
 RUN set -ex; \

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -60,7 +60,7 @@ services:
 
   worker:
     image: "localhost/galaxy_ng/galaxy_ng:${COMPOSE_PROFILE}${DEV_IMAGE_SUFFIX:-}"
-    command: ['run', 'worker']
+    command: ['run', 'worker-reload']
     environment:
       - "WITH_DEV_INSTALL=${WITH_DEV_INSTALL}"
       - "LOCK_REQUIREMENTS=${LOCK_REQUIREMENTS}"

--- a/docker/bin/start-worker-reload
+++ b/docker/bin/start-worker-reload
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+WATCHED_FILES=$(python -c "print(' '.join([f'/src/{item}' for item in '$DEV_SOURCE_PATH'.split(':')]))")
+exec find $WATCHED_FILES \( -path /src/galaxy_ng/.venv -o -path /src/galaxy_ng/build -o -path /src/galaxy_ng/.eggs \) -prune -o -name '*.py' -o -name '*.env' | entr -n -r pulpcore-worker


### PR DESCRIPTION
When any `*.py` or `*.env` file changes on galaxy_ng or any other directory added to `DEV_SOURCE_PATH` then worker reloads inside the container.

Affects: docker based dev environment only

No-Issue

