### PR TITLE
Make roles and group/roles visible for users with group permission

### DIFF
--- a/galaxy_ng/app/access_control/statements/insights.py
+++ b/galaxy_ng/app/access_control/statements/insights.py
@@ -226,4 +226,31 @@ INSIGHTS_STATEMENTS = {
             "condition": "has_rh_entitlements",
         },
     ],
+
+    'groups/roles': [
+        {
+            "action": ["list", "retrieve"],
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.view_group"
+        },
+        {
+            "action": "*",
+            "principal": "admin",
+            "effect": "allow"
+        }
+    ],
+    'roles': [
+        {
+            "action": ["list"],
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.view_group"
+        },
+        {
+            "action": "*",
+            "principal": "admin",
+            "effect": "allow"
+        }
+    ]
 }

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -397,11 +397,16 @@ STANDALONE_STATEMENTS = {
 
     'groups/roles': [
         {
-            "action": ["list"],
+            "action": ["list", "retrieve"],
             "principal": "authenticated",
             "effect": "allow",
             "condition": "has_model_perms:galaxy.view_group"
         },
+        {
+            "action": "*",
+            "principal": "admin",
+            "effect": "allow"
+        }
     ],
     'roles': [
         {
@@ -410,5 +415,10 @@ STANDALONE_STATEMENTS = {
             "effect": "allow",
             "condition": "has_model_perms:galaxy.view_group"
         },
+        {
+            "action": "*",
+            "principal": "admin",
+            "effect": "allow"
+        }
     ]
 }

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -394,4 +394,21 @@ STANDALONE_STATEMENTS = {
             "condition": "has_distro_permission:container.change_containerdistribution"
         },
     ],
+
+    'groups/roles': [
+        {
+            "action": ["list"],
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.view_group"
+        },
+    ],
+    'roles': [
+        {
+            "action": ["list"],
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.view_group"
+        },
+    ]
 }


### PR DESCRIPTION
No-Issue

#### What is this PR doing:
A user with group permission should be able to display `group/roles` and `roles`. Without this, group detail and group management in UI are broken. 

The question is should users with group permissions (`galaxy.view_group`) be able to view roles and visit the `/ui/roles/` screen or only `is_superuser` should be able to do that.

#### Reviewers must know:
Related to [AAH-1699](https://issues.redhat.com/browse/AAH-1699)
#### Notes: 
broken UI:
![Screenshot from 2022-06-13 18-58-01](https://user-images.githubusercontent.com/19647757/173405915-b7a18cc1-c55d-4afe-9688-91c9aacaab26.png)



**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit