### PR TITLE
Add option to log collection downloads.

### DIFF
--- a/CHANGES/1118.feature
+++ b/CHANGES/1118.feature
@@ -1,0 +1,1 @@
+Add option to log collection downloads.

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -189,6 +189,11 @@ class CollectionArtifactDownloadView(api_base.APIView):
         prefix = settings.CONTENT_PATH_PREFIX.strip('/')
         distribution = self._get_ansible_distribution(distro_base_path)
 
+        if settings.ANSIBLE_COLLECT_DOWNLOAD_LOG:
+            pulp_ansible_views.CollectionArtifactDownloadView.log_download(
+                request, filename, distro_base_path
+            )
+
         if settings.GALAXY_DEPLOYMENT_MODE == DeploymentMode.INSIGHTS.value:
             url = 'http://{host}:{port}/{prefix}/{distro_base_path}/{filename}'.format(
                 host=settings.X_PULP_CONTENT_HOST,


### PR DESCRIPTION
Issue: AAH-1118

#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Add the download log capabilities from pulp ansible.

#### Notes: 
This will have to get merged after the next release of pulp ansible is available.