### PR TITLE
Pin pulp-ansible in plugin_template, add make cmd

### DIFF
--- a/.github/workflows/pulp_constraints.yml
+++ b/.github/workflows/pulp_constraints.yml
@@ -11,4 +11,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run script to validate commits for both pull request and a push
-        run: make pulp/template-plugin-check
+        run: make pulp/plugin-template-check

--- a/.github/workflows/scripts/before_install.sh
+++ b/.github/workflows/scripts/before_install.sh
@@ -122,7 +122,7 @@ fi
 cd ..
 
 
-git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.13
+git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.13.0
 cd pulp_ansible
 
 if [ -n "$PULP_ANSIBLE_PR_NUMBER" ]; then

--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -32,7 +32,7 @@ TAG=ci_build
 if [ -e $REPO_ROOT/../pulp_ansible ]; then
   PULP_ANSIBLE=./pulp_ansible
 else
-  PULP_ANSIBLE=git+https://github.com/pulp/pulp_ansible.git@0.13
+  PULP_ANSIBLE=git+https://github.com/pulp/pulp_ansible.git@0.13.0
 fi
 
 if [ -e $REPO_ROOT/../pulp_container ]; then

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,14 @@ requirements/pip-upgrade-all:     ## Update based on setup.py and *.in files, an
 	pip-compile -o requirements/requirements.insights.txt setup.py requirements/requirements.insights.in --upgrade
 	pip-compile -o requirements/requirements.standalone.txt setup.py requirements/requirements.standalone.in --upgrade
 
-.PHONY: pulp/template-plugin-check
-pulp/template-plugin-check:
+.PHONY: pulp/plugin-template-check
+pulp/plugin-template-check:
 	./dev/common/check_pulp_template.sh
+
+.PHONY: pulp/run-plugin-template-script
+pulp/run-plugin-template-script:
+	echo "Running plugin_template script in sibling directory"
+	cd ../plugin_template/ && ./plugin-template --github galaxy_ng
 
 # Repository management
 

--- a/template_config.yml
+++ b/template_config.yml
@@ -5,7 +5,7 @@
 
 additional_repos:
 - bindings: true
-  branch: 0.13
+  branch: 0.13.0
   name: pulp_ansible
   org: pulp
 - bindings: true


### PR DESCRIPTION
#### What is this PR doing:
* Fix tests: pin CI pulp-ansible version to a release and not HEAD
* Add make command to run the `plugin_template` script
* Updated existing make command name to match `plugin_template`: `pulp/plugin-template-check`
 
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit