### PR TITLE
Skip CI jobs for docs only PRs

### DIFF
--- a/.github/workflows/ci_insights.yml
+++ b/.github/workflows/ci_insights.yml
@@ -1,9 +1,13 @@
 ---
 name: Insights
-on: 
+on:
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'CHANGES/**'
   push:
     branches:
       - '*'

--- a/.github/workflows/ci_standalone-community.yml
+++ b/.github/workflows/ci_standalone-community.yml
@@ -1,9 +1,13 @@
 ---
 name: Standalone Community
-on: 
+on:
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'CHANGES/**'
   push:
     branches:
       - '*'

--- a/.github/workflows/ci_standalone-ldap.yml
+++ b/.github/workflows/ci_standalone-ldap.yml
@@ -1,9 +1,13 @@
 ---
 name: Standalone LDAP
-on: 
+on:
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'CHANGES/**'
   push:
     branches:
       - '*'

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'CHANGES/**'
   push:
     branches:
       - '*'

--- a/CHANGES/1492.misc
+++ b/CHANGES/1492.misc
@@ -1,0 +1,1 @@
+Skip pr_check for docs only PRs

--- a/CHANGES/1493.misc
+++ b/CHANGES/1493.misc
@@ -1,0 +1,1 @@
+Skip CI integration test runs for docs only PRs

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,6 +1,29 @@
 #!/bin/bash
 
 # --------------------------------------------
+# Check if changed files begin with one of the ignored prefixes
+# and if all do then skip running remainder of script
+# Example ignored prefixes: "docs/", "CHANGES/"
+# --------------------------------------------
+FILES_CHANGED=$(git diff origin/master --name-only)
+echo FILES_CHANGED=$FILES_CHANGED
+skip_pr_check="true"
+for line in $FILES_CHANGED; do
+    if ! [[ $line =~ ^("docs/"|"CHANGES/"|"mkdocs.yml"|".github/") ]]; then skip_pr_check="false"; fi
+done
+
+# Need to make a dummy results file to make tests pass
+mkdir -p artifacts
+cat << EOF > artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF
+
+if [ $skip_pr_check == "true" ]; then exit 0; fi
+
+
+# --------------------------------------------
 # Options that must be configured by app owner
 # --------------------------------------------
 APP_NAME="automation-hub,gateway,insights-ephemeral"  # name of app-sre "application" folder this component lives in


### PR DESCRIPTION
#### What is this PR doing:

* Skip pr_check for docs only PRs
* Skip CI integration test runs for docs only PRs

Issue: AAH-1492
Issue: AAH-1493

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit