### PR TITLE
Inject context to filter signatures based on distro.repository

### DIFF
--- a/CHANGES/1941.bugfix
+++ b/CHANGES/1941.bugfix
@@ -1,0 +1,1 @@
+Filter signatures scoped by distro.repository

--- a/galaxy_ng/app/access_control/statements/insights.py
+++ b/galaxy_ng/app/access_control/statements/insights.py
@@ -38,7 +38,7 @@ _collection_statements = [
         "condition": ["can_update_collection", "has_rh_entitlements"],
     },
     {
-        "action": "move_content",
+        "action": ["copy_content", "move_content"],
         "principal": "authenticated",
         "effect": "allow",
         "condition": [

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -48,7 +48,7 @@ _collection_statements = [
         "condition": "can_update_collection"
     },
     {
-        "action": "move_content",
+        "action": ["copy_content", "move_content"],
         "principal": "authenticated",
         "effect": "allow",
         "condition": "has_model_perms:ansible.modify_ansible_repo_content"

--- a/galaxy_ng/app/api/ui/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/viewsets/collection.py
@@ -116,8 +116,8 @@ class CollectionViewSet(
             deprecated=Exists(deprecated_query),
             version_identifier=version_identifier_expression,
             sign_state=Case(
-                When(signatures__isnull=False, then=Value("signed")),
-                When(signatures__isnull=True, then=Value("unsigned")),
+                When(signatures__pk__in=self._distro_content, then=Value("signed")),
+                default=Value("unsigned"),
             )
         )
 
@@ -151,8 +151,8 @@ class CollectionViewSet(
         return get_object_or_404(
             base_qs.annotate(
                 sign_state=Case(
-                    When(signatures__isnull=False, then=Value("signed")),
-                    When(signatures__isnull=True, then=Value("unsigned")),
+                    When(signatures__pk__in=self._distro_content, then=Value("signed")),
+                    default=Value("unsigned")
                 )
             ),
             version=version,

--- a/galaxy_ng/app/api/v3/urls.py
+++ b/galaxy_ng/app/api/v3/urls.py
@@ -99,6 +99,12 @@ urlpatterns = [
         viewsets.CollectionVersionMoveViewSet.as_view({"post": "move_content"}),
         name="collection-version-move",
     ),
+    path(
+        "collections/<str:namespace>/<str:name>/versions/<str:version>/copy/"
+        "<str:source_path>/<str:dest_path>/",
+        viewsets.CollectionVersionCopyViewSet.as_view({"post": "copy_content"}),
+        name="collection-version-copy",
+    ),
 
     path("", include(v3_urls)),
 

--- a/galaxy_ng/app/api/v3/viewsets/__init__.py
+++ b/galaxy_ng/app/api/v3/viewsets/__init__.py
@@ -2,6 +2,7 @@ from .collection import (
     CollectionArtifactDownloadView,
     CollectionUploadViewSet,
     CollectionVersionMoveViewSet,
+    CollectionVersionCopyViewSet,
     CollectionVersionViewSet,
 )
 
@@ -20,6 +21,7 @@ __all__ = (
     'CollectionArtifactDownloadView',
     'CollectionUploadViewSet',
     'CollectionVersionMoveViewSet',
+    'CollectionVersionCopyViewSet',
     'NamespaceViewSet',
     'SyncConfigViewSet',
     'TaskViewSet',

--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -7,7 +7,13 @@ import pytest
 from orionutils.generator import build_collection
 
 from ..constants import USERNAME_PUBLISHER
-from ..utils import get_client, set_certification, wait_for_task, wait_for_url
+from ..utils import (
+    copy_collection_version,
+    get_client,
+    set_certification,
+    wait_for_task,
+    wait_for_url,
+)
 
 pytestmark = pytest.mark.qa  # noqa: F821
 
@@ -89,3 +95,81 @@ def test_move_collection_version(ansible_config, upload_artifact):
     except Exception:
         failed = True
     assert failed
+
+
+@pytest.mark.galaxyapi_smoke
+@pytest.mark.certification
+@pytest.mark.collection_move
+@pytest.mark.move
+def test_copy_collection_version(ansible_config, upload_artifact):
+    """Tests whether a colleciton can be copied from repo to repo"""
+
+    config = ansible_config("partner_engineer")
+    api_client = get_client(
+        config=config,
+        request_token=True,
+        require_auth=True
+    )
+
+    def get_all_collections():
+        collections = {
+            'staging': {},
+            'community': {}
+        }
+        for repo in collections.keys():
+            next_page = f'/api/automation-hub/_ui/v1/collection-versions/?repository={repo}'
+            while next_page:
+                resp = api_client(next_page)
+                for _collection in resp['data']:
+                    key = (_collection['namespace'], _collection['name'], _collection['version'])
+                    collections[repo][key] = _collection
+                next_page = resp.get('links', {}).get('next')
+        return collections
+
+    pre = get_all_collections()
+    artifact = build_collection(
+        "skeleton",
+        config={
+            "namespace": USERNAME_PUBLISHER,
+            "tags": ["tools", "copytest"],
+        }
+    )
+    ckey = (artifact.namespace, artifact.name, artifact.version)
+    assert ckey not in pre['staging']
+    assert ckey not in pre['community']
+
+    # import and wait ...
+    resp = upload_artifact(config, api_client, artifact)
+    resp = wait_for_task(api_client, resp)
+    assert resp['state'] == 'completed'
+    dest_url = (
+        f"content/staging/v3/collections/{artifact.namespace}/"
+        f"{artifact.name}/versions/{artifact.version}/"
+    )
+    wait_for_url(api_client, dest_url)
+
+    # Make sure it ended up in staging ...
+    before = get_all_collections()
+    assert ckey in before['staging']
+    assert ckey not in before['community']
+
+    # Copy the collection to /community/
+    copy_result = copy_collection_version(
+        api_client,
+        artifact,
+        src_repo_name="staging",
+        dest_repo_name="community"
+    )
+
+    # Check the response...
+    assert copy_result["namespace"]["name"] == artifact.namespace
+    assert copy_result["name"] == artifact.name
+    assert copy_result["version"] == artifact.version
+    assert copy_result["href"] is not None
+    assert copy_result["metadata"]["tags"] == ["tools", "copytest"]
+    assert len(copy_result["signatures"]) == 0
+
+    # Make sure it's copied and not moved
+    after = get_all_collections()
+    assert ckey in after['staging']
+    assert ckey in after['community']

--- a/galaxy_ng/tests/integration/utils/__init__.py
+++ b/galaxy_ng/tests/integration/utils/__init__.py
@@ -7,6 +7,7 @@ from .client_ui import UIClient
 from .collection_inspector import CollectionInspector
 from .collections import (
     build_collection,
+    copy_collection_version,
     upload_artifact,
     modify_artifact,
     get_collections_namespace_path,
@@ -36,6 +37,7 @@ from .urls import (
 __all__ = (
     get_client,
     ansible_galaxy,
+    copy_collection_version,
     SocialGithubClient,
     UIClient,
     CollectionInspector,


### PR DESCRIPTION
Issue: AAH-1941

#### What is this PR doing:
Filtering signatures by distro.repository coming from context["request"]

#### Reviewers must know:
affects:
http://0.0.0.0:5001/api/automation-hub/_ui/v1/repo/rh-certified/namespace/name/
http://0.0.0.0:5001/api/automation-hub/_ui/v1/repo/rh-certified/
http://0.0.0.0:8002/ui/repo/rh-certified
http://0.0.0.0:8002/ui/repo/rh-certified/namespace/name
http://0.0.0.0:5001/api/automation-hub/_ui/v1/collection-versions/?repository=reponame


Copy Endpoint Added

```bash
/api/automation-hub/content/<str:path>/v3/collections/<str:namespace>/<str:name>/versions/<str:version>/copy/<str:source_path>/<str:dest_path>/	galaxy_ng.app.api.v3.viewsets.collection.CollectionVersionCopyViewSet	galaxy:api:v3:collection-version-copy
/api/automation-hub/v3/collections/<str:namespace>/<str:name>/versions/<str:version>/copy/<str:source_path>/<str:dest_path>/	galaxy_ng.app.api.v3.viewsets.collection.CollectionVersionCopyViewSet	galaxy:api:v3:collection-version-copy

```

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit