### PR TITLE
Adds an ee_admin user to test setup

### DIFF
--- a/CHANGES/1796.misc
+++ b/CHANGES/1796.misc
@@ -1,0 +1,1 @@
+Updated tests to use non-admin user

--- a/dev/common/setup_test_data.py
+++ b/dev/common/setup_test_data.py
@@ -62,7 +62,7 @@ admin.is_staff = True
 admin.save()
 
 # Note: this user is not a part of ephemeral keycloak users
-ee_admin, _ = User.objects.get_or_create(username="ee-admin")
+ee_admin, _ = User.objects.get_or_create(username="ee_admin")
 ee_admin.set_password("redhat")
 ee_admin.groups.add(ee_group)
 ee_admin.save()

--- a/dev/common/setup_test_data.py
+++ b/dev/common/setup_test_data.py
@@ -26,6 +26,12 @@ for role in pe_roles:
     if role not in roles_in_group:
         assign_role(rolename=role, entity=pe_group)
 
+print("Add a group that has registry and registry remote roles assigned")
+ee_group, _ = Group.objects.get_or_create(name="ee_group_for_tests")
+ee_role = 'galaxy.execution_environment_admin'
+roles_in_ee_group = [group_role.role.name for group_role in ee_group.object_roles.all()]
+if ee_role not in roles_in_ee_group:
+    assign_role(rolename=ee_role, entity=ee_group)
 
 print("Get or create test users to match keycloak passwords")
 
@@ -55,6 +61,12 @@ admin.is_superuser = True
 admin.is_staff = True
 admin.save()
 
+# Note: this user is not a part of ephemeral keycloak users
+ee_admin, _ = User.objects.get_or_create(username="ee-admin")
+ee_admin.set_password("redhat")
+ee_admin.groups.add(ee_group)
+ee_admin.save()
+
 # Note: User not used for integration tests, not part of ephemeral keycloak users
 legacy_admin, _ = User.objects.get_or_create(username="admin")
 legacy_admin.set_password("admin")
@@ -69,6 +81,7 @@ Token.objects.get_or_create(user=basic_user, key="abcdefghijklmnopqrstuvwxyz1234
 Token.objects.get_or_create(user=partner_engineer, key="abcdefghijklmnopqrstuvwxyz1234567892")
 Token.objects.get_or_create(user=org_admin, key="abcdefghijklmnopqrstuvwxyz1234567893")
 Token.objects.get_or_create(user=admin, key="abcdefghijklmnopqrstuvwxyz1234567894")
+Token.objects.get_or_create(user=ee_admin, key="abcdefghijklmnopqrstuvwxyz1234567895")
 
 
 print("Get or create namespaces + add object permissions to group")

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -165,8 +165,7 @@ def test_api_ui_v1_distributions_by_id(ansible_config):
 @pytest.mark.api_ui
 def test_api_ui_v1_execution_environments_registries(ansible_config):
 
-    # TODO: refactor to use non-admin
-    cfg = ansible_config('admin')
+    cfg = ansible_config('ee_admin')
     with UIClient(config=cfg) as uclient:
 
         # get the response

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -98,7 +98,7 @@ class AnsibleConfigFixture(dict):
             "token": "abcdefghijklmnopqrstuvwxyz1234567894",
         },
         "ee_admin": {
-            "username": "ee-admin",
+            "username": "ee_admin",
             "password": "redhat",
             "token": "abcdefghijklmnopqrstuvwxyz1234567895",
         },

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -97,6 +97,11 @@ class AnsibleConfigFixture(dict):
             "password": "professor",
             "token": "abcdefghijklmnopqrstuvwxyz1234567894",
         },
+        "ee_admin": {
+            "username": "ee-admin",
+            "password": "redhat",
+            "token": "abcdefghijklmnopqrstuvwxyz1234567895",
+        },
         "github_user_1": {
             "username": "gh01",
             "password": "redhat",


### PR DESCRIPTION
#### What is this PR doing:
Creates an `ee_admin` user to be used in integration tests.  Replaces the use of the `admin` user in the `test_api_ui_v1_execution_environments_registries` test per the TODO item.

<!-- Add Jira issue link -->
Issue: AAH-1796

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit