### PR TITLE
Set CacheControl hdrs directives no-cache on login

### DIFF
--- a/CHANGES/1323.bugfix
+++ b/CHANGES/1323.bugfix
@@ -1,0 +1,1 @@
+Set no-cache headers of auth login endpoints

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -46,6 +46,23 @@ def test_api_ui_v1_login(ansible_config):
         assert uclient.cookies['sessionid'] is not None
 
 
+# /api/automation-hub/_ui/v1/auth/login/
+@pytest.mark.standalone_only
+@pytest.mark.api_ui
+def test_api_ui_v1_login_cache_header(ansible_config):
+
+    cfg = ansible_config("basic_user")
+
+    # an authenticated session has a csrftoken and a sessionid
+    with UIClient(config=cfg) as uclient:
+        assert uclient.cookies['csrftoken'] is not None
+        assert uclient.cookies['sessionid'] is not None
+
+        # verify the auth/login related urls provide a must-revalidate cache type
+        resp = uclient.get('_ui/v1/auth/login/')
+        assert resp.headers['Cache-Control'] == 'no-cache, no-store, must-revalidate'
+
+
 # /api/automation-hub/_ui/v1/auth/logout/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui


### PR DESCRIPTION

#### What is this PR doing:
The default CacheControl value is vague and unset, but set it specifically to no-cache;must-revalidate;no-store for responses from login view.

Issue: AAH-1323

#### Reviewers must know:
Original test case was the jira issue https://issues.redhat.com/browse/AAH-1277 , of which https://issues.redhat.com/browse/AAH-1323 is a child of.  There is some limited details
about the scanning tool and a link to the output.

Open questions: Does this break our ui login?

#### Notes: 

To test, get a galaxy_ng up and running, and hit the https://GALAXY_NG_SERVER/ui/ and attempt to log in. Record the response headers. For old versions, this should include a very limited CacheControl header.

With new version, repeat, but this time the response headers should look something like:
```
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
```

Additional testing would be verifying that the user stays logged into the session, and nothing session/auth related happens.
