### PR TITLE
bump master to 4.7.0dev

### DIFF
--- a/galaxy_ng/__init__.py
+++ b/galaxy_ng/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.6.0dev"
+__version__ = "4.7.0dev"
 
 default_app_config = "galaxy_ng.app.PulpGalaxyPluginAppConfig"

--- a/galaxy_ng/app/__init__.py
+++ b/galaxy_ng/app/__init__.py
@@ -6,7 +6,7 @@ class PulpGalaxyPluginAppConfig(PulpPluginAppConfig):
 
     name = "galaxy_ng.app"
     label = "galaxy"
-    version = "4.6.0dev"
+    version = "4.7.0dev"
     python_package_name = "galaxy-ng"
 
     def ready(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.6.0dev
+current_version = 4.7.0dev
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+))?((?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools.command.build_py import build_py as _BuildPyCommand
 from setuptools.command.sdist import sdist as _SDistCommand
 
 package_name = os.environ.get("GALAXY_NG_ALTERNATE_NAME", "galaxy-ng")
-version = "4.6.0dev"
+version = "4.7.0dev"
 
 
 class PrepareStaticCommand(Command):


### PR DESCRIPTION
No-Issue

Bumping master version to 4.7.0dev as per the Preflight Checklist in the [Release](https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=AUTOHUB&title=Release+Processes) documentation for Y-stream releases.