### PR TITLE
Rename migrations to not override default branch

### DIFF
--- a/galaxy_ng/app/migrations/0028_update_synclist_model.py
+++ b/galaxy_ng/app/migrations/0028_update_synclist_model.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('ansible', '0041_alter_collectionversion_collection'),
-        ('galaxy', '0028_move_perms_to_roles'),
+        ('galaxy', '0027_delete_contentredirectcontentguard'),
     ]
 
     operations = [

--- a/galaxy_ng/app/migrations/0029_move_perms_to_roles.py
+++ b/galaxy_ng/app/migrations/0029_move_perms_to_roles.py
@@ -423,7 +423,7 @@ def edit_guardian_tables(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("galaxy", "0027_delete_contentredirectcontentguard"),
+        ("galaxy", "0028_update_synclist_model"),
     ]
 
     operations = [

--- a/galaxy_ng/tests/unit/migrations/test_0028_update_synclist_model.py
+++ b/galaxy_ng/tests/unit/migrations/test_0028_update_synclist_model.py
@@ -19,7 +19,7 @@ This is not tested in a historical context, but uses latest models.
 class TestEditSyncListObj(TestCase):
     def _run_python_operation(self):
         """Calls RunPython operation, passes schema_editor"""
-        migration = import_module("galaxy_ng.app.migrations.0029_update_synclist_model")
+        migration = import_module("galaxy_ng.app.migrations.0028_update_synclist_model")
         migration.populate_synclist_distros(apps, connection.schema_editor())
 
     def test_match_synclist_to_distro(self):

--- a/galaxy_ng/tests/unit/migrations/test_0029_move_perms_to_roles.py
+++ b/galaxy_ng/tests/unit/migrations/test_0029_move_perms_to_roles.py
@@ -185,7 +185,7 @@ class TestMigratingPermissionsToRoles(TestCase):
         )
     
     def _run_migrations(self):
-        migration = importlib.import_module("galaxy_ng.app.migrations.0028_move_perms_to_roles")
+        migration = importlib.import_module("galaxy_ng.app.migrations.0029_move_perms_to_roles")
         migration.migrate_group_permissions_to_roles(apps, None)
         migration.migrate_user_permissions_to_roles(apps, None)
 


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
The default branch already has a 0028 migration, making sure this branch
appends to that

In the rebase, I chose to rename the migration on master, and this PR fixes that.

<!-- Add Jira issue link -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit