### PR TITLE
Remove deprecated media type from pulp_container.

### DIFF
--- a/CHANGES/1828.misc
+++ b/CHANGES/1828.misc
@@ -1,0 +1,1 @@
+Remove deprecated media type from pulp_container.

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -182,7 +182,7 @@ class ContainerManifestSerializer(serializers.ModelSerializer):
     def get_config_blob(self, obj):
         if not obj.config_blob:
             return {}
-        return {"digest": obj.config_blob.digest, "media_type": obj.config_blob.media_type}
+        return {"digest": obj.config_blob.digest}
 
     @extend_schema_field(serializers.ListField)
     def get_tags(self, obj):
@@ -228,7 +228,6 @@ class ContainerManifestDetailSerializer(ContainerManifestSerializer):
 
         return {
             "digest": obj.config_blob.digest,
-            "media_type": obj.config_blob.media_type,
             "data": config_json,
         }
 


### PR DESCRIPTION
Issue: AAH-1828

#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Pulp container removed the media type from config blobs, which was causing 500s on our api: https://github.com/pulp/pulp_container/pull/600