### PR TITLE
Remove the '--editable' pip flag for prod Dockerfile

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -39,7 +39,7 @@ RUN set -ex; \
                                /var/lib/pulp/tmp \
                                /etc/pulp/certs \
                                /tmp/ansible && \
-    pip install --no-deps --editable /app && \
+    pip install --no-deps /app && \
     PULP_CONTENT_ORIGIN=x django-admin collectstatic && \
     install -Dm 0644 /app/ansible.cfg /etc/ansible/ansible.cfg && \
     install -Dm 0644 /app/docker/etc/settings.py /etc/pulp/settings.py && \


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Remove the '--editable' pip flag for prod

Introduced in 63179d0984a75f9689401940dd6078160bc2cd62
but presumably not needed now.

Issue: No-Issue


#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit