### PR TITLE
Add django script to manage users in group

### DIFF
--- a/galaxy_ng/app/management/commands/manage-group-users.py
+++ b/galaxy_ng/app/management/commands/manage-group-users.py
@@ -1,0 +1,46 @@
+from galaxy_ng.app.models.auth import Group
+
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Django management command for creating groups
+    """
+
+    help = 'Add or remove users from an access group'
+
+    def add_arguments(self, parser):
+        parser.add_argument('users', nargs='+')
+        parser.add_argument('group')
+        parser.add_argument(
+            "--remove",
+            action="store_true",
+            help="Remove users from group",
+            default=False,
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+        group_name = options['group']
+        try:
+            group = Group.objects.get(name=group_name)
+        except User.DoesNotExist:
+            self.stdout.write("Group '{}' not found. Skipping.".format(group_name))
+        else:
+            for username in options['users']:
+                try:
+                    user = User.objects.get(username=username)
+                except User.DoesNotExist:
+                    self.stdout.write("User '{}' not found. Skipping.".format(username))
+                    continue
+                if options["remove"]:
+                    user.groups.remove(group)
+                else:
+                    user.groups.add(group)
+                user.save()
+                self.stdout.write("{} group '{}' {} user '{}'".format(("Removed" if options["remove"] else "Assigned"), group_name, ("from" if options["remove"] else "to"), username))
+


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Allows you to add or remove users from groups for local users. This is needed when Keycloak auth is enabled as there is no way to manage local users otherwise and local users are required to be able to do CI type jobs. This script allows a workaround to be put in place and can be used in conjunction with the other Django scripts in this directory.

#### Reviewers must know:
No issue exists for this PR.

<!-- e.g: Testing steps, dependencies, needed branches etc. -->
```
$ django-admin manage-user-groups ansible automation newgroup
Assigned group 'newgroup' to user 'ansible'
Assigned group 'newgroup' to user 'automation'
```

```
$ django-admin manage-user-groups --remove ansible automation newgroup
Removed group 'newgroup' from user 'ansible'
Removed group 'newgroup' from user 'automation'
```

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit