### PR TITLE
Allow roles assignment to group with `change_group` permission

### DIFF
--- a/CHANGES/1766.bugfix
+++ b/CHANGES/1766.bugfix
@@ -1,0 +1,1 @@
+Allow roles assignment to group with `change_group` permission

--- a/galaxy_ng/app/access_control/statements/insights.py
+++ b/galaxy_ng/app/access_control/statements/insights.py
@@ -235,6 +235,12 @@ INSIGHTS_STATEMENTS = {
             "condition": "has_model_perms:galaxy.view_group"
         },
         {
+            "action": "create",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.change_group"
+        },
+        {
             "action": "*",
             "principal": "admin",
             "effect": "allow"

--- a/galaxy_ng/app/access_control/statements/insights.py
+++ b/galaxy_ng/app/access_control/statements/insights.py
@@ -241,6 +241,12 @@ INSIGHTS_STATEMENTS = {
             "condition": "has_model_perms:galaxy.change_group"
         },
         {
+            "action": "destroy",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.change_group"
+        },
+        {
             "action": "*",
             "principal": "admin",
             "effect": "allow"

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -403,6 +403,12 @@ STANDALONE_STATEMENTS = {
             "condition": "has_model_perms:galaxy.view_group"
         },
         {
+            "action": "create",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.change_group"
+        },
+        {
             "action": "*",
             "principal": "admin",
             "effect": "allow"

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -409,6 +409,12 @@ STANDALONE_STATEMENTS = {
             "condition": "has_model_perms:galaxy.change_group"
         },
         {
+            "action": "destroy",
+            "principal": "authenticated",
+            "effect": "allow",
+            "condition": "has_model_perms:galaxy.change_group"
+        },
+        {
             "action": "*",
             "principal": "admin",
             "effect": "allow"


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Let users with `change_group` permission to be able to add roles to the group.

<!-- Add Jira issue link -->
Issue:  [AAH-1766](https://issues.redhat.com/browse/AAH-1766)

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->
Users with the ability to edit groups should be able to add roles to the group. They just can't modify or create new roles.

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit