### PR TITLE
Add sign_state to UI/API ee repositories

### DIFF
--- a/CHANGES/1906.misc
+++ b/CHANGES/1906.misc
@@ -1,0 +1,1 @@
+Add sign_state on ee repositories ui api

--- a/dev/common/container_sign.sh
+++ b/dev/common/container_sign.sh
@@ -4,7 +4,9 @@
 #export GPG_TTY=$(tty)
 
 # On a production system, this next variable should be set on the outer environment, not here.
-export PULP_CONTAINER_SIGNING_KEY_FINGERPRINT=$(gpg --show-keys --with-colons --with-fingerprint /tmp/ansible-sign.key | awk -F: '$1 == "fpr" {print $10;}' | head -n1)
+# export PULP_CONTAINER_SIGNING_KEY_FINGERPRINT=$(gpg --show-keys --with-colons --with-fingerprint /tmp/ansible-sign.key | awk -F: '$1 == "fpr" {print $10;}' | head -n1)
+# Below matches the fingerprint for dev environment key.
+export PULP_CONTAINER_SIGNING_KEY_FINGERPRINT=EBED170E8C9480E22A1D059B15250E9EC0A62577
 
 # Create a file with passphrase only if the key is password protected.
 echo "Galaxy2022" > /tmp/key_password.txt

--- a/galaxy_ng/app/api/ui/serializers/execution_environment.py
+++ b/galaxy_ng/app/api/ui/serializers/execution_environment.py
@@ -105,6 +105,10 @@ class ContainerRepositorySerializer(serializers.ModelSerializer):
         if repo.remote:
             remote = ContainerRemoteSerializer(repo.remote.cast()).data
 
+        sign_state = repo.content.filter(
+            pulp_type="container.signature"
+        ).count() > 0 and "signed" or "unsigned"
+
         return {
             "repository": {
                 "pulp_id": repo.pk,
@@ -114,7 +118,8 @@ class ContainerRepositorySerializer(serializers.ModelSerializer):
                 "description": repo.description,
                 "pulp_created": repo.pulp_created,
                 "pulp_labels": {label.key: label.value for label in repo.pulp_labels.all()},
-                "remote": remote
+                "remote": remote,
+                "sign_state": sign_state
             },
             "distribution": {
                 "pulp_id": distro.pk,

--- a/galaxy_ng/tests/integration/api/test_container_signing.py
+++ b/galaxy_ng/tests/integration/api/test_container_signing.py
@@ -59,3 +59,7 @@ def test_push_and_sign_a_container(ansible_config, flags):
     # Check the image is signed on the latest version
     latest_version = client(latest_version_href)
     assert latest_version["content_summary"]["added"]["container.signature"]["count"] > 0
+
+    # Check the sign state is set on the UI API
+    ee = client("/api/automation-hub/_ui/v1/execution-environments/repositories/?name=alpine")
+    assert ee["data"][0]["pulp"]["repository"]["sign_state"] == "signed"


### PR DESCRIPTION
Issue: AAH-1906

#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->


`http://0.0.0.0:5001/api/automation-hub/_ui/v1/execution-environments/repositories/?name=hello-world`
```
"data": [
    {
      "id": "7bf357fb-7f78-4879-8793-7caa8a3efd7b",
      "name": "hello-world",
      "pulp": {
        "repository": {
          "pulp_id": "db452e37-2b6e-4d59-b638-ffbb933d86df",
          "pulp_type": "container.container-push",
          "version": 4,
          "name": "hello-world",
          "description": null,
          "pulp_created": "2022-08-11T11:11:13.778021Z",
          "pulp_labels": {},
          "remote": null,
          "sign_state": "signed"   # <--- THIS ####
        },
```

<!-- Add Jira issue link -->
Issue: AAH-####

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit