### PR TITLE
clowder: Add template to run management commands via job

### DIFF
--- a/CHANGES/1608.misc
+++ b/CHANGES/1608.misc
@@ -1,0 +1,1 @@
+Add template to run django-admin management commands via OpenShift job, through appsre saas file.

--- a/openshift/clowder/run-job.yaml
+++ b/openshift/clowder/run-job.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: automation-hub-job
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: automation-hub-job-${IMAGE_TAG}-${JOBID}
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          imagePullSecrets:
+            - name: quay-cloudservices-pull
+          containers:
+            - image: ${IMAGE_NAME}:${IMAGE_TAG}
+              imagePullPolicy: IfNotPresent
+              name: automation-hub-job
+              resources:
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+              command: ["/bin/sh", "-c"]
+              args: ["${ARGS}"]
+              env:
+                - name: RERUN
+                  value: ${RERUN}
+                - name: ACG_CONFIG
+                  value: /cdapp/cdappconfig.json
+                - name: PULP_GALAXY_DEPLOYMENT_MODE
+                  value: "insights"
+                - name: PULP_CONTENT_ORIGIN
+                  value: ${CONTENT_ORIGIN}
+                - name: PULP_RH_ENTITLEMENT_REQUIRED
+                  value: "insights"
+                - name: PULP_X_PULP_CONTENT_HOST
+                  value: "automation-hub-pulp-content-app-cwa"
+                - name: PULP_X_PULP_CONTENT_PORT
+                  value: "10000"
+                - name: PULP_REDIS_SSL
+                  value: "true"
+              volumeMounts:
+                - name: pulp-key
+                  mountPath: /etc/pulp/certs/database_fields.symmetric.key
+                  subPath: database_fields.symmetric.key
+                - name: config-secret
+                  mountPath: /cdapp
+          volumes:
+            - name: pulp-key
+              secret:
+                secretName: pulp-key
+            - name: config-secret
+              secret:
+                secretName: automation-hub
+
+parameters:
+  - name: ARGS
+    value: echo "please provide ARGS parameter to run a command"
+  - name: RERUN
+    value: "0"
+  - name: CONTENT_ORIGIN
+    value: localhost
+
+  - name: IMAGE_NAME
+    value: quay.io/cloudservices/automation-hub-galaxy-ng
+  - name: IMAGE_TAG
+    required: true
+  - name: JOBID
+    generate: expression
+    from: "[0-9a-z]{5}"
+
+  - name: MEMORY_REQUEST
+    value: 1024Mi
+  - name: MEMORY_LIMIT
+    value: 2048Mi
+  - name: CPU_REQUEST
+    value: 250m
+  - name: CPU_LIMIT
+    value: 1000m


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Adds template to run django-admin management commands via OpenShift job, through appsre saas file.

<!-- Add Jira issue link -->
Issue: AAH-1608

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit