### PR TITLE
Update remote rh-certified default url

### DIFF
--- a/CHANGES/1770.misc
+++ b/CHANGES/1770.misc
@@ -1,0 +1,1 @@
+Update remote rh-certified default url to `https://console.redhat.com/api/automation-hub/`

--- a/galaxy_ng/app/migrations/0017_populate_repos_and_remotes.py
+++ b/galaxy_ng/app/migrations/0017_populate_repos_and_remotes.py
@@ -31,7 +31,7 @@ REPOSITORIES = [
         "next_version": 1,
         "remote": {
             "name": "rh-certified",
-            "url": "https://cloud.redhat.com/api/automation-hub/",
+            "url": "https://console.redhat.com/api/automation-hub/",
             "requirements_file": None,
             "token": None,
             "auth_url": (

--- a/galaxy_ng/app/migrations/0030_update_collection_remote_rhcertified_url.py
+++ b/galaxy_ng/app/migrations/0030_update_collection_remote_rhcertified_url.py
@@ -18,7 +18,7 @@ def update_collection_remote_rhcertified_url(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('galaxy', '0028_update_synclist_model'),
+        ('galaxy', '0029_move_perms_to_roles'),
     ]
 
     operations = [

--- a/galaxy_ng/app/migrations/0030_update_collection_remote_rhcertified_url.py
+++ b/galaxy_ng/app/migrations/0030_update_collection_remote_rhcertified_url.py
@@ -8,7 +8,7 @@ def update_collection_remote_rhcertified_url(apps, schema_editor):
     
     CollectionRemote = apps.get_model('ansible', 'CollectionRemote')
     
-    rh_remote = CollectionRemote.objects.get(name='rh-certified')
+    rh_remote = CollectionRemote.objects.filter(name='rh-certified').first()
 
     if rh_remote and rh_remote.url.startswith('https://cloud.redhat.com/'):
         rh_remote.url = rh_remote.url.replace('https://cloud.redhat.com/', 'https://console.redhat.com/')

--- a/galaxy_ng/app/migrations/0030_update_collection_remote_rhcertified_url.py
+++ b/galaxy_ng/app/migrations/0030_update_collection_remote_rhcertified_url.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+def update_collection_remote_rhcertified_url(apps, schema_editor):
+    """
+    Updates the existing collection remote `rh-certified` url field  
+    if startswith `https://cloud.redhat.com/`.
+    """
+    
+    CollectionRemote = apps.get_model('ansible', 'CollectionRemote')
+    
+    rh_remote = CollectionRemote.objects.filter(
+        name='rh-certified',
+        url__startswith='https://cloud.redhat.com/')
+
+    if rh_remote:
+        rh_remote.update(url='https://console.redhat.com/api/automation-hub/')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('galaxy', '0028_update_synclist_model'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=update_collection_remote_rhcertified_url,
+            reverse_code=migrations.RunPython.noop
+        )
+    ]

--- a/galaxy_ng/app/migrations/0030_update_collection_remote_rhcertified_url.py
+++ b/galaxy_ng/app/migrations/0030_update_collection_remote_rhcertified_url.py
@@ -8,12 +8,11 @@ def update_collection_remote_rhcertified_url(apps, schema_editor):
     
     CollectionRemote = apps.get_model('ansible', 'CollectionRemote')
     
-    rh_remote = CollectionRemote.objects.filter(
-        name='rh-certified',
-        url__startswith='https://cloud.redhat.com/')
+    rh_remote = CollectionRemote.objects.get(name='rh-certified')
 
-    if rh_remote:
-        rh_remote.update(url='https://console.redhat.com/api/automation-hub/')
+    if rh_remote and rh_remote.url.startswith('https://cloud.redhat.com/'):
+        rh_remote.url = rh_remote.url.replace('https://cloud.redhat.com/', 'https://console.redhat.com/')
+        rh_remote.save()
 
 
 class Migration(migrations.Migration):

--- a/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_collection_viewsets.py
@@ -242,7 +242,7 @@ class TestUiCollectionRemoteViewSet(BaseTestCase):
         super().setUp()
         self.remote_data = {
             "name": "rh-certified",
-            "url": "https://cloud.redhat.com/api/automation-hub/",
+            "url": "https://console.redhat.com/api/automation-hub/",
         }
         self.remote = CollectionRemote.objects.get(name=self.remote_data["name"])
         self.repository = AnsibleRepository.objects.get(name=self.remote_data["name"])

--- a/galaxy_ng/tests/unit/migrations/test_0030_update_collection_remote_rhcertified_url.py
+++ b/galaxy_ng/tests/unit/migrations/test_0030_update_collection_remote_rhcertified_url.py
@@ -1,0 +1,38 @@
+from importlib import import_module
+
+from django.db import connection
+from django.test import TestCase
+from django.apps import apps
+
+from pulp_ansible.app.models import CollectionRemote
+
+
+class TestRemoteRHCertifiedCollectionURL(TestCase):
+
+    def _run_migration(self):
+        migration = import_module("galaxy_ng.app.migrations.0030_update_collection_remote_rhcertified_url")
+        migration.update_collection_remote_rhcertified_url(apps, connection.schema_editor())
+    
+    def test_correct_url_update_after_migration(self):
+        url = 'https://cloud.redhat.com/api/automation-hub/content/1237261-synclist/'
+        CollectionRemote.objects.filter(name="rh-certified").update(url=url)        
+        
+        remote = CollectionRemote.objects.get(name='rh-certified')
+        self.assertEqual(remote.url, url)
+
+        self._run_migration()
+        
+        remote.refresh_from_db()
+        self.assertEqual(remote.url, 'https://console.redhat.com/api/automation-hub/content/1237261-synclist/')
+
+    def test_no_url_change_after_migration(self):
+        url = 'https://console.stage.redhat.com/api/automation-hub/'
+        CollectionRemote.objects.filter(name="rh-certified").update(url=url)
+
+        remote = CollectionRemote.objects.get(name='rh-certified')
+        self.assertEqual(remote.url, url)
+
+        self._run_migration()
+
+        remote.refresh_from_db()
+        self.assertEqual(remote.url, url)


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->

Change default URL in remote `rh-certified` repository to `https://console.redhat.com/api/automation-hub/`
<!-- Add Jira issue link -->
Issue: [AAH-1770](https://issues.redhat.com/browse/AAH-1770)

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit