### PR TITLE
Add role check to app auth unit test

### DIFF
--- a/galaxy_ng/tests/unit/app/test_app_auth.py
+++ b/galaxy_ng/tests/unit/app/test_app_auth.py
@@ -1,7 +1,9 @@
 from unittest.mock import Mock
 
+from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 from pulp_ansible.app.models import AnsibleDistribution, AnsibleRepository
+from pulpcore.plugin.models.role import Role
 
 from galaxy_ng.app.auth.auth import RHIdentityAuthentication
 from galaxy_ng.app.constants import DeploymentMode
@@ -35,10 +37,21 @@ class TestRHIdentityAuth(BaseTestCase):
 
         # check objects exist: user, group, synclist, distro
         User.objects.get(username=username)
-        Group.objects.get(name=group_name)
+        group = Group.objects.get(name=group_name)
         synclist = SyncList.objects.get(name=synclist_name)
         distro = AnsibleDistribution.objects.get(name=synclist_name)
         self.assertEqual(synclist.distribution, distro)
+
+        # test rbac: check group is linked to expected role
+        self.assertEqual(group.object_roles.all().count(), 1)
+        group_role = group.object_roles.all().first()
+        synclist_owner_role = Role.objects.get(name="galaxy.synclist_owner")
+        self.assertEqual(group_role.role, synclist_owner_role)
+
+        # test rbac: check group is linked to expected object
+        self.assertEqual(str(synclist.id), group_role.object_id)
+        ct = ContentType.objects.get(id=group_role.content_type_id)
+        self.assertEqual(ct.model, "synclist")
 
         # assert objects do not exist: repo
         self.assertFalse(AnsibleRepository.objects.filter(name=synclist_name))


### PR DESCRIPTION
#### What is this PR doing:
Test the GroupRole object that is created when a new customer logs in insights mode

<!-- Add Jira issue link -->
No-Issue

#### Notes: 

**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit