### PR TITLE
dev standalone-keycloak: use keycloak/keycloak:legacy, not latest

### DIFF
--- a/dev/standalone-keycloak/docker-compose.yml
+++ b/dev/standalone-keycloak/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - './standalone-keycloak/galaxy_ng.env'
       - '../.compose.env'
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    image: quay.io/keycloak/keycloak:legacy
     env_file:
       - './standalone-keycloak/keycloak.env'
       - '../.compose.env'


### PR DESCRIPTION
when #889 was merged, the current keycloak version was 15.0.2,
since 17.0.0, `docker run keycloak/keycloak` just shows help instead of running the server
and there's a new `*-legacy` version which still runs the server

Updating to latest legacy, tested with 18.0.1-legacy

(this seems related to https://github.com/keycloak/keycloak/commit/30d2dcb7b3e6f283e4bdd463e051dd8fb80af836 and making https://github.com/keycloak/keycloak-containers legacy)

No-Issue

---

Somebody should test this actually works, I've seen it work and I've seen it fail, either could have been caused by some extra data from running keycloak 15.0.2 which definitely works.