### PR TITLE
Fix a bug preventing SSO users from logging in with podman

### DIFF
--- a/CHANGES/1921.bugfix
+++ b/CHANGES/1921.bugfix
@@ -1,0 +1,1 @@
+Fix a bug preventing keycloak SSO users from logging in to the container registry with podman/docker login.

--- a/dev/standalone-keycloak/galaxy_ng.env
+++ b/dev/standalone-keycloak/galaxy_ng.env
@@ -1,7 +1,6 @@
 PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
 
 PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
-PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'galaxy_ng.app.auth.token.ExpiringTokenAuthentication', 'galaxy_ng.app.auth.keycloak.KeycloakBasicAuth']
 PULP_GALAXY_DEPLOYMENT_MODE=standalone
 PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false
 PULP_RH_ENTITLEMENT_REQUIRED=insights

--- a/dev/standalone-ldap/galaxy_ng.env
+++ b/dev/standalone-ldap/galaxy_ng.env
@@ -2,7 +2,6 @@ PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
 PULP_GALAXY_COLLECTION_SIGNING_SERVICE=ansible-default
 PULP_GALAXY_CONTAINER_SIGNING_SERVICE='container-default'
 PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
-PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication','rest_framework.authentication.TokenAuthentication','rest_framework.authentication.BasicAuthentication']
 PULP_GALAXY_DEPLOYMENT_MODE=standalone
 PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false
 PULP_RH_ENTITLEMENT_REQUIRED=insights

--- a/dev/standalone-rbac-roles/galaxy_ng.env
+++ b/dev/standalone-rbac-roles/galaxy_ng.env
@@ -1,7 +1,6 @@
 PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
 
 PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
-PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication', 'rest_framework.authentication.BasicAuthentication']
 PULP_GALAXY_DEPLOYMENT_MODE=standalone
 
 # Commenting this out so local cypress can pass.

--- a/dev/standalone/galaxy_ng.env
+++ b/dev/standalone/galaxy_ng.env
@@ -1,7 +1,6 @@
 PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
 
 PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
-PULP_GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication', 'rest_framework.authentication.BasicAuthentication']
 PULP_GALAXY_DEPLOYMENT_MODE=standalone
 
 # Commenting this out so local cypress can pass.

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -35,7 +35,7 @@ def post(settings: Dynaconf) -> Dict[str, Any]:
 
     # This should go last, and it needs to receive the data from the previous configuration
     # functions because this function configures the rest framework auth classes based off
-    # of the galaxy auth classes, and if galaxy auth classes are overridden by any of the 
+    # of the galaxy auth classes, and if galaxy auth classes are overridden by any of the
     # other dynaconf hooks (such as keycloak), those changes need to be applied to the
     # rest framework auth classes too.
     data.update(configure_authentication_classes(settings, data))


### PR DESCRIPTION
Issue: AAH-1921

Note: The reason we could never reproduce this in our environment was because we were setting the correct auth classes in our container, rather than relying on the default ones in settings.py. I've removed all of these settings from our .env files where they shouldn't be changed.

We don't have keycloak CI tests, so suggestions are welcome for how to add tests.