### PR TITLE
Optimize RBAC tests 

### DIFF
--- a/galaxy_ng/tests/integration/api/rbac_actions/utils.py
+++ b/galaxy_ng/tests/integration/api/rbac_actions/utils.py
@@ -114,7 +114,7 @@ def wait_for_task(resp, path=None, timeout=300):
 
 
 def ensure_test_container_is_pulled():
-    cmd = ["podman", "container", "exists", TEST_CONTAINER]
+    cmd = ["podman", "image", "exists", TEST_CONTAINER]
     proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if proc.returncode == 1:
         cmd = ["podman", "image", "pull", "alpine"]
@@ -364,6 +364,9 @@ class ReusableCollection:
         wait_for_all_tasks()
         del_namespace(namespace['name'])
 
+    def __del__(self):
+        self.cleanup()
+
 
 def cleanup_test_obj(response, pk, del_func):
     data = response.json()
@@ -431,6 +434,9 @@ class ReusableContainerRegistry:
     def cleanup(self):
         del_registry(self._registry["id"])
 
+    def __del__(self):
+        self.cleanup()
+
 
 class ReusableRemoteContainer:
     def __init__(self, name, registry_pk, groups=None):
@@ -490,6 +496,9 @@ class ReusableRemoteContainer:
 
     def cleanup(self):
         del_container(f"{self._ns_name}/{self._name}")
+
+    def __del__(self):
+        self.cleanup()
 
 
 class ReusableLocalContainer:
@@ -556,3 +565,6 @@ class ReusableLocalContainer:
 
     def cleanup(self):
         del_container(self._name)
+
+    def __del__(self):
+        self.cleanup()

--- a/galaxy_ng/tests/integration/api/test_rbac_roles.py
+++ b/galaxy_ng/tests/integration/api/test_rbac_roles.py
@@ -336,7 +336,7 @@ def _get_reusable_extras():
 
     if len(REUSABLE_EXTRA) == 0:
         _registry = ReusableContainerRegistry(gen_string())
-        _registry_pk = _registry.get_registry()["pk"]
+        _registry_pk = _registry.get_registry()["id"]
 
         REUSABLE_EXTRA = {
             "collection": ReusableCollection(gen_string()),

--- a/galaxy_ng/tests/integration/api/test_rbac_roles.py
+++ b/galaxy_ng/tests/integration/api/test_rbac_roles.py
@@ -352,9 +352,6 @@ def _get_reusable_extras():
 @pytest.mark.standalone_only
 @pytest.mark.parametrize("role", ROLES_TO_TEST)
 def test_global_role_actions(role):
-    registry = ReusableContainerRegistry(gen_string())
-    registry_pk = registry.get_registry()["id"]
-
     USERNAME = f"{NAMESPACE}_user_{gen_string()}"
 
     user = create_user(USERNAME, PASSWORD)
@@ -455,9 +452,6 @@ def test_object_role_actions():
 @pytest.mark.rbac_roles
 @pytest.mark.standalone_only
 def test_role_actions_for_admin():
-    registry = ReusableContainerRegistry(gen_string())
-    registry_pk = registry.get_registry()["id"]
-
     extra = _get_reusable_extras()
     failures = []
 


### PR DESCRIPTION
Changes:
- fixed a bug where the alpine test container was getting pulled on every test (~10 seconds per test)
- initialize reusable objects once at beginning of test (~22 seconds per test)
- tear down reusable objects once at the end of the tests (~6 seconds per test)

Total time saved: 38 seconds per test (total 8 minutes across 13 tests)

Notes:
Half the test time is used by podman for testing pushing containers. Even when the user doesn't have permissions to push containers, this step still takes 10 seconds and runs 3 times per test. I would like to find a way to further optimize this, but there doesn't seem to be any way around the fact that podman is just really slow.