### PR TITLE
Artifacts cleanup on deleting collection

### DIFF
--- a/.ci/scripts/extra_linting.sh
+++ b/.ci/scripts/extra_linting.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-EXIT_CODE=0
-if (git grep "orphan_protection_time=0" ./galaxy_ng);then
-    echo "Setting 'orphan_protection_time' to 0 can lead to a race condition.\n";
-    EXIT_CODE=1
-fi
-exit $EXIT_CODE

--- a/CHANGES/1749.bugfix
+++ b/CHANGES/1749.bugfix
@@ -1,0 +1,1 @@
+Fix persisting artifacts in collection deletion


### PR DESCRIPTION
Issue: [AAH-1749](https://issues.redhat.com/browse/AAH-1749)

#### What is this PR doing:
Removing artifacts on deleting collection. Solution taken from [pulp_ansible/tasks/deletion.py](https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/tasks/deletion.py#L79) 

<!-- Add Jira issue link -->
Issue:  [AAH-1749](https://issues.redhat.com/browse/AAH-1749)

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->
Reuploading collection fails with duplicate key: `duplicate key value violates unique constraint "core_artifact_sha256_key"`

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit