### PR TITLE
Update The Filter For Red Hat Index of EE

### DIFF
--- a/galaxy_ng/app/tasks/index_registry.py
+++ b/galaxy_ng/app/tasks/index_registry.py
@@ -128,7 +128,7 @@ def index_execution_environments_from_redhat_registry(registry_pk, request_data)
     remotes = []
 
     query = {
-        "filter": "build_categories=in=('Automation Execution Environment')",
+        "filter": "build_categories=in=('Automation execution environment')",
         "page": 0,
         "sort_by": "creation_date[asc]"
     }


### PR DESCRIPTION

#### What is this PR doing:
The category is called "Automation execution environment" as of this commit. Without this change the task completes without any issue but does not return any data.

[Currently - Automation Execution Environment](https://catalog.redhat.com/api/containers/v1/repositories?filter=build_categories=in=(%27Automation%20Execution%20Environment%27))
vs
[Modified - Automation execution environment](https://catalog.redhat.com/api/containers/v1/repositories?filter=build_categories=in=(%27Automation%20execution%20environment%27))

<!-- Add Jira issue link -->
Issue: AAH-1737

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit