### PR TITLE
Mark existing rbac role tests as standalone-only

### DIFF
--- a/galaxy_ng/tests/integration/api/test_groups.py
+++ b/galaxy_ng/tests/integration/api/test_groups.py
@@ -16,6 +16,7 @@ pytestmark = pytest.mark.qa  # noqa: F821
 
 @pytest.mark.group
 @pytest.mark.role
+@pytest.mark.standalone_only
 def test_group_role_listing(ansible_config):
     """Tests ability to list roles assigned to a namespace."""
 

--- a/galaxy_ng/tests/integration/api/test_rbac_roles.py
+++ b/galaxy_ng/tests/integration/api/test_rbac_roles.py
@@ -297,6 +297,7 @@ ACTIONS_FOR_ALL_USERS = {
 
 
 @pytest.mark.role_rbac
+@pytest.mark.standalone_only
 @pytest.mark.parametrize("role", ROLES_TO_TEST)
 def test_global_role_actions(role):
     registry = ReusableContainerRegistry(gen_string())
@@ -340,6 +341,7 @@ def test_global_role_actions(role):
 
 
 @pytest.mark.role_rbac
+@pytest.mark.standalone_only
 def test_role_actions_for_admin():
     registry = ReusableContainerRegistry(gen_string())
     registry_pk = registry.get_registry()["pk"]


### PR DESCRIPTION
#### What is this PR doing:
Marking existing rbac role tests as standalone-only to prevent failures in insights tests runs.
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit