### PR TITLE
Fix sign_state query for faster collection signing performance

### DIFF
--- a/CHANGES/1794.bugfix
+++ b/CHANGES/1794.bugfix
@@ -1,0 +1,1 @@
+Return only the sign state of the latest version of a collection.

--- a/galaxy_ng/app/api/ui/serializers/collection.py
+++ b/galaxy_ng/app/api/ui/serializers/collection.py
@@ -151,9 +151,6 @@ class _CollectionSerializer(Serializer):
 class CollectionListSerializer(_CollectionSerializer):
     deprecated = serializers.BooleanField()
     sign_state = serializers.CharField()
-    total_versions = serializers.IntegerField(default=0)
-    signed_versions = serializers.IntegerField(default=0)
-    unsigned_versions = serializers.IntegerField(default=0)
 
     @extend_schema_field(CollectionVersionBaseSerializer)
     def get_latest_version(self, obj):
@@ -163,9 +160,6 @@ class CollectionListSerializer(_CollectionSerializer):
 class CollectionDetailSerializer(_CollectionSerializer):
     all_versions = serializers.SerializerMethodField()
     sign_state = serializers.CharField()
-    total_versions = serializers.IntegerField(default=0)
-    signed_versions = serializers.IntegerField(default=0)
-    unsigned_versions = serializers.IntegerField(default=0)
 
     # TODO: rename field to "version_details" since with
     # "version" query param this won't always be the latest version

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -397,7 +397,7 @@ class ContainerRemoteSerializer(
             defaults={'registry': registry, 'repository_remote': instance}
         )
 
-        if(instance.name != validated_data['name']):
+        if (instance.name != validated_data['name']):
             raise serializers.ValidationError(detail={
                 "name": _("Name cannot be changed.")
             })

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -1,5 +1,5 @@
 from django.db.models import Exists, OuterRef, Q, Value, F, Func, CharField
-# from django.db.models import When, Case, Subquery
+from django.db.models import When, Case
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
 from django.shortcuts import get_object_or_404
@@ -59,65 +59,6 @@ class CollectionViewSet(
     filterset_class = CollectionByCollectionVersionFilter
     permission_classes = [access_policy.CollectionAccessPolicy]
 
-    def build_signing_annotations(self, base_total_qs):
-        """Builds a dict with queryset annotations.
-
-        Containing:
-
-            Count of Versions of the Collection
-            Count of Signed Versions of the Collection
-            Count of Unsigned Versions of the Collection
-            Sign State of the Collection
-                signed: all versions are signed
-                unsigned: all versions are unsigned
-                partial: some versions are signed, some are unsigned
-        """
-        # ATTENTION!!!
-        # THIS IS TEMPORARILY DISABLED DUE TO A SLOW IN THE ANNOTATION QUERIES
-        # https://issues.redhat.com/browse/AAH-1775
-
-        # # Ensure it filters only the same namespace
-        # base_total_qs = base_total_qs.filter(
-        #     namespace=OuterRef("namespace"), name=OuterRef("name")
-        # )
-
-        # total_versions_query = Subquery(
-        #     base_total_qs.annotate(total=Func(F("pk"), function="count")).values('total')
-        # )
-        total_versions_query = Value(0)
-
-        # signed_versions_query = Subquery(
-        #     base_total_qs.filter(
-        #         signatures__isnull=False,
-        #     ).annotate(
-        #         total=Func(F("pk"), function="count")
-        #     ).values('total')
-        # )
-        signed_versions_query = Value(0)
-
-        # unsigned_versions_query = Subquery(
-        #     base_total_qs.filter(
-        #         signatures__isnull=True,
-        #     ).annotate(
-        #         total=Func(F("pk"), function="count")
-        #     ).values('total')
-        # )
-        unsigned_versions_query = Value(0)
-
-        # sign_state_query = Case(
-        #     When(signed_versions=F("total_versions"), then=Value("signed")),
-        #     When(unsigned_versions=F("total_versions"), then=Value("unsigned")),
-        #     When(signed_versions__lt=F("total_versions"), then=Value("partial")),
-        # )
-        sign_state_query = Value("unsigned")
-
-        return {
-            "total_versions": total_versions_query,
-            "signed_versions": signed_versions_query,
-            "unsigned_versions": unsigned_versions_query,
-            "sign_state": sign_state_query,
-        }
-
     def get_queryset(self):
         """Returns a CollectionVersions queryset for specified distribution."""
         if getattr(self, "swagger_fake_view", False):
@@ -166,7 +107,10 @@ class CollectionViewSet(
         version_qs = version_qs.annotate(
             deprecated=Exists(deprecated_query),
             version_identifier=version_identifier_expression,
-            **self.build_signing_annotations(base_versions_query)
+            sign_state=Case(
+                When(signatures__isnull=False, then=Value("signed")),
+                When(signatures__isnull=True, then=Value("unsigned")),
+            )
         )
 
         # AAH-1484 - filtering by version_identifier

--- a/galaxy_ng/tests/integration/api/test_collection_signing.py
+++ b/galaxy_ng/tests/integration/api/test_collection_signing.py
@@ -135,26 +135,19 @@ def test_collection_auto_sign_on_approval(api_client, config, settings, flags, u
     assert collection["signatures"][0]["pubkey_fingerprint"] is not None
     assert collection["signatures"][0]["pulp_created"] is not None
 
-    # DISABLED due to https://issues.redhat.com/browse/AAH-1775
     # Assert that the collection is signed on UI API
-    # collection_on_ui = api_client(
-    #     "/api/automation-hub/_ui/v1/repo/published/"
-    #     f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
-    #     f"&sign_state=signed&version={artifact.version}"
-    # )["data"][0]
-
-    # Disabled due to https://issues.redhat.com/browse/AAH-1775
-    # assert collection_on_ui["sign_state"] == "signed"
-    # assert collection_on_ui["total_versions"] == 1
-    # assert collection_on_ui["signed_versions"] == 1
-    # assert collection_on_ui["unsigned_versions"] == 0
-
-    # metadata = collection_on_ui["latest_version"]["metadata"]
-    # assert len(metadata["signatures"]) >= 1
-    # assert metadata["signatures"][0]["signing_service"] == signing_service
-    # assert metadata["signatures"][0]["signature"] is not None
-    # assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
-    # assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
+    collection_on_ui = api_client(
+        "/api/automation-hub/_ui/v1/repo/published/"
+        f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
+        f"&sign_state=signed&version={artifact.version}"
+    )["data"][0]
+    assert collection_on_ui["sign_state"] == "signed"
+    metadata = collection_on_ui["latest_version"]["metadata"]
+    assert len(metadata["signatures"]) >= 1
+    assert metadata["signatures"][0]["signing_service"] == signing_service
+    assert metadata["signatures"][0]["signature"] is not None
+    assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
+    assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
 
 
 @pytest.mark.collection_signing
@@ -227,23 +220,19 @@ def test_collection_sign_on_demand(api_client, config, settings, flags, upload_a
     assert collection["signatures"][0]["pubkey_fingerprint"] is not None
     assert collection["signatures"][0]["pulp_created"] is not None
 
-    # DISABLED due to https://issues.redhat.com/browse/AAH-1775
     # # Assert that the collection is signed on UI API
-    # collection_on_ui = api_client(
-    #     "/api/automation-hub/_ui/v1/repo/staging/"
-    #     f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
-    #     f"&sign_state=signed&version={artifact.version}"
-    # )["data"][0]
-    # assert collection_on_ui["sign_state"] == "signed"
-    # assert collection_on_ui["total_versions"] == 1
-    # assert collection_on_ui["signed_versions"] == 1
-    # assert collection_on_ui["unsigned_versions"] == 0
-    # metadata = collection_on_ui["latest_version"]["metadata"]
-    # assert len(metadata["signatures"]) >= 1
-    # assert metadata["signatures"][0]["signing_service"] == signing_service
-    # assert metadata["signatures"][0]["signature"] is not None
-    # assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
-    # assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
+    collection_on_ui = api_client(
+        "/api/automation-hub/_ui/v1/repo/staging/"
+        f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
+        f"&sign_state=signed&version={artifact.version}"
+    )["data"][0]
+    assert collection_on_ui["sign_state"] == "signed"
+    metadata = collection_on_ui["latest_version"]["metadata"]
+    assert len(metadata["signatures"]) >= 1
+    assert metadata["signatures"][0]["signing_service"] == signing_service
+    assert metadata["signatures"][0]["signature"] is not None
+    assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
+    assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
 
 
 @pytest.mark.collection_signing
@@ -296,9 +285,7 @@ def test_collection_move_with_signatures(api_client, config, settings, flags, up
 
         # Assert that the collection is signed on UI API
         collections = get_all_collections_by_repo(api_client)
-
-        # DISABLED due to https://issues.redhat.com/browse/AAH-1775
-        # assert collections["staging"][ckey]["sign_state"] == "signed"
+        assert collections["staging"][ckey]["sign_state"] == "signed"
 
         # Move the collection to /published/
         cert_result = set_certification(api_client, artifact)
@@ -323,23 +310,19 @@ def test_collection_move_with_signatures(api_client, config, settings, flags, up
     assert collection["signatures"][0]["pubkey_fingerprint"] is not None
     assert collection["signatures"][0]["pulp_created"] is not None
 
-    # DISABLED due to https://issues.redhat.com/browse/AAH-1775
     # # Assert that the collection is signed on UI API
-    # collection_on_ui = api_client(
-    #     "/api/automation-hub/_ui/v1/repo/published/"
-    #     f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
-    #     f"&sign_state=signed&version={artifact.version}"
-    # )["data"][0]
-    # assert collection_on_ui["sign_state"] == "signed"
-    # assert collection_on_ui["total_versions"] == 1
-    # assert collection_on_ui["signed_versions"] == 1
-    # assert collection_on_ui["unsigned_versions"] == 0
-    # metadata = collection_on_ui["latest_version"]["metadata"]
-    # assert len(metadata["signatures"]) >= 1
-    # assert metadata["signatures"][0]["signing_service"] == signing_service
-    # assert metadata["signatures"][0]["signature"] is not None
-    # assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
-    # assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
+    collection_on_ui = api_client(
+        "/api/automation-hub/_ui/v1/repo/published/"
+        f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
+        f"&sign_state=signed&version={artifact.version}"
+    )["data"][0]
+    assert collection_on_ui["sign_state"] == "signed"
+    metadata = collection_on_ui["latest_version"]["metadata"]
+    assert len(metadata["signatures"]) >= 1
+    assert metadata["signatures"][0]["signing_service"] == signing_service
+    assert metadata["signatures"][0]["signature"] is not None
+    assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
+    assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
 
 
 @pytest.mark.collection_signing


### PR DESCRIPTION
Issue: AAH-1794

Remove counters for partially signed, all signed, and all unsigned collection versions and instead return the sign state of only the latest version of a collection.

