### PR TITLE
Convert get_client into a callable class for easier consumption.

### DIFF
--- a/dev/insights/proxy/flaskapp.py
+++ b/dev/insights/proxy/flaskapp.py
@@ -42,10 +42,18 @@ print(f'UPSTREAM_BASE_URL: {UPSTREAM_BASE_URL}')
 
 # Refresh tokens are what the clients use to request a bearer token from keycloak
 REFRESH_TOKENS = {
+    # jdoe
     '1234567890': '1',
+    'abcdefghijklmnopqrstuvwxyz1234567892': '1',
+    # iqe_normal_user
     '1234567891': '2',
+    'abcdefghijklmnopqrstuvwxyz1234567891': '2',
+    # org-admin
     '1234567892': '3',
+    'abcdefghijklmnopqrstuvwxyz1234567893': '3',
+    # notifications-admin
     '1234567893': '4',
+    'abcdefghijklmnopqrstuvwxyz1234567894': '4',
 }
 
 # Bearer tokens are used for all api calls

--- a/galaxy_ng/tests/integration/api/test_community.py
+++ b/galaxy_ng/tests/integration/api/test_community.py
@@ -224,6 +224,7 @@ def test_v1_sync_with_user_and_limit(ansible_config):
             except Exception:
                 pass
 
+    # start the sync
     resp = api_client('/api/v1/sync/', method='POST', args=pargs)
     assert isinstance(resp, dict)
     assert resp.get('task') is not None
@@ -234,7 +235,7 @@ def test_v1_sync_with_user_and_limit(ansible_config):
     poll_url = f'/api/v1/tasks/{task_id}/'
     state = None
     counter = 0
-    while state is None or state == 'RUNNING' and counter <= 20:
+    while state is None or state == 'RUNNING' and counter <= 100:
         counter += 1
         task_resp = api_client(poll_url, method='GET')
         state = task_resp['results'][0]['state']

--- a/galaxy_ng/tests/integration/api/test_container_ldap.py
+++ b/galaxy_ng/tests/integration/api/test_container_ldap.py
@@ -3,7 +3,6 @@
 See: https://issues.redhat.com/browse/AAH-1358
 """
 import subprocess
-import time
 from urllib.parse import urlparse
 
 import pytest

--- a/galaxy_ng/tests/integration/utils/client_ansible_lib.py
+++ b/galaxy_ng/tests/integration/utils/client_ansible_lib.py
@@ -2,7 +2,8 @@
 
 import json
 import logging
-import os
+
+import requests
 
 from ansible import context
 from ansible.galaxy.api import GalaxyAPI
@@ -16,69 +17,210 @@ logger = logging.getLogger(__name__)
 
 def get_client(config, require_auth=True, request_token=True, headers=None):
     """Get an API client given a role."""
-    headers = headers or {}
-    server = config["url"]
-    assert "200" not in server
-    auth_url = config.get("auth_url")
 
-    # force the galaxy client lib to think the ignore certs kwarg was used
-    # NOTE: this does not work with 2.12+
-    context.CLIARGS = {"ignore_certs": True}
+    return AnsibeGalaxyHttpClient(
+        config=config,
+        require_auth=require_auth,
+        request_token=request_token,
+        headers=headers
+    )
 
-    # request token implies that upstream test wants to use authentication.
-    # however, some tests need to auth but send request_token=False, so this
-    # kwarg is poorly named and confusing.
-    token = config.get("token") or None
 
-    # Only use token when in standalone mode
-    if os.getenv("HUB_LOCAL") is None:
-        token = None  # TODO: refactor
+class AnsibeGalaxyHttpClient:
 
-    if request_token:
-        if token:
-            # keycloak must have a unique auth url ...
-            if auth_url:
-                token = KeycloakToken(config["token"], auth_url=auth_url)
+    # the instantiated http client
+    _galaxy_api_client = None
+
+    # force the client to fetch a token?
+    _request_token = False
+
+    # force the client to do auth?
+    _require_auth = False
+
+    # the auth token
+    _token = None
+
+    # the auth'ed token type
+    #   * keycloak -> bearer
+    #   * galaxy -> token
+    #   * basic -> user+pass
+    _token_type = None
+
+    def __init__(self, config=None, require_auth=True, request_token=True, headers=None):
+        self._config = config
+        self._require_auth = require_auth
+        self._request_token = request_token
+        self._headers = headers or {}
+
+        # this is usually http://localhost:5001/api/automation-hub/
+        self._server = self._config["url"]
+
+        # this is usually a keycloak token request url
+        self._auth_url = config.get("auth_url")
+
+        # force the galaxy client lib to think the ignore certs kwarg was used
+        # NOTE: this does not work with 2.12+
+        context.CLIARGS = {"ignore_certs": True, "verbose": True}
+
+        # negotiate for the auth token
+        self.set_token()
+
+        # instantiate the client
+        self._galaxy_api_client = GalaxyAPI(
+            None,
+            "automation_hub",
+            url=self._server,
+            token=self.token
+        )
+
+        # Fix for 2.12+
+        self._galaxy_api_client.validate_certs = False
+
+    def __call__(self, url, *args, **kwargs):
+        """
+        Make the class callable so that tests won't
+        need a complete refactor.
+        """
+        return self.request(url, *args, **kwargs)
+
+    @property
+    def config(self):
+        return self._config
+
+    @property
+    def token(self):
+        return self._token
+
+    @property
+    def token_type(self):
+        return self._token_type
+
+    def set_token(self):
+
+        # start with the access token if known
+        _token = self._config.get("token") or None
+        self._token_type = 'config'
+
+        # get some sort of token (keycloak/galaxy/basic)
+        if self._request_token:
+
+            if _token:
+                # keycloak must have a unique auth url ...
+                if self._auth_url:
+                    # keycloak needs an access token to then return a bearer token
+                    self._token = KeycloakToken(self._config["token"], auth_url=self._auth_url)
+                    self._token_type = 'keycloak'
+                else:
+                    # django tokens - Authorization: token <token>
+                    self._token = GalaxyToken(self._config["token"])
+                    self._token_type = 'galaxy'
             else:
-                token = GalaxyToken(config["token"])
+                # fallback to basic auth tokens
+                self._token = BasicAuthToken(self._config["username"], self._config["password"])
+                self._token_type = 'basic'
+
+        # use basic auth
+        elif self._require_auth:
+            self._token = BasicAuthToken(self._config["username"], self._config["password"])
+            self._token_type = 'basic'
+
+        # anonymous auth
         else:
-            token = BasicAuthToken(config["username"], config["password"])
-    else:
-        if require_auth:
-            token = BasicAuthToken(config["username"], config["password"])
-        else:
-            token = None
-    client = GalaxyAPI(None, "automation_hub", url=server, token=token)
+            self._token = None
+            self._token_type = None
 
-    # Fix for 2.12+
-    client.validate_certs = False
+    def request(
+        self,
+        url: str = None,
+        args=None,
+        headers: dict = None,
+        method: str = None,
+        auth_required: bool = False,
+        #error_context_msg=None,
+    ) -> dict:
 
-    # make an api call with the upstream galaxy client lib from ansible core
-    def request(url, *args, **kwargs):
-        url = url_safe_join(server, url)
-        req_headers = dict(headers)
-        kwargs_headers = kwargs.get('headers') or {}
-        kwargs_headers_keys = list(kwargs_headers.keys())
-        kwargs_headers_keys = [x.lower() for x in list(kwargs_headers.keys())]
+        """
+        Make an api call with the upstream galaxy client lib from ansible core.
+        """
 
-        if isinstance(kwargs.get("args"), dict):
-            kwargs["args"] = json.dumps(kwargs["args"])
+        _args = args
 
-        # Always send content-type
-        if 'content-type' in kwargs_headers_keys:
-            for k, v in headers.items():
+        # the callers are only sending partial urls most of the time
+        url = url_safe_join(self._server, url)
+        print(f'{method} {url} {args}')
+
+        # detect args type and cast as needed
+        is_json = False
+        if isinstance(args, (dict, list)):
+            args = json.dumps(args)
+            is_json = True
+        elif args and (args.startswith(b'{') or args.startswith(b'[')):
+            args = json.dumps(json.loads(args))
+            is_json = True
+
+        # cast headers to dict if needed
+        if headers is None:
+            headers = {}
+
+        # add in the initially configured headers
+        if self._headers:
+            headers.update(self._headers)
+
+        # Always send content-type if json
+        if is_json or args is None:
+            for k in list(headers.keys()):
                 if k.lower() == 'content-type':
-                    req_headers.pop(k, None)
-        else:
-            req_headers["Content-Type"] = "application/json"
+                    headers.pop(k, None)
+        if is_json:
+            headers["Content-Type"] = "application/json"
+        elif args is None:
+            # fallback to text for NoneType
+            headers["Content-Type"] = "application/text"
 
-        if req_headers:
-            if "headers" in kwargs:
-                kwargs["headers"].update(req_headers)
-            else:
-                kwargs["headers"] = req_headers
+        # payload
+        #   grant_type=refresh_token&client_id=cloud-services&refresh_token=abcdefghijklmnopqrstuvwxyz1234567894
+        # POST
+        # auth_url
+        #   'https://mocks-keycloak-ephemeral-ydabku.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/auth/realms/redhat-external/protocol/openid-connect/token'
 
-        return client._call_galaxy(url, *args, **kwargs)
+        payload = {
+            'grant_type': 'refresh_token',
+            'client_id': 'cloud-services',
+            'refresh_token': self.config.get('token')
+        }
 
-    request.config = config
-    return request
+        payload = {
+            'grant_type': 'password',
+            'client_id': 'cloud-services',
+            'username': self.config.get('username'),
+            'password': self.config.get('password'),
+        }
+
+        session = requests.Session()
+
+        rr = session.post(
+            self.config.get('auth_url'),
+            headers={
+                'User-Agent': 'ansible-galaxy/2.10.17 (Linux; python:3.10.6)'
+            },
+            data=payload,
+            #json=payload,
+            verify=False
+        )
+        bearer_token = rr.json()['access_token']
+        headers['Authorization'] = f'Bearer {bearer_token}'
+        #import epdb; epdb.st()
+
+        rr2 = session.get(url, headers=headers, verify=False)
+        import epdb; epdb.st()
+
+        # https://tinyurl.com/53m2scen
+        return self._galaxy_api_client._call_galaxy(
+            url,
+            args=args,
+            headers=headers,
+            method=method,
+            #auth_required=auth_required,
+            auth_required=False,
+            #error_context_msg=error_context_msg,
+        )

--- a/galaxy_ng/tests/integration/utils/client_ansible_lib.py
+++ b/galaxy_ng/tests/integration/utils/client_ansible_lib.py
@@ -150,7 +150,6 @@ class AnsibeGalaxyHttpClient:
             'password': self.config.get('password'),
         }
 
-
         session = requests.Session()
         rr = session.post(
             self.config.get('auth_url'),
@@ -158,7 +157,6 @@ class AnsibeGalaxyHttpClient:
                 'User-Agent': 'ansible-galaxy/2.10.17 (Linux; python:3.10.6)'
             },
             data=payload,
-            #json=payload,
             verify=False
         )
 
@@ -171,14 +169,11 @@ class AnsibeGalaxyHttpClient:
         headers: dict = None,
         method: str = 'GET',
         auth_required: bool = False,
-        #error_context_msg=None,
     ) -> dict:
 
         """
         Make an api call with the upstream galaxy client lib from ansible core.
         """
-
-        _args = args
 
         # the callers are only sending partial urls most of the time
         url = url_safe_join(self._server, url)

--- a/galaxy_ng/tests/integration/utils/client_ansible_lib.py
+++ b/galaxy_ng/tests/integration/utils/client_ansible_lib.py
@@ -168,12 +168,16 @@ class AnsibeGalaxyHttpClient:
         args=None,
         headers: dict = None,
         method: str = 'GET',
-        auth_required: bool = False,
+        auth_required: bool = None,
     ) -> dict:
 
         """
         Make an api call with the upstream galaxy client lib from ansible core.
         """
+
+        # default back to the auth_required value set at client init
+        if auth_required is None:
+            auth_required = self._require_auth
 
         # the callers are only sending partial urls most of the time
         url = url_safe_join(self._server, url)

--- a/galaxy_ng/tests/integration/utils/urls.py
+++ b/galaxy_ng/tests/integration/utils/urls.py
@@ -42,15 +42,22 @@ def test_url_safe_join():
         [
             'http://localhost:5001/api/<prefix>/',
             '/api/<prefix>/_ui/v1/collection-versions/?limit=10&offset=10&repository=published',
-            'http://localhost:5001/api/<prefix>/_ui/v1/collection-versions/'
-            '?limit=10&offset=10&repository=published'
+            (
+                'http://localhost:5001/api/<prefix>/_ui/v1'
+                + '/collection-versions/?limit=10&offset=10&repository=published'
+            )
         ],
         [
             'http://localhost:5001/api/<prefix>/',
-            'v3/collections/autohubtest2/autohubtest2_teawkayi/versions/1.0.0/move/staging/'
-            'published/',
-            'http://localhost:5001/api/<prefix>/v3/collections/autohubtest2/autohubtest2_teawkayi/'
-            'versions/1.0.0/move/staging/published/'
+            (
+                'v3/collections/autohubtest2/autohubtest2_teawkayi'
+                + '/versions/1.0.0/move/staging/published/'
+            ),
+            (
+                'http://localhost:5001/api/<prefix>/v3'
+                + '/collections/autohubtest2/autohubtest2_teawkayi'
+                + '/versions/1.0.0/move/staging/published/'
+            )
         ]
     ]
 


### PR DESCRIPTION
#### What is this PR doing:
get_client and it's functional return were making it hard to inspect anything about how the client was spun up, such as the token or token type. This PR has it instead return a class instance with properties and methods that allow better introspection and future refactoring.

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit