### PR TITLE
[Backport to stable-4.5] [bugfix] Fix signing feature flags for UI

### DIFF
--- a/CHANGES/1690.bugfix
+++ b/CHANGES/1690.bugfix
@@ -1,0 +1,1 @@
+Fix feature flags for signing

--- a/galaxy_ng/app/api/ui/views/feature_flags.py
+++ b/galaxy_ng/app/api/ui/views/feature_flags.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
+from pulpcore.plugin.models import SigningService
 from galaxy_ng.app.api import base as api_base
 
 
@@ -9,4 +10,50 @@ class FeatureFlagsView(api_base.APIView):
     permission_classes = [IsAuthenticatedOrReadOnly]
 
     def get(self, request, *args, **kwargs):
-        return Response(settings.GALAXY_FEATURE_FLAGS)
+        flags = settings.get("GALAXY_FEATURE_FLAGS", {})
+        _load_conditional_signing_flags(flags)
+        return Response(flags)
+
+
+def _load_conditional_signing_flags(flags):
+    """Computes conditional flags for signing feature. ref: AAH-1690"""
+    # kept for backwards compatibility to avoid breaking outdated UIs
+    flags.setdefault(
+        "collection_signing",
+        bool(settings.get("GALAXY_COLLECTION_SIGNING_SERVICE"))
+    )
+
+    # Main signing feature switcher (replaces collection_signing)
+    enabled = flags.setdefault(
+        "signatures_enabled",
+        flags["collection_signing"]
+    )
+    # Should UI require signature upload for enabling approval button?
+    require_upload = flags.setdefault(
+        "require_upload_signatures",
+        enabled and bool(settings.get("GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL"))
+    )
+
+    # Is the system configured with a Signing Service to create signatures?
+    def _signing_service_exists(settings):
+        name = settings.get("GALAXY_COLLECTION_SIGNING_SERVICE")
+        return SigningService.objects.filter(name=name).exists()
+
+    can_create = flags.setdefault(
+        "can_create_signatures",
+        enabled and _signing_service_exists(settings)
+    )
+
+    # Is the system enabled to accept signature uploads?
+    can_upload = flags.setdefault(
+        "can_upload_signatures",
+        enabled and require_upload or bool(settings.get("GALAXY_SIGNATURE_UPLOAD_ENABLED"))
+    )
+    # Does the system automatically sign automatically upon approval?
+    flags.setdefault(
+        "collection_auto_sign",
+        enabled and can_create and bool(settings.get("GALAXY_AUTO_SIGN_COLLECTIONS"))
+    )
+
+    # Should UI show badges, text, signature blob, filters...
+    flags.setdefault("display_signatures", enabled and can_create or can_upload)

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -1,9 +1,9 @@
 import json
-import ldap
-import pkg_resources
 import os
 from typing import Any, Dict
 
+import ldap
+import pkg_resources
 from django_auth_ldap.config import LDAPSearch
 from dynaconf import Dynaconf
 
@@ -15,6 +15,9 @@ def post(settings: Dynaconf) -> Dict[str, Any]:
 
     settings: A read-only copy of the django.conf.settings
     returns: a dictionary to be merged to django.conf.settings
+
+    NOTES:
+        Feature flags must be loaded directly on `app/api/ui/views/feature_flags.py` view.
     """
     data = {"dynaconf_merge": False}
     # existing keys will be merged if dynaconf_merge is set to True
@@ -24,7 +27,6 @@ def post(settings: Dynaconf) -> Dict[str, Any]:
     data.update(configure_logging(settings))
     data.update(configure_keycloak(settings))
     data.update(configure_cors(settings))
-    data.update(configure_feature_flags(settings))
     data.update(configure_pulp_ansible(settings))
     data.update(configure_authentication_classes(settings))
     data.update(configure_authentication_backends(settings))
@@ -270,16 +272,6 @@ def configure_cors(settings: Dynaconf) -> Dict[str, Any]:
     if settings.get("GALAXY_ENABLE_CORS", default=False):
         corsmiddleware = ["galaxy_ng.app.common.openapi.AllowCorsMiddleware"]
         data["MIDDLEWARE"] = corsmiddleware + settings.get("MIDDLEWARE", [])
-    return data
-
-
-def configure_feature_flags(settings: Dynaconf) -> Dict[str, Any]:
-    """Adds conditional feature flags"""
-    data = {}
-    data["GALAXY_FEATURE_FLAGS__collection_signing"] = settings.get(
-        "GALAXY_COLLECTION_SIGNING_SERVICE") is not None
-    data["GALAXY_FEATURE_FLAGS__collection_auto_sign"] = settings.get(
-        "GALAXY_AUTO_SIGN_COLLECTIONS", False)
     return data
 
 

--- a/galaxy_ng/tests/integration/api/test_collection_signing.py
+++ b/galaxy_ng/tests/integration/api/test_collection_signing.py
@@ -37,6 +37,11 @@ def settings(api_client):
     return api_client("/api/automation-hub/_ui/v1/settings/")
 
 
+@pytest.fixture(scope="function")
+def flags(api_client):
+    return api_client("/api/automation-hub/_ui/v1/feature-flags/")
+
+
 @pytest.fixture(scope="function", autouse=True)
 def namespace(api_client):
     # ensure namespace exists
@@ -76,18 +81,18 @@ def sign_on_demand(api_client, signing_service, sign_url=None, **payload):
 @pytest.mark.collection_signing
 @pytest.mark.collection_move
 @pytest.mark.standalone_only
-def test_collection_auto_sign_on_approval(api_client, config, settings, upload_artifact):
+def test_collection_auto_sign_on_approval(api_client, config, settings, flags, upload_artifact):
     """Test whether a collection is uploaded and automatically signed on approval
     when GALAXY_AUTO_SIGN_COLLECTIONS is set to true.
     """
-    if not settings.get("GALAXY_AUTO_SIGN_COLLECTIONS"):
+    if not flags.get("collection_auto_sign"):
         pytest.skip("GALAXY_AUTO_SIGN_COLLECTIONS is not enabled")
     else:
         log.info("GALAXY_AUTO_SIGN_COLLECTIONS is enabled")
 
-    signing_service = settings.get("GALAXY_COLLECTION_SIGNING_SERVICE")
-    if not signing_service:
-        pytest.skip("GALAXY_SIGN_SERVICE is not set")
+    can_sign = flags.get("can_create_signatures")
+    if not can_sign:
+        pytest.skip("GALAXY_COLLECTION_SIGNING_SERVICE is not configured")
 
     artifact = build_collection(
         "skeleton",
@@ -114,6 +119,8 @@ def test_collection_auto_sign_on_approval(api_client, config, settings, upload_a
     collections = get_all_collections_by_repo(api_client)
     assert ckey not in collections["staging"]
     assert ckey in collections["published"]
+
+    signing_service = settings.get("GALAXY_COLLECTION_SIGNING_SERVICE")
 
     # Assert that the collection is signed on v3 api
     collection = api_client(
@@ -164,7 +171,7 @@ def test_collection_auto_sign_on_approval(api_client, config, settings, upload_a
         ),
     ],
 )
-def test_collection_sign_on_demand(api_client, config, settings, upload_artifact, sign_url):
+def test_collection_sign_on_demand(api_client, config, settings, flags, upload_artifact, sign_url):
     """Test whether a collection can be signed on-demand by calling _ui/v1/collection_signing/"""
     if not settings.get("GALAXY_REQUIRE_CONTENT_APPROVAL"):
         pytest.skip(
@@ -172,9 +179,9 @@ def test_collection_sign_on_demand(api_client, config, settings, upload_artifact
             "so content is automatically signed during approval"
         )
 
-    signing_service = settings.get("GALAXY_COLLECTION_SIGNING_SERVICE")
-    if not signing_service:
-        pytest.skip("GALAXY_SIGN_SERVICE is not set")
+    can_sign = flags.get("can_create_signatures")
+    if not can_sign:
+        pytest.skip("GALAXY_COLLECTION_SIGNING_SERVICE is not configured")
 
     artifact = build_collection(
         "skeleton",
@@ -193,6 +200,8 @@ def test_collection_sign_on_demand(api_client, config, settings, upload_artifact
     assert ckey in collections["staging"]
     assert ckey not in collections["published"]
 
+    signing_service = settings.get("GALAXY_COLLECTION_SIGNING_SERVICE")
+
     # Sign the collection
     sign_payload = {
         "distro_base_path": "staging",
@@ -201,7 +210,6 @@ def test_collection_sign_on_demand(api_client, config, settings, upload_artifact
         "version": artifact.version,
     }
     sign_on_demand(api_client, signing_service, sign_url.format(**sign_payload), **sign_payload)
-
     # Assert that the collection is signed on v3 api
     collection = api_client(
         "/api/automation-hub/content/staging/v3/collections/"
@@ -236,13 +244,14 @@ def test_collection_sign_on_demand(api_client, config, settings, upload_artifact
 @pytest.mark.collection_signing
 @pytest.mark.collection_move
 @pytest.mark.standalone_only
-def test_collection_move_with_signatures(api_client, config, settings, upload_artifact):
+def test_collection_move_with_signatures(api_client, config, settings, flags, upload_artifact):
     """Test whether a collection can be moved from repo to repo with its
     signatures.
     """
-    signing_service = settings.get("GALAXY_COLLECTION_SIGNING_SERVICE")
-    if not signing_service:
-        pytest.skip("GALAXY_SIGN_SERVICE is not set")
+
+    can_sign = flags.get("can_create_signatures")
+    if not can_sign:
+        pytest.skip("GALAXY_COLLECTION_SIGNING_SERVICE is not configured")
 
     artifact = build_collection(
         "skeleton",
@@ -260,6 +269,8 @@ def test_collection_move_with_signatures(api_client, config, settings, upload_ar
     collections = get_all_collections_by_repo(api_client)
     assert ckey in collections["staging"]
     assert ckey not in collections["published"]
+
+    signing_service = settings.get("GALAXY_COLLECTION_SIGNING_SERVICE")
 
     if settings.get("GALAXY_REQUIRE_CONTENT_APPROVAL"):
         # Sign the collection while still on staging


### PR DESCRIPTION
Issue: AAH-1690

#### What is this PR doing:
## Feature flags
The web UI of reads feature flags from `settings.GALAXY_FEATURE_FLAGS` which is a Python `dict` object holding keys to granularly control the signing feature, the flags has default values computed based on 
`settings` and usually **IT IS NOT NEEDED TO CHANGE IT MANUALLY**, however if needed can be manually changed.
For example, to **enable signing feature** + **upload of signatures**
```env
export PULP_GALAXY_FEATURE_FLAGS__signatures_enabled=true
export PULP_GALAXY_FEATURE_FLAGS__can_upload_signatures=true
```
> **TIP** the above can also be defined on `/etc/pulp/settings.py`, remove the `PULP_` prefix and use Python booleans `GALAXY_FEATURE_FLAGS__signatures_enabled = True`
### The Signing Flags
- `signatures_enabled`
    - renaming of  `collection_signing` (which will be kept for compatibility)
    - **defaults**: the value of `collection_signing` flag 
      (which is true whenever `settings.GALAXY_COLLECTION_SIGNING_SERVICE` is `True`)
- `require_upload_signatures`
    - Should approve button be disabled if signature is required?
    - **defaults**: the value of settings.GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL AND signatures_enabled
- `can_create_signatures`
    - Should UI display the links to sign collection on namespace and version pages?
    - **defaults**: signature_enabled AND settings.COLLECTION_SIGNING_SERVICE is set AND `SigningService` is configured with signing keys.
- `can_upload_signatures`
    - Should UI display the upload signature button?
    - **defaults**: signatures_enabled AND require_upload_signatures or settings.GALAXY_SIGNATURE_UPLOAD_ENABLED
- `collection_auto_sign`
    - Should collection be automatically signed during manual approval or auto approval?
    - **defaults**: signatures_enabled AND can_create_signatures and settings.GALAXY_AUTO_SIGN..
-  `display_signatures`
    - Should UI show: badges, text, signature text, filter?
    - **defaults**: signatures_enabled AND ( can_create_signatures OR can_upload_signatures)
> The flags above are exposed on `/api/automation-hub/_ui/v1/feature-flags/` URL.

```json
{
  "execution_environments": true,
  "collection_signing": true,
  "signatures_enabled": true,
  "require_upload_signatures": false,
  "can_create_signatures": true,
  "can_upload_signatures": false,
  "collection_auto_sign": false,
  "display_signatures": true
}
```


#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit