### PR TITLE
clowder: increase cpu limit

### DIFF
--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -385,7 +385,7 @@ parameters:
 - name: GALAXY_API_CPU_REQUEST
   value: 200m
 - name: GALAXY_API_CPU_LIMIT
-  value: 600m
+  value: '1'
 
 # pulp-content-app resource requirements
 - name: PULP_CONTENT_APP_REPLICAS
@@ -397,7 +397,7 @@ parameters:
 - name: PULP_CONTENT_APP_CPU_REQUEST
   value: 200m
 - name: PULP_CONTENT_APP_CPU_LIMIT
-  value: 600m
+  value: '1'
 
 # pulp-worker resource requirements
 - name: PULP_WORKER_REPLICAS


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
* Increase the default api and content-app CPU limit to 1 core

This has shown to reduce the likelihood of a crashloop backoff in ephemeral where `[CRITICAL] WORKER TIMEOUT` errors are seen during container startup.

<!-- Add Jira issue link -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit