### PR TITLE
Stop creating AnsibleRepository with foreign key to SyncList

### DIFF
--- a/CHANGES/1788.misc
+++ b/CHANGES/1788.misc
@@ -1,1 +1,1 @@
-Remove existing synclist repo database objects
+Stop creating AnsibleRepository with foreign key to SyncList

--- a/CHANGES/1788.misc
+++ b/CHANGES/1788.misc
@@ -1,0 +1,1 @@
+Remove existing synclist repo database objects

--- a/galaxy_ng/app/auth/auth.py
+++ b/galaxy_ng/app/auth/auth.py
@@ -93,13 +93,12 @@ class RHIdentityAuthentication(BaseAuthentication):
                 account_name=group.account_number()
             )
 
-            repository = self._ensure_repository(distro_name)
             self._get_or_create_synclist_distribution(distro_name, upstream_repository)
 
             default_synclist, _ = SyncList.objects.get_or_create(
                 name=distro_name,
                 defaults={
-                    "repository": repository,
+                    "repository": upstream_repository,
                     "upstream_repository": upstream_repository,
                     "policy": SYNCLIST_DEFAULT_POLICY,
                 },
@@ -109,13 +108,6 @@ class RHIdentityAuthentication(BaseAuthentication):
                                                'galaxy.delete_synclist', 'galaxy.change_synclist']}
             default_synclist.save()
         return default_synclist
-
-    @staticmethod
-    def _ensure_repository(name):
-        repository, created = AnsibleRepository.objects.get_or_create(name=name)
-        if created:
-            repository.save()
-        return repository
 
     @staticmethod
     def _ensure_user(username, group, **attrs):

--- a/galaxy_ng/tests/unit/app/test_app_auth.py
+++ b/galaxy_ng/tests/unit/app/test_app_auth.py
@@ -1,0 +1,43 @@
+from unittest.mock import Mock
+
+from django.test import override_settings
+from pulp_ansible.app.models import AnsibleDistribution, AnsibleRepository
+
+from galaxy_ng.app.auth.auth import RHIdentityAuthentication
+from galaxy_ng.app.constants import DeploymentMode
+from galaxy_ng.app.models import Group, SyncList, User
+from galaxy_ng.tests.unit.api import rh_auth as rh_auth_utils
+from galaxy_ng.tests.unit.api.base import BaseTestCase
+
+
+@override_settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.INSIGHTS.value)
+class TestRHIdentityAuth(BaseTestCase):
+    def test_authenticate(self):
+        # user setup
+        username = "user_testing_rh_auth"
+        account_number = "22446688"
+        x_rh_identity = rh_auth_utils.user_x_rh_identity(username, account_number)
+        request = Mock()
+        request.META = {"HTTP_X_RH_IDENTITY": x_rh_identity}
+        rh_id_auth = RHIdentityAuthentication()
+
+        # assert objects do not exist: user, group, synclist, distro, repo
+        group_name = f"rh-identity-account:{account_number}"
+        synclist_name = f"{account_number}-synclist"
+        self.assertFalse(User.objects.filter(username=username))
+        self.assertFalse(Group.objects.filter(name=group_name))
+        self.assertFalse(SyncList.objects.filter(name=synclist_name))
+        self.assertFalse(AnsibleRepository.objects.filter(name=synclist_name))
+        self.assertFalse(AnsibleDistribution.objects.filter(name=synclist_name))
+
+        # perform the authentication that creates objects
+        rh_id_auth.authenticate(request)
+
+        # check objects exist: user, group, synclist, distro
+        User.objects.get(username=username)
+        Group.objects.get(name=group_name)
+        SyncList.objects.get(name=synclist_name)
+        AnsibleDistribution.objects.get(name=synclist_name)
+
+        # assert objects do not exist: repo
+        self.assertFalse(AnsibleRepository.objects.filter(name=synclist_name))


### PR DESCRIPTION
#### What is this PR doing:
Stop creating AnsibleRepository with foreign key to SyncList, since CRC installation in insights mode no longer needs them
* Stop creating #####-synclist repos
* On create a SyncList obj, link it to non-synclist repo published
* Add unit test for obj creation during rh auth

<!-- Add Jira issue link -->
Issue: AAH-1788

#### Notes: 

**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit