### PR TITLE
Fail CI lint on flake8 error

### DIFF
--- a/.ci/scripts/extra_linting.sh
+++ b/.ci/scripts/extra_linting.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
+EXIT_CODE=0
+
 # Plugin template removed the call to the flake8 linter
 # so we need to call it ourselves.
-flake8 --config flake8.cfg
+flake8 --config flake8.cfg || EXIT_CODE=1
 
-EXIT_CODE=0
 if (git grep "orphan_protection_time=0" ./galaxy_ng);then
     echo "Setting 'orphan_protection_time' to 0 can lead to a race condition.\n";
     EXIT_CODE=1

--- a/galaxy_ng/tests/integration/utils/urls.py
+++ b/galaxy_ng/tests/integration/utils/urls.py
@@ -1,8 +1,6 @@
 """Utility functions for AH tests."""
 
-import os
 import time
-import uuid
 
 from urllib.parse import urljoin
 from urllib.parse import urlparse
@@ -44,16 +42,19 @@ def test_url_safe_join():
         [
             'http://localhost:5001/api/<prefix>/',
             '/api/<prefix>/_ui/v1/collection-versions/?limit=10&offset=10&repository=published',
-            'http://localhost:5001/api/<prefix>/_ui/v1/collection-versions/?limit=10&offset=10&repository=published'
+            'http://localhost:5001/api/<prefix>/_ui/v1/collection-versions/'
+            '?limit=10&offset=10&repository=published'
         ],
         [
             'http://localhost:5001/api/<prefix>/',
-            'v3/collections/autohubtest2/autohubtest2_teawkayi/versions/1.0.0/move/staging/published/',
-            'http://localhost:5001/api/<prefix>/v3/collections/autohubtest2/autohubtest2_teawkayi/versions/1.0.0/move/staging/published/'
+            'v3/collections/autohubtest2/autohubtest2_teawkayi/versions/1.0.0/move/staging/'
+            'published/',
+            'http://localhost:5001/api/<prefix>/v3/collections/autohubtest2/autohubtest2_teawkayi/'
+            'versions/1.0.0/move/staging/published/'
         ]
     ]
 
-    for idt,tc in enumerate(testcases):
+    for idt, tc in enumerate(testcases):
         server = tc[0]
         url = tc[1]
         expected = tc[2]


### PR DESCRIPTION
No-Issue

Ci Lint (`Galaxy CI / lint (pull_request)`) doesn't fail on an error from flake8 command



on current master locally:
```
flake8 --config flake8.cfg
./galaxy_ng/tests/integration/utils/urls.py:3:1: F401 'os' imported but unused
./galaxy_ng/tests/integration/utils/urls.py:5:1: F401 'uuid' imported but unused
./galaxy_ng/tests/integration/utils/urls.py:47:101: E501 line too long (116 > 100 characters)
./galaxy_ng/tests/integration/utils/urls.py:51:101: E501 line too long (103 > 100 characters)
./galaxy_ng/tests/integration/utils/urls.py:52:101: E501 line too long (137 > 100 characters)
./galaxy_ng/tests/integration/utils/urls.py:56:12: E231 missing whitespace after ','
```

see `Run extra lint checks` in https://github.com/ansible/galaxy_ng/actions/runs/3056613257/jobs/4930952071

