### PR TITLE
Add diagnose messages to the feature-flags endpoint

### DIFF
--- a/CHANGES/1738.misc
+++ b/CHANGES/1738.misc
@@ -1,0 +1,1 @@
+add messages to feature flags endpoint

--- a/galaxy_ng/app/api/ui/views/feature_flags.py
+++ b/galaxy_ng/app/api/ui/views/feature_flags.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
@@ -17,43 +18,65 @@ class FeatureFlagsView(api_base.APIView):
 
 def _load_conditional_signing_flags(flags):
     """Computes conditional flags for signing feature. ref: AAH-1690"""
+    _messages = []
+
+    signing_service_name = settings.get("GALAXY_COLLECTION_SIGNING_SERVICE")
+
     # kept for backwards compatibility to avoid breaking outdated UIs
-    flags.setdefault(
-        "collection_signing",
-        bool(settings.get("GALAXY_COLLECTION_SIGNING_SERVICE"))
+    flags.setdefault("collection_signing", bool(signing_service_name))
+
+    # Should UI require signature upload for enabling approval button?
+    require_upload = flags.setdefault(
+        "require_upload_signatures", bool(settings.get("GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL"))
     )
 
     # Main signing feature switcher (replaces collection_signing)
-    enabled = flags.setdefault(
-        "signatures_enabled",
-        flags["collection_signing"]
-    )
-    # Should UI require signature upload for enabling approval button?
-    require_upload = flags.setdefault(
-        "require_upload_signatures",
-        enabled and bool(settings.get("GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL"))
-    )
-
-    # Is the system configured with a Signing Service to create signatures?
-    def _signing_service_exists(settings):
-        name = settings.get("GALAXY_COLLECTION_SIGNING_SERVICE")
-        return SigningService.objects.filter(name=name).exists()
-
-    can_create = flags.setdefault(
-        "can_create_signatures",
-        enabled and _signing_service_exists(settings)
-    )
+    # If system requires signature upload, then assume signing is enabled
+    # also if signing service name is set, assume signing is enabled
+    enabled = flags.setdefault("signatures_enabled", require_upload or flags["collection_signing"])
 
     # Is the system enabled to accept signature uploads?
     can_upload = flags.setdefault(
         "can_upload_signatures",
         enabled and require_upload or bool(settings.get("GALAXY_SIGNATURE_UPLOAD_ENABLED"))
     )
+
+    # Is the system configured with a Signing Service to create signatures?
+    signing_service_exists = False
+    if signing_service_name:
+        signing_service_exists = SigningService.objects.filter(name=signing_service_name).exists()
+        if not signing_service_exists:
+            msg = _(
+                "WARNING:GALAXY_COLLECTION_SIGNING_SERVICE is set to '{}', "
+                "however the respective SigningService does not exist in the database."
+            )
+            _messages.append(msg.format(signing_service_name))
+
+    can_create = flags.setdefault("can_create_signatures", enabled and signing_service_exists)
+
     # Does the system automatically sign automatically upon approval?
-    flags.setdefault(
+    auto_sign = flags.setdefault(
         "collection_auto_sign",
         enabled and can_create and bool(settings.get("GALAXY_AUTO_SIGN_COLLECTIONS"))
     )
 
+    if auto_sign and not signing_service_exists:
+        msg = _(
+            "WARNING:GALAXY_AUTO_SIGN_COLLECTIONS is set to True, "
+            "however the system is not configured with a SigningService to create signatures."
+        )
+        _messages.append(msg)
+
     # Should UI show badges, text, signature blob, filters...
-    flags.setdefault("display_signatures", enabled and can_create or can_upload)
+    can_display = flags.setdefault("display_signatures", enabled and any((can_create, can_upload)))
+
+    # Is system displaying only synced signatures?
+    if can_display and not any((can_create, can_upload)):
+        msg = _(
+            "INFO:System is configured to display signatures (coming from remote syncs) "
+            "but is not configured to create or accept upload of signatures."
+        )
+        _messages.append(msg)
+
+    # Display messages if any
+    flags["_messages"] = _messages

--- a/galaxy_ng/tests/integration/schemas.py
+++ b/galaxy_ng/tests/integration/schemas.py
@@ -121,6 +121,7 @@ schema_featureflags = {
         'collection_auto_sign',
         'display_signatures',
         'execution_environments',
+        '_messages',
     ],
     'properties': {
         'collection_signing': {'type': 'boolean'},
@@ -131,6 +132,7 @@ schema_featureflags = {
         'collection_auto_sign': {'type': 'boolean'},
         'display_signatures': {'type': 'boolean'},
         'execution_environments': {'type': 'boolean'},
+        '_messages': {'type': 'array'},
     }
 }
 


### PR DESCRIPTION
Issue: AAH-1738

#### What is this PR doing:
```json
{
  "display_signatures": true,
  "collection_auto_sign": true,
  "execution_environments": true,
  "collection_signing": true,
  "require_upload_signatures": false,
  "signatures_enabled": true,
  "can_upload_signatures": false,
  "can_create_signatures": false,
  "_messages": [
    "WARNING:GALAXY_COLLECTION_SIGNING_SERVICE is set to 'ansible-default25', however the respective SigningService does not exist in the database.",
    "WARNING:GALAXY_AUTO_SIGN_COLLECTIONS is set to True, however the system is not configured with a SigningService to create signatures.",
    "INFO:System is configured to display signatures (coming from remote syncs) but is not configured to create or accept upload of signatures."
  ]
}
```