### PR TITLE
Allow GALAXY_COLLECTION_SIGNING_SERVICE to be set as empty string

### DIFF
--- a/CHANGES/1709.misc
+++ b/CHANGES/1709.misc
@@ -1,0 +1,1 @@
+Allow GALAXY_COLLECTION_SIGNING_SERVICE to be set as empty string

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -273,8 +273,9 @@ def configure_cors(settings: Dynaconf) -> Dict[str, Any]:
 def configure_feature_flags(settings: Dynaconf) -> Dict[str, Any]:
     """Adds conditional feature flags"""
     data = {}
-    data["GALAXY_FEATURE_FLAGS__collection_signing"] = settings.get(
-        "GALAXY_COLLECTION_SIGNING_SERVICE") is not None
+    data["GALAXY_FEATURE_FLAGS__collection_signing"] = bool(
+        settings.get("GALAXY_COLLECTION_SIGNING_SERVICE", "")
+    )
     data["GALAXY_FEATURE_FLAGS__collection_auto_sign"] = settings.get(
         "GALAXY_AUTO_SIGN_COLLECTIONS", False)
     return data

--- a/galaxy_ng/tests/unit/api/test_api_ui_feature_flags.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_feature_flags.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
+from galaxy_ng.app.dynaconf_hooks import configure_feature_flags
+
 from .base import BaseTestCase, get_current_ui_url
 
 
@@ -21,3 +23,13 @@ class TestUiFeatureFlagsView(BaseTestCase):
         response = self.client.get(self.feature_flags_url)
         self.assertEqual(response.data['execution_environments'], True)
         self.assertEqual(response.data['widget_x'], False)
+
+    def test_dynaconf_collection_signing_flag(self):
+        data = configure_feature_flags(settings)
+        self.assertEqual(data["GALAXY_FEATURE_FLAGS__collection_signing"], True)
+
+        original_setting = settings.GALAXY_COLLECTION_SIGNING_SERVICE
+        settings.GALAXY_COLLECTION_SIGNING_SERVICE = ""
+        data = configure_feature_flags(settings)
+        self.assertEqual(data["GALAXY_FEATURE_FLAGS__collection_signing"], False)
+        settings.GALAXY_COLLECTION_SIGNING_SERVICE = original_setting


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Allow GALAXY_COLLECTION_SIGNING_SERVICE to be set as empty string by OCP.

<!-- Add Jira issue link -->
Issue: AAH-1709

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit