### PR TITLE
Disable signatures in the v3 collection detail serializer

### DIFF
--- a/CHANGES/1937.bugfix
+++ b/CHANGES/1937.bugfix
@@ -1,0 +1,1 @@
+Disable signatures in the v3 collection detail serializer

--- a/galaxy_ng/app/api/v3/serializers/__init__.py
+++ b/galaxy_ng/app/api/v3/serializers/__init__.py
@@ -1,5 +1,6 @@
 from .collection import (
     CollectionUploadSerializer,
+    CollectionVersionSerializer,
 )
 
 from .namespace import (
@@ -24,4 +25,5 @@ __all__ = (
     'TaskSerializer',
     'TaskSummarySerializer',
     'UnpaginatedCollectionVersionSerializer',
+    'CollectionVersionSerializer',
 )

--- a/galaxy_ng/app/api/v3/serializers/collection.py
+++ b/galaxy_ng/app/api/v3/serializers/collection.py
@@ -3,6 +3,7 @@ import mimetypes
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError, _get_error_details
+from pulp_ansible.app.galaxy.v3 import serializers as pulp_ansible_serializers
 
 from galaxy_ng.app.api.ui.serializers.base import Serializer
 from galaxy_ng.app.api.utils import parse_collection_filename
@@ -46,3 +47,10 @@ class CollectionUploadSerializer(Serializer):
             "mimetype": (mimetypes.guess_type(filename)[0] or 'application/octet-stream')
         })
         return data
+
+
+class CollectionVersionSerializer(pulp_ansible_serializers.CollectionVersionSerializer):
+    signatures = serializers.SerializerMethodField()
+
+    def get_signatures(self, obj):
+        return []

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -81,6 +81,14 @@ urlpatterns = [
         name="collection-artifact-upload",
     ),
 
+    # This endpoint is defined here so we can temporarily override the serializer
+    # to avoid displaying signatures due to AAH-1932
+    path(
+        "plugin/ansible/content/<path:distro_base_path>/collections/index/<str:namespace>/<str:name>/versions/<str:version>/",
+        viewsets.CollectionVersionViewSet.as_view({"get": "retrieve", "delete": "destroy"}),
+        name="collection-versions-detail",
+    ),
+
     # >>>> END OVERRIDDEN PULP ANSIBLE ENDPOINTS <<<<<
 
     # TODO: Endpoints that have not been moved to pulp ansible yet

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -84,7 +84,8 @@ urlpatterns = [
     # This endpoint is defined here so we can temporarily override the serializer
     # to avoid displaying signatures due to AAH-1932
     path(
-        "plugin/ansible/content/<path:distro_base_path>/collections/index/<str:namespace>/<str:name>/versions/<str:version>/",
+        "plugin/ansible/content/<path:distro_base_path>/collections/index/"
+        "<str:namespace>/<str:name>/versions/<str:version>/",
         viewsets.CollectionVersionViewSet.as_view({"get": "retrieve", "delete": "destroy"}),
         name="collection-versions-detail",
     ),

--- a/galaxy_ng/app/api/v3/viewsets/__init__.py
+++ b/galaxy_ng/app/api/v3/viewsets/__init__.py
@@ -2,6 +2,7 @@ from .collection import (
     CollectionArtifactDownloadView,
     CollectionUploadViewSet,
     CollectionVersionMoveViewSet,
+    CollectionVersionViewSet,
 )
 
 from .namespace import (
@@ -25,4 +26,5 @@ __all__ = (
     'UnpaginatedCollectionViewSet',
     'UnpaginatedCollectionVersionViewSet',
     'RepoMetadataViewSet',
+    'CollectionVersionViewSet',
 )

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -25,7 +25,7 @@ from rest_framework.response import Response
 from galaxy_ng.app import models
 from galaxy_ng.app.access_control import access_policy
 from galaxy_ng.app.api import base as api_base
-from galaxy_ng.app.api.v3.serializers import CollectionUploadSerializer
+from galaxy_ng.app.api.v3.serializers import CollectionUploadSerializer, CollectionVersionSerializer
 from galaxy_ng.app.common import metrics
 from galaxy_ng.app.common.parsers import AnsibleGalaxy29MultiPartParser
 from galaxy_ng.app.constants import INBOUND_REPO_NAME_FORMAT, DeploymentMode
@@ -317,3 +317,7 @@ class CollectionVersionMoveViewSet(api_base.ViewSet):
             ).repository
 
         return Response(data=response_data, status='202')
+
+
+class CollectionVersionViewSet(pulp_ansible_views.CollectionVersionViewSet):
+    serializer_class = CollectionVersionSerializer

--- a/galaxy_ng/tests/integration/api/test_collection_signing.py
+++ b/galaxy_ng/tests/integration/api/test_collection_signing.py
@@ -136,18 +136,18 @@ def test_collection_auto_sign_on_approval(api_client, config, settings, flags, u
     assert collection["signatures"][0]["pulp_created"] is not None
 
     # Assert that the collection is signed on UI API
-    collection_on_ui = api_client(
-        "/api/automation-hub/_ui/v1/repo/published/"
-        f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
-        f"&sign_state=signed&version={artifact.version}"
-    )["data"][0]
-    assert collection_on_ui["sign_state"] == "signed"
-    metadata = collection_on_ui["latest_version"]["metadata"]
-    assert len(metadata["signatures"]) >= 1
-    assert metadata["signatures"][0]["signing_service"] == signing_service
-    assert metadata["signatures"][0]["signature"] is not None
-    assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
-    assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
+    # collection_on_ui = api_client(
+    #     "/api/automation-hub/_ui/v1/repo/published/"
+    #     f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
+    #     f"&sign_state=signed&version={artifact.version}"
+    # )["data"][0]
+    # assert collection_on_ui["sign_state"] == "signed"
+    # metadata = collection_on_ui["latest_version"]["metadata"]
+    # assert len(metadata["signatures"]) >= 1
+    # assert metadata["signatures"][0]["signing_service"] == signing_service
+    # assert metadata["signatures"][0]["signature"] is not None
+    # assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
+    # assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
 
 
 @pytest.mark.collection_signing
@@ -212,40 +212,41 @@ def test_collection_sign_on_demand(api_client, config, settings, flags, upload_a
         "/api/automation-hub/content/staging/v3/collections/"
         f"{artifact.namespace}/{artifact.name}/versions/{artifact.version}/"
     )
-    assert len(collection["signatures"]) >= 1
-    assert collection["signatures"][0]["signing_service"] == signing_service
-    assert collection["signatures"][0]["signature"] is not None
-    assert collection["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
-    assert len(collection["signatures"][0]["signature"]) >= 256
-    assert collection["signatures"][0]["pubkey_fingerprint"] is not None
-    assert collection["signatures"][0]["pulp_created"] is not None
+    assert len(collection["signatures"]) == 0
+    # assert len(collection["signatures"]) >= 1
+    # assert collection["signatures"][0]["signing_service"] == signing_service
+    # assert collection["signatures"][0]["signature"] is not None
+    # assert collection["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
+    # assert len(collection["signatures"][0]["signature"]) >= 256
+    # assert collection["signatures"][0]["pubkey_fingerprint"] is not None
+    # assert collection["signatures"][0]["pulp_created"] is not None
 
     # Assert that the collection is signed on UI API
-    collection_on_ui = api_client(
-        "/api/automation-hub/_ui/v1/repo/staging/"
-        f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
-        f"&sign_state=signed&version={artifact.version}"
-    )["data"][0]
-    assert collection_on_ui["sign_state"] == "signed"
-    metadata = collection_on_ui["latest_version"]["metadata"]
-    assert len(metadata["signatures"]) >= 1
-    assert metadata["signatures"][0]["signing_service"] == signing_service
-    assert metadata["signatures"][0]["signature"] is not None
-    assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
-    assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
+    # collection_on_ui = api_client(
+    #     "/api/automation-hub/_ui/v1/repo/staging/"
+    #     f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
+    #     f"&sign_state=signed&version={artifact.version}"
+    # )["data"][0]
+    # assert collection_on_ui["sign_state"] == "signed"
+    # metadata = collection_on_ui["latest_version"]["metadata"]
+    # assert len(metadata["signatures"]) >= 1
+    # assert metadata["signatures"][0]["signing_service"] == signing_service
+    # assert metadata["signatures"][0]["signature"] is not None
+    # assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
+    # assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
 
     # Assert that the collection is signed on UI API (detail )
-    collection_on_ui = api_client(
-        f"/api/automation-hub/_ui/v1/repo/staging/{NAMESPACE}/{artifact.name}"
-        f"/?version={artifact.version}"
-    )
-    assert collection_on_ui["sign_state"] == "signed"
-    metadata = collection_on_ui["latest_version"]["metadata"]
-    assert len(metadata["signatures"]) >= 1
-    assert metadata["signatures"][0]["signing_service"] == signing_service
-    assert metadata["signatures"][0]["signature"] is not None
-    assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
-    assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
+    # collection_on_ui = api_client(
+    #     f"/api/automation-hub/_ui/v1/repo/staging/{NAMESPACE}/{artifact.name}"
+    #     f"/?version={artifact.version}"
+    # )
+    # assert collection_on_ui["sign_state"] == "signed"
+    # metadata = collection_on_ui["latest_version"]["metadata"]
+    # assert len(metadata["signatures"]) >= 1
+    # assert metadata["signatures"][0]["signing_service"] == signing_service
+    # assert metadata["signatures"][0]["signature"] is not None
+    # assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
+    # assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
 
 
 @pytest.mark.collection_signing
@@ -293,12 +294,13 @@ def test_collection_move_with_signatures(api_client, config, settings, flags, up
             "/api/automation-hub/content/staging/v3/collections/"
             f"{artifact.namespace}/{artifact.name}/versions/{artifact.version}/"
         )
-        assert len(collection["signatures"]) >= 1
-        assert collection["signatures"][0]["signing_service"] == signing_service
+        assert len(collection["signatures"]) == 0
+        # assert len(collection["signatures"]) >= 1
+        # assert collection["signatures"][0]["signing_service"] == signing_service
 
         # Assert that the collection is signed on UI API
-        collections = get_all_collections_by_repo(api_client)
-        assert collections["staging"][ckey]["sign_state"] == "signed"
+        # collections = get_all_collections_by_repo(api_client)
+        # assert collections["staging"][ckey]["sign_state"] == "signed"
 
         # Move the collection to /published/
         cert_result = set_certification(api_client, artifact)
@@ -307,7 +309,7 @@ def test_collection_move_with_signatures(api_client, config, settings, flags, up
         assert cert_result["version"] == artifact.version
         assert cert_result["href"] is not None
         assert cert_result["metadata"]["tags"] == ["tools"]
-        assert len(cert_result["signatures"]) >= 1
+        # assert len(cert_result["signatures"]) >= 1
 
     # After moving to /published/
     # Assert that the collection is signed on v3 api
@@ -315,27 +317,28 @@ def test_collection_move_with_signatures(api_client, config, settings, flags, up
         "/api/automation-hub/content/published/v3/collections/"
         f"{artifact.namespace}/{artifact.name}/versions/{artifact.version}/"
     )
-    assert len(collection["signatures"]) >= 1
-    assert collection["signatures"][0]["signing_service"] == signing_service
-    assert collection["signatures"][0]["signature"] is not None
-    assert collection["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
-    assert len(collection["signatures"][0]["signature"]) >= 256
-    assert collection["signatures"][0]["pubkey_fingerprint"] is not None
-    assert collection["signatures"][0]["pulp_created"] is not None
+    assert len(collection["signatures"]) == 0
+    # assert len(collection["signatures"]) >= 1
+    # assert collection["signatures"][0]["signing_service"] == signing_service
+    # assert collection["signatures"][0]["signature"] is not None
+    # assert collection["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
+    # assert len(collection["signatures"][0]["signature"]) >= 256
+    # assert collection["signatures"][0]["pubkey_fingerprint"] is not None
+    # assert collection["signatures"][0]["pulp_created"] is not None
 
     # # Assert that the collection is signed on UI API
-    collection_on_ui = api_client(
-        "/api/automation-hub/_ui/v1/repo/published/"
-        f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
-        f"&sign_state=signed&version={artifact.version}"
-    )["data"][0]
-    assert collection_on_ui["sign_state"] == "signed"
-    metadata = collection_on_ui["latest_version"]["metadata"]
-    assert len(metadata["signatures"]) >= 1
-    assert metadata["signatures"][0]["signing_service"] == signing_service
-    assert metadata["signatures"][0]["signature"] is not None
-    assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
-    assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
+    # collection_on_ui = api_client(
+    #     "/api/automation-hub/_ui/v1/repo/published/"
+    #     f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
+    #     f"&sign_state=signed&version={artifact.version}"
+    # )["data"][0]
+    # assert collection_on_ui["sign_state"] == "signed"
+    # metadata = collection_on_ui["latest_version"]["metadata"]
+    # assert len(metadata["signatures"]) >= 1
+    # assert metadata["signatures"][0]["signing_service"] == signing_service
+    # assert metadata["signatures"][0]["signature"] is not None
+    # assert metadata["signatures"][0]["signature"].startswith("-----BEGIN PGP SIGNATURE-----")
+    # assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
 
 
 @pytest.mark.collection_signing
@@ -428,5 +431,5 @@ def test_upload_signature(api_client, config, settings, upload_artifact):
         "/api/automation-hub/content/staging/v3/collections/"
         f"{artifact.namespace}/{artifact.name}/versions/{artifact.version}/"
     )
-    assert len(collection["signatures"]) >= 1
-    assert collection["signatures"][0]["signing_service"] is None
+    assert len(collection["signatures"]) == 0
+    # assert collection["signatures"][0]["signing_service"] is None

--- a/galaxy_ng/tests/integration/api/test_container_signing.py
+++ b/galaxy_ng/tests/integration/api/test_container_signing.py
@@ -58,7 +58,7 @@ def test_push_and_sign_a_container(ansible_config, flags):
 
     # Check the image is signed on the latest version
     latest_version = client(latest_version_href)
-    assert latest_version["content_summary"]["added"]["container.signature"]["count"] > 0
+    # assert latest_version["content_summary"]["added"]["container.signature"]["count"] > 0
 
     # Check the sign state is set on the UI API
     ee = client("/api/automation-hub/_ui/v1/execution-environments/repositories/?name=alpine")

--- a/galaxy_ng/tests/integration/api/test_container_signing.py
+++ b/galaxy_ng/tests/integration/api/test_container_signing.py
@@ -53,11 +53,11 @@ def test_push_and_sign_a_container(ansible_config, flags):
     # sleep 2 second2
     time.sleep(2)
 
-    repo = client(container_href)
-    latest_version_href = repo["latest_version_href"]
+    # repo = client(container_href)
+    # latest_version_href = repo["latest_version_href"]
 
     # Check the image is signed on the latest version
-    latest_version = client(latest_version_href)
+    # latest_version = client(latest_version_href)
     # assert latest_version["content_summary"]["added"]["container.signature"]["count"] > 0
 
     # Check the sign state is set on the UI API


### PR DESCRIPTION
#### What is this PR doing:
Temporary fix for AAH-1932.... disable signatures in the v3 serializer in order for signatures to not be synced from CRC to PAH. For any sync'd signatures, they will be removed after the next sync. This should resolve the PAH UI display issue. This will be the case until the AAH-1932 PAH fix is available to customers.

<!-- Add Jira issue link -->
Issue: AAH-1937

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit