### PR TITLE
Add user profiles to integration tests

### DIFF
--- a/CHANGES/1449.misc
+++ b/CHANGES/1449.misc
@@ -1,0 +1,1 @@
+Allow integration tests to run with non-admin user

--- a/dev/common/RUN_INTEGRATION.sh
+++ b/dev/common/RUN_INTEGRATION.sh
@@ -6,17 +6,12 @@ if [[ -z $HUB_LOCAL ]]; then
     export NAMESPACE="ephemeral-1riioj"
     export HUB_API_ROOT="https://front-end-aggregator-${NAMESPACE}.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/api/automation-hub/"
     export HUB_AUTH_URL="https://mocks-keycloak-${NAMESPACE}.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/auth/realms/redhat-external/protocol/openid-connect/token"
-    export HUB_USERNAME="jdoe"
-    export HUB_PASSWORD="redhat"
     export HUB_USE_MOVE_ENDPOINT="true"
     unset HUB_TOKEN
 else
     unset NAMESPACE
     unset HUB_AUTH_URL
-    unset HUB_USERNAME
-    unset HUB_PASSWORD
     export HUB_USE_MOVE_ENDPOINT="true"
-    export HUB_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890"
 fi
 
 which virtualenv || pip install --user virtualenv
@@ -34,9 +29,11 @@ echo "PYTHON: $(which python)"
 pip install -r integration_requirements.txt
 pip show epdb || pip install epdb
 
+echo "Setting up test users"
+docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_users.py
 
 # when running user can specify extra pytest arguments such as
-# export HUB_LOCAL=1 
+# export HUB_LOCAL=1
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 if [[ -z $HUB_LOCAL ]]; then
     pytest --capture=no -m "not standalone_only" $@ -v galaxy_ng/tests/integration

--- a/dev/common/setup_test_users.py
+++ b/dev/common/setup_test_users.py
@@ -1,0 +1,25 @@
+from galaxy_ng.app.models.auth import User
+from rest_framework.authtoken.models import Token
+
+# Get or create test users to match keycloak passwords
+basic_user, _ = User.objects.get_or_create(username="iqe_normal_user")
+basic_user.set_password("redhat")
+
+partner_engineer, _ = User.objects.get_or_create(username="jdoe")
+partner_engineer.set_password("redhat")
+
+org_admin, _ = User.objects.get_or_create(username="org-admin")
+org_admin.set_password("redhat")
+
+admin, _ = User.objects.get_or_create(username="notifications_admin")
+admin.set_password("redhat")
+admin.is_superuser = True
+admin.is_staff = True
+admin.save()
+
+
+# Get or create tokens for test users
+Token.objects.get_or_create(user=basic_user, key="abcdefghijklmnopqrstuvwxyz1234567891")
+Token.objects.get_or_create(user=partner_engineer, key="abcdefghijklmnopqrstuvwxyz1234567892")
+Token.objects.get_or_create(user=org_admin, key="abcdefghijklmnopqrstuvwxyz1234567893")
+Token.objects.get_or_create(user=admin, key="abcdefghijklmnopqrstuvwxyz1234567894")

--- a/dev/ephemeral/smoke_test.sh
+++ b/dev/ephemeral/smoke_test.sh
@@ -7,7 +7,7 @@ cat /etc/redhat-release
 cat /etc/issue
 
 echo "RPM packges ..."
-rpm -qa 
+rpm -qa
 
 echo "Set project to ${NAMESPACE}"
 oc project ${NAMESPACE}
@@ -15,23 +15,16 @@ oc project ${NAMESPACE}
 echo "Find galaxy-api pod"
 AH_API_POD=$(oc get pod -l pod=automation-hub-galaxy-api -o custom-columns=POD:.metadata.name --no-headers | head -1)
 
-echo "Fixing keycloak user permissions"
-oc exec -i $AH_API_POD /entrypoint.sh manage shell < dev/ephemeral/fixuser.py
-
 #echo "Create token for keycloak user"
 #oc exec -i $AH_API_POD /entrypoint.sh manage shell < dev/ephemeral/create_token.py
+
+echo "Setting up test users"
+oc exec -i $AH_API_POD /entrypoint.sh manage shell < dev/common/setup_test_users.py
 
 echo "Creating test data"
 oc exec -i $AH_API_POD /entrypoint.sh manage shell < dev/ephemeral/create_objects.py
 
-# What is the username?
-export HUB_USERNAME="jdoe"
-
-# What is the password?
-export HUB_PASSWORD="redhat"
-
-# What is the token?
-#export HUB_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890"
+export TEARDOWN_RAN=1
 
 # Force "publishing" uploaded collections
 export HUB_USE_MOVE_ENDPOINT="true"

--- a/galaxy_ng/app/auth/auth.py
+++ b/galaxy_ng/app/auth/auth.py
@@ -124,7 +124,7 @@ class RHIdentityAuthentication(BaseAuthentication):
                 username=username,
                 defaults=attrs,
             )
-            if created:
+            if group not in user.groups.all():
                 user.groups.add(group)
         return user
 

--- a/galaxy_ng/tests/integration/api/test_synclist.py
+++ b/galaxy_ng/tests/integration/api/test_synclist.py
@@ -12,27 +12,14 @@ from ..utils import get_client, set_certification, wait_for_task
 pytestmark = pytest.mark.qa  # noqa: F821
 
 
-# TODO: see if ansible_config() does or can be made to accept a user param
-@contextmanager
-def set_username_env_var(hub_username):
-    try:
-        original_username = os.environ.get("HUB_USERNAME", "")
-        os.environ["HUB_USERNAME"] = hub_username
-        yield
-    finally:
-        os.environ["HUB_USERNAME"] = original_username
-
-
 @pytest.mark.galaxyapi_smoke
 @pytest.mark.synclist
 @pytest.mark.cloud_only
 def test_synclist_object_get(ansible_config):
     """Validate user can read the endpoints with synclist objects."""
 
-    # set user to org-admin to access synclists
-    with set_username_env_var("org-admin"):
-        config = ansible_config("ansible_partner")
-        api_client = get_client(config, request_token=True, require_auth=True)
+    config = ansible_config("org_admin")
+    api_client = get_client(config, request_token=True, require_auth=True)
 
     resp = api_client("_ui/v1/my-synclists/", args={}, method="GET")
     assert resp["meta"]["count"] == 1
@@ -72,10 +59,8 @@ def test_synclist_object_edit(ansible_config, upload_artifact):
     #     ]
     # }
 
-    # set user to org-admin to access synclists
-    with set_username_env_var("org-admin"):
-        config = ansible_config("ansible_partner")
-        api_client = get_client(config, request_token=True, require_auth=True)
+    config = ansible_config("org_admin")
+    api_client = get_client(config, request_token=True, require_auth=True)
 
     # determine synclist repo associated to user
     resp = api_client("_ui/v1/my-synclists/", args={}, method="GET")
@@ -107,9 +92,8 @@ def test_edit_synclist_see_in_excludes(ansible_config, upload_artifact):
     confirm no change to content/{SyncList.name}/v3/collections/
     """
 
-    # NOTE: on stage env, a toggle action accesses these:
+    # NOTE: on stage env, a toggle action does:
     # PUT https://console.stage.redhat.com/api/automation-hub/_ui/v1/my-synclists/1/
-    # POST https://console.stage.redhat.com/api/automation-hub/_ui/v1/my-synclists/1/curate/
 
     config = ansible_config("ansible_partner")
     api_client = get_client(config, request_token=True, require_auth=True)
@@ -121,10 +105,8 @@ def test_edit_synclist_see_in_excludes(ansible_config, upload_artifact):
     set_certification(api_client, collection)
     collection_key = (collection.namespace, collection.name)
 
-    # set user to org-admin to access synclists
-    with set_username_env_var("org-admin"):
-        config = ansible_config("ansible_partner")
-        api_client = get_client(config, request_token=True, require_auth=True)
+    config = ansible_config("org_admin")
+    api_client = get_client(config, request_token=True, require_auth=True)
 
     # determine synclist repo associated to user
     resp = api_client("_ui/v1/my-synclists/", args={}, method="GET")

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -346,18 +346,18 @@ def test_api_ui_v1_groups_users(ansible_config):
                 break
         assert pe_id is not None
 
-        # validate the pe user is in the group's userlist
+        # validate username="admin" is in the group's userlist
+        # true when `make docker/loaddata` run after build
         resp = uclient.get(f'_ui/v1/groups/{pe_id}/users/')
         assert resp.status_code == 200
         users_ds = resp.json()
         validate_json(instance=users_ds, schema=schema_objectlist)
-        assert cfg.get('username') in [x['username'] for x in users_ds['data']]
+        assert 'admin' in [x['username'] for x in users_ds['data']]
 
 
 # /api/automation-hub/_ui/v1/groups/{group_pk}/users/{id}/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
-@pytest.mark.testme
 def test_api_ui_v1_groups_users_add_delete(ansible_config):
 
     cfg = ansible_config('ansible_partner')
@@ -486,10 +486,7 @@ def test_api_ui_v1_me(ansible_config):
 
         assert not ds['is_anonymous']
         assert ds['username'] == cfg.get('username')
-        assert ds['email'] == 'admin@example.com'
         assert ds['auth_provider'] == ['django']
-        assert ds['groups'] == [{'id': 1, 'name': 'system:partner-engineers'}]
-        assert ds['id'] == 1
 
 
 # /api/automation-hub/_ui/v1/my-distributions/
@@ -675,8 +672,8 @@ def test_api_ui_v1_users_by_id(ansible_config):
         ds = resp.json()
         validate_json(instance=ds, schema=schema_user)
 
+        # true when `make docker/loaddata` run after build
         assert ds['id'] == 1
-        assert ds['username'] == cfg.get('username')
         assert ds['email'] == 'admin@example.com'
         assert ds['is_superuser'] is True
         assert ds['groups'] == [{'id': 1, 'name': 'system:partner-engineers'}]

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -68,7 +68,50 @@ class AnsibleConfigFixture(dict):
     #   config = ansible_config("ansible_partner")
     #   config = ansible_config("ansible_insights")
 
-    def __init__(self, namespace1, namespace=None):
+    PROFILES = {
+        "basic_user": {
+            "username": "iqe_normal_user",
+            "password": "redhat",
+            "token": "abcdefghijklmnopqrstuvwxyz1234567891",
+        },
+        "partner_engineer": {
+            "username": "jdoe",
+            "password": "redhat",
+            "token": "abcdefghijklmnopqrstuvwxyz1234567892",
+        },
+        "org_admin": {  # user is org admin in keycloak
+            "username": "org-admin",
+            "password": "redhat",
+            "token": "abcdefghijklmnopqrstuvwxyz1234567893",
+        },
+        "admin": {  # this is a superuser
+            "username": "notifications_admin",
+            "password": "redhat",
+            "token": "abcdefghijklmnopqrstuvwxyz1234567894",
+        },
+        "ansible_partner": {  # TODO: consolidate into admin user
+            "username": "notifications_admin",
+            "password": "redhat",
+            "token": "abcdefghijklmnopqrstuvwxyz1234567894",
+        },
+        "ansible_insights": {  # TODO: consolidate into admin user
+            "username": "notifications_admin",
+            "password": "redhat",
+            "token": "abcdefghijklmnopqrstuvwxyz1234567894",
+        },
+        "ansible_user": {  # TODO: consolidate into admin user
+            "username": "notifications_admin",
+            "password": "redhat",
+            "token": "abcdefghijklmnopqrstuvwxyz1234567894",
+        },
+        "APP": {},  # TODO: unsure why used
+        "AUTOMATION_HUB": {},  # TODO: unsure why used
+    }
+
+    def __init__(self, profile, namespace=None):
+        self.profile = profile
+        if profile not in self.PROFILES.keys():
+            raise Exception("AnsibleConfigFixture profile unknown")
         self.namespace = namespace
 
     def __repr__(self):
@@ -91,22 +134,13 @@ class AnsibleConfigFixture(dict):
             )
 
         elif key == 'token':
-            return os.environ.get(
-                'HUB_TOKEN',
-                None
-            )
+            return self.PROFILES[self.profile]['token']
 
         elif key == 'username':
-            return os.environ.get(
-                'HUB_USERNAME',
-                'admin'
-            )
+            return self.PROFILES[self.profile]['username']
 
         elif key == 'password':
-            return os.environ.get(
-                'HUB_PASSWORD',
-                'admin'
-            )
+            return self.PROFILES[self.profile]['password']
 
         elif key == 'hub_use_inbound':
             # This value will be compared to "use_distribution" in the

--- a/galaxy_ng/tests/integration/utils.py
+++ b/galaxy_ng/tests/integration/utils.py
@@ -113,6 +113,11 @@ def get_client(config, require_auth=True, request_token=True, headers=None):
     # however, some tests need to auth but send request_token=False, so this
     # kwarg is poorly named and confusing.
     token = config.get("token") or None
+
+    # Only use token when in standalone mode
+    if os.getenv("HUB_LOCAL") != "1":
+        token = None  # TODO: refactor
+
     if request_token:
         if token:
             # keycloak must have a unique auth url ...


### PR DESCRIPTION
#### What is this PR doing:
Most integration test run as an admin user, this PR gives the ability to choose the type of user for the test

<!-- Add Jira issue link -->
Issue: AAH-1449

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit