### PR TITLE
Restrict collection uploads to namespace owners

### DIFF
--- a/CHANGES/1888.bugfix
+++ b/CHANGES/1888.bugfix
@@ -1,0 +1,1 @@
+Verify user is in the ownership group of a namespace prior to uploading


### PR DESCRIPTION
#### What is this PR doing:
Restrict collection uploads to namespace owners when they exist, rely on model-permissions otherwise.

<!-- Add Jira issue link -->
Issue: AAH-1888

#### Reviewers must know:
See AAH-1888 for reproduction steps

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit