### PR TITLE
Add make commands for functional tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,3 +243,17 @@ docs/build:
 
 docs/serve:
 	@mkdocs serve
+
+.PHONY: test/functional/generate_client
+test/functional/generate_client:         ## Opens bash session in the api container
+	./dev/pulp_smash/generate_client.sh $(PLUGIN)
+
+.PHONY: test/functional/install_requirements
+test/functional/install_requirements:         ## Opens bash session in the api container
+	./dev/pulp_smash/generate_client.sh pulpcore
+	./dev/pulp_smash/generate_client.sh $(PLUGIN)
+	./dev/pulp_smash/install_requirements.sh $(PLUGIN)
+
+.PHONY: test/functional/run
+test/functional/run:         ## Opens bash session in the api container
+	./dev/pulp_smash/run_functional_tests.sh $(PLUGIN) $(FLAGS)

--- a/dev/pulp_smash/generate_client.sh
+++ b/dev/pulp_smash/generate_client.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+declare PROJECT=$1
+
+if [[ "$VIRTUAL_ENV" == "" ]]
+then
+    echo "This command must be run in a python virtual env."
+    exit 1
+fi
+
+if [ ! -d "../pulp-openapi-generator/" ] 
+then
+    echo "Please clone github.com:pulp/pulp-smash.git into ../pulp-openapi-generator/"
+    exit 1
+fi
+
+cd ../pulp-openapi-generator/
+
+export PULP_URL=http://localhost:5001
+export PULP_API_ROOT=/api/automation-hub/pulp/
+
+./generate.sh $PROJECT python
+
+pip install -e ../pulp-openapi-generator/$PROJECT-client

--- a/dev/pulp_smash/install_requirements.sh
+++ b/dev/pulp_smash/install_requirements.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+declare PROJECT=$1
+
+if [[ "$VIRTUAL_ENV" == "" ]]
+then
+    echo "This command must be run in a python virtual env."
+    exit 1
+fi
+
+if [ ! -d "../$PROJECT/" ] 
+then
+    echo "Please clone $PROJECT into ../$PROJECT/"
+    exit 1
+fi
+
+cd ../$PROJECT/
+
+pip install -e .
+pip install -r functest_requirements.txt

--- a/dev/pulp_smash/requirements.txt
+++ b/dev/pulp_smash/requirements.txt
@@ -1,0 +1,6 @@
+pulp-smash @ git+https://github.com/pulp/pulp-smash.git
+orionutils
+pytest
+python-gnupg
+pulpcore-client
+pulp-file-client

--- a/dev/pulp_smash/run_functional_tests.sh
+++ b/dev/pulp_smash/run_functional_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+declare PROJECT=$1
+
+set -e
+
+if [[ "$VIRTUAL_ENV" == "" ]]
+then
+    echo "This command must be run in a python virtual env."
+    exit 1
+fi
+
+export XDG_CONFIG_HOME=dev/ 
+
+pytest -r sx --color=yes --pyargs $PROJECT.tests.functional ${@:2}

--- a/dev/pulp_smash/settings.json
+++ b/dev/pulp_smash/settings.json
@@ -1,0 +1,36 @@
+{
+  "hosts": [
+    {
+      "hostname": "localhost",
+      "roles": {
+        "api": {
+          "port": 5001,
+          "scheme": "http",
+          "service": "nginx",
+          "verify": false
+        },
+        "content": {
+          "port": 24816,
+          "scheme": "http",
+          "service": "pulp_content_app",
+          "verify": false
+        },
+        "pulp resource manager": {},
+        "pulp workers": {},
+        "redis": {},
+        "shell": {
+          "transport": "docker",
+          "container": "galaxy_ng_api_1"
+        }
+      }
+    }
+  ],
+  "pulp": {
+    "auth": [
+      "admin",
+      "admin"
+    ],
+    "selinux enabled": false,
+    "version": "3"
+  }
+}


### PR DESCRIPTION
No-Issue

## Instructions

Create a new python virtual environment and activate it.

```
python3 -m venv venv/

source venv/bin/activate
```

Clone [pulp open api generator](https://github.com/pulp/pulp-openapi-generator) into the directory above galaxy_ng as well as any other pulp plugins you want to test (such as pulp_ansible or galaxy_ng). The parent dir should look something like this:

```
..
├── ansible-hub-ui
├── galaxy-importer
├── galaxy_ng
├── pulp-openapi-generator
├── pulp_ansible
├── pulp_container
└── pulpcore
```

With the `./compose up` environment running, run the following make commands from the galaxy_ng project:

NOTE: Pulp smash will ask you for your password to inspect the containers.

```
# Install the test dependencies and bindings.
make test/functional/install_requirements PLUGIN=pulp_ansible

# Run the tests
make test/functional/run PLUGIN=pulp_ansible FLAGS="-k test_download_with_content_guard"
```

After making any changes to the API (this includes query parameters, serializers, routes etc) you'll need to rebuild the pulp bindings:

```
make test/functional/generate_client PLUGIN=pulp_ansible
```

Notes:
- `PLUGIN` is required on each of these make commands and should be the name of the git checkout for the plugin. `pulpcore`, `galaxy_ng`, `pulp_ansible` and `pulp_container` should work.
- `test/functional/run` takes and optional `FLAGS` argument that allows the user to pass pytest flags to pytest. A handy one is `-k name_of_my_test` which allows the user to run any test that match the given name.