### PR TITLE
Add EE integration tests for container_path endpoints

### DIFF
--- a/CHANGES/1585.misc
+++ b/CHANGES/1585.misc
@@ -1,0 +1,1 @@
+Add integration tests for container_paths endpoints

--- a/galaxy_ng/tests/integration/api/test_container_ldap.py
+++ b/galaxy_ng/tests/integration/api/test_container_ldap.py
@@ -3,7 +3,6 @@
 See: https://issues.redhat.com/browse/AAH-1358
 """
 import subprocess
-import time
 from urllib.parse import urlparse
 
 import pytest

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -16,6 +16,7 @@ from ..schemas import (
     schema_distro,
     schema_distro_repository,
     schema_ee_registry,
+    schema_ee_namespace_detail,
     schema_featureflags,
     schema_group,
     schema_me,
@@ -28,8 +29,29 @@ from ..schemas import (
     schema_user,
 )
 from ..utils import UIClient, generate_unused_namespace, get_client
+from .rbac_actions.utils import podman_push
+
+from orionutils.generator import randstr
 
 REGEX_403 = r"HTTP Code: 403"
+
+
+def wait_for_task(uclient, task):
+    counter = 0
+    state = None
+    while state in [None, 'waiting', 'running']:
+        counter += 1
+        if counter >= 60:
+            raise Exception('Task is taking too long')
+        resp = uclient.get(absolute_url=task['task'])
+        assert resp.status_code == 200
+        ds = resp.json()
+        validate_json(instance=ds, schema=schema_task_detail)
+        state = ds['state']
+        if state == 'completed':
+            break
+        time.sleep(SLEEP_SECONDS_POLLING)
+    assert state == 'completed'
 
 
 # /api/automation-hub/_ui/v1/auth/login/
@@ -157,10 +179,6 @@ def test_api_ui_v1_distributions_by_id(ansible_config):
             assert _ds['pulp_id'] == distro_id
 
 
-# /api/automation-hub/_ui/v1/execution-environments/namespaces/
-# /api/automation-hub/_ui/v1/execution-environments/namespaces/{name}/
-
-
 # /api/automation-hub/_ui/v1/execution-environments/registries/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
@@ -204,21 +222,7 @@ def test_api_ui_v1_execution_environments_registries(ansible_config):
         validate_json(instance=task, schema=schema_task)
 
         # wait for sync to finish
-        counter = 0
-        state = None
-        while state in [None, 'waiting', 'running']:
-            counter += 1
-            if counter >= 60:
-                raise Exception('ee registry sync task is taking too long')
-            resp = uclient.get(absolute_url=task['task'])
-            assert resp.status_code == 200
-            ds = resp.json()
-            validate_json(instance=ds, schema=schema_task_detail)
-            state = ds['state']
-            if state == 'completed':
-                break
-            time.sleep(SLEEP_SECONDS_POLLING)
-        assert state == 'completed'
+        wait_for_task(uclient, task)
 
         # index it
         resp = uclient.post(
@@ -269,14 +273,80 @@ def test_api_ui_v1_execution_environments_registries(ansible_config):
 
 # /api/automation-hub/_ui/v1/execution-environments/remotes/
 # /api/automation-hub/_ui/v1/execution-environments/remotes/{pulp_id}/
-# /api/automation-hub/_ui/v1/execution-environments/repositories/
-# /api/automation-hub/_ui/v1/execution-environments/repositories/{base_path}/
 # /api/automation-hub/_ui/v1/execution-environments/repositories/{base_path}/_content/history/
 # /api/automation-hub/_ui/v1/execution-environments/repositories/{base_path}/_content/images/
 # /api/automation-hub/_ui/v1/execution-environments/repositories/{base_path}/_content/images/{manifest_ref}/
 # /api/automation-hub/_ui/v1/execution-environments/repositories/{base_path}/_content/readme/
 # /api/automation-hub/_ui/v1/execution-environments/repositories/{base_path}/_content/sync/
 # /api/automation-hub/_ui/v1/execution-environments/repositories/{base_path}/_content/tags/
+
+# /api/automation-hub/_ui/v1/execution-environments/repositories/
+# /api/automation-hub/_ui/v1/execution-environments/repositories/{base_path}/
+# /api/automation-hub/_ui/v1/execution-environments/namespaces/
+# /api/automation-hub/_ui/v1/execution-environments/namespaces/{name}/
+@pytest.mark.standalone_only
+@pytest.mark.api_ui
+def test_api_ui_v1_execution_environments_repositories(ansible_config):
+    cfg = ansible_config('ee_admin')
+    new_namespace = f'ns_{randstr()}'
+    new_repository = f'repo_{randstr()}'
+    new_name = f'{new_namespace}/{new_repository}'
+
+    podman_push(cfg['username'], cfg['password'], new_name)
+
+    with UIClient(config=cfg) as uclient:
+
+        # get the ee repositories view
+        repository_resp = uclient.get('_ui/v1/execution-environments/repositories/')
+        assert repository_resp.status_code == 200
+
+        # assert the correct response serializer
+        repository_ds = repository_resp.json()
+        validate_json(instance=repository_ds, schema=schema_objectlist)
+
+        # validate new repository was created
+        repository_names = [x['name'] for x in repository_ds['data']]
+        assert new_name in repository_names
+
+        # get the namespaces list
+        namespace_resp = uclient.get('_ui/v1/execution-environments/namespaces/')
+        assert namespace_resp.status_code == 200
+
+        # assert correct response serializer
+        namespace_ds = namespace_resp.json()
+        validate_json(instance=namespace_ds, schema=schema_objectlist)
+
+        # assert new namespace was created
+        assert new_namespace in [x['name'] for x in namespace_ds['data']]
+
+        ns_detail_resp = uclient.get(f'_ui/v1/execution-environments/namespaces/{new_namespace}')
+        assert ns_detail_resp.status_code == 200
+
+        # assert correct response serializer
+        ns_detail_ds = ns_detail_resp.json()
+        validate_json(instance=ns_detail_ds, schema=schema_ee_namespace_detail)
+
+        # assert new namespace was created
+        assert new_namespace == ns_detail_ds['name']
+        assert cfg['username'] in ns_detail_ds['owners']
+
+        # delete the respository
+        delete_repository_resp = uclient.delete(
+            f'_ui/v1/execution-environments/repositories/{new_name}/'
+        )
+        assert delete_repository_resp.status_code == 202
+        task = delete_repository_resp.json()
+        wait_for_task(uclient, task)
+
+        # get the repositories list again
+        repository_resp = uclient.get('_ui/v1/execution-environments/repositories/')
+        assert repository_resp.status_code == 200
+
+        # assert the new repository has been deleted
+        repository_ds = repository_resp.json()
+        repository_names = [x['name'] for x in repository_ds['data']]
+
+        assert new_name not in repository_names
 
 
 # /api/automation-hub/_ui/v1/feature-flags/

--- a/galaxy_ng/tests/integration/schemas.py
+++ b/galaxy_ng/tests/integration/schemas.py
@@ -366,6 +366,24 @@ schema_collection_import_detail = {
 }
 
 
+schema_ee_namespace_detail = {
+    'type': 'object',
+    'additional_properties': False,
+    'required': [
+        'name',
+        'my_permissions',
+        'owners',
+        'groups',
+    ],
+    'properties': {
+        'name': {'type': 'string'},
+        'my_permissions': {'type': ['array', 'null']},
+        'owners': {'type': ['array', 'null']},
+        'groups': {'type': ['array', 'null']},
+    }
+}
+
+
 schema_ee_registry = {
     'type': 'object',
     'additional_properties': False,

--- a/galaxy_ng/tests/integration/utils/__init__.py
+++ b/galaxy_ng/tests/integration/utils/__init__.py
@@ -25,7 +25,7 @@ from .namespaces import (
     generate_unused_namespace,
     create_unused_namespace
 )
-from .tasks import wait_for_task
+from .tasks import wait_for_task, wait_for_task_ui_client
 from .tools import is_docker_installed, uuid4
 from .urls import (
     url_safe_join,
@@ -54,6 +54,7 @@ __all__ = (
     generate_unused_namespace,
     create_unused_namespace,
     wait_for_task,
+    wait_for_task_ui_client,
     is_docker_installed,
     uuid4,
     url_safe_join,

--- a/galaxy_ng/tests/integration/utils/tasks.py
+++ b/galaxy_ng/tests/integration/utils/tasks.py
@@ -27,3 +27,20 @@ def wait_for_task(api_client, resp, timeout=300):
             ready = resp["state"] not in ("running", "waiting")
         time.sleep(SLEEP_SECONDS_POLLING)
     return resp
+
+
+def wait_for_task_ui_client(uclient, task):
+    counter = 0
+    state = None
+    while state in [None, 'waiting', 'running']:
+        counter += 1
+        if counter >= 60:
+            raise Exception('Task is taking too long')
+        resp = uclient.get(absolute_url=task['task'])
+        assert resp.status_code == 200
+        ds = resp.json()
+        state = ds['state']
+        if state == 'completed':
+            break
+        time.sleep(SLEEP_SECONDS_POLLING)
+    assert state == 'completed'


### PR DESCRIPTION
#### What is this PR doing:
Adds tests for `container_paths` endpoints in AAH-1585, refactored to create a `UI_Client` `wait_for_task` function.

<!-- Add Jira issue link -->
Issue: AAH-1585

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit