### PR TITLE
Update README's openapi spec url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To learn more about Pulp, [view the Pulp project page](https://pulpproject.org/)
 
 ## OpenAPI Spec
 
-View the latest version of the spec by [clicking here](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/ansible/galaxy_ng/master/openapi/openapi.yaml).
+View the latest version of the spec by [clicking here](https://console.redhat.com/api/automation-hub/v3/openapi.yaml).
 
 ## Contributing
 


### PR DESCRIPTION
#### What is this PR doing:
```
speaking of galaxy_ng, I tried to look at the open API spec listed in the readme and the link is broken
seems like it was removed in some PR because it was out of date and the app auto-generates one at runtime
but for someone not running it, there's now no way to view it, and the readme still has that broken link
would've opened an issue, but that customized jira instance hosting the issues is um... super hard to interact with, sorry
```
#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit