### PR TITLE
Add backport labels to PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,3 +10,6 @@ backport-4.4:
 
 backport-4.5:
 - galaxy_ng/app/**/*
+
+backport-4.6:
+- galaxy_ng/app/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+# Ensure PR with changes to app functionality gets backport labels
+# to be looked at by PR author and reviewer to keep or remove
+# called by .github/workflows/labeler.yml
+
+backport-4.2:
+- galaxy_ng/app/**/*
+
+backport-4.4:
+- galaxy_ng/app/**/*
+
+backport-4.5:
+- galaxy_ng/app/**/*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,6 @@ Issue: AAH-####
 #### Reviewers must know:
 <!-- e.g: Testing steps, dependencies, needed branches etc. -->
 
-#### Notes: 
-
-**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
-**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
+**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
+**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
 **Merger**: When merging, include the Jira issue link in the squashed commit

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+# Add labels to pull request
+# uses logic in .github/labeler.yml
+
+---
+name: "Add labels to pull request"
+
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,12 @@
-# Add labels to pull request
+# Add labels to pull requests against master
 # uses logic in .github/labeler.yml
 
 ---
 name: "Add labels to pull request"
 
 on:
-- pull_request_target
+  pull_request_target:
+    branches: [ "master" ]
 
 jobs:
   triage:


### PR DESCRIPTION
#### What is this PR doing:
Ensure PR with changes to app functionality gets backport labels to be looked at by PR author and reviewer to keep or remove

<!-- Add Jira issue link -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coveragee
**Merger**: When merging, include the Jira issue link in the squashed commit