### PR TITLE
Use the correct auth header format for insights proxy

### DIFF
--- a/dev/insights/proxy/flaskapp.py
+++ b/dev/insights/proxy/flaskapp.py
@@ -165,7 +165,8 @@ def get_dir(path):
 
     # assemble the base set of headers with the identity
     headers = {}
-    headers['X_RH_IDENTITY'] = userid_to_identity(user_id)
+    # django is going to replace - with _ and prefix with HTTP_
+    headers['X-RH-IDENTITY'] = userid_to_identity(user_id)
 
     if request.method == 'POST':
 


### PR DESCRIPTION
#### What is this PR doing:

https://www.grouparoo.com/blog/dont-use-underscores-in-http-headers

By default the Nginx option underscores_in_headers is off

https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/?highlight=underscore#missing-disappearing-http-headers

If you do not explicitly set underscores_in_headers on;, NGINX will silently drop HTTP headers with underscores (which are perfectly valid according to the HTTP standard). This is done in order to prevent ambiguities when mapping headers to CGI variables as both dashes and underscores are mapped to underscores during that process.

https://docs.djangoproject.com/en/4.1/ref/request-response/

With the exception of CONTENT_LENGTH and CONTENT_TYPE, as given above, any HTTP headers in the request are converted to META keys by converting all characters to uppercase, replacing any hyphens with underscores and adding an HTTP_ prefix to the name. So, for example, a header called X-Bender would be mapped to the META key HTTP_X_BENDER.


#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit