### PR TITLE
Set django CSRF_COOKIE_SECURE in settings.py

### DIFF
--- a/CHANGES/1322.bugfix
+++ b/CHANGES/1322.bugfix
@@ -1,0 +1,1 @@
+Add CSRF_COOKIE_SECURE setting to only set cookies on https connections

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -237,3 +237,6 @@ SOCIAL_AUTH_GITHUB_BASE_URL = os.environ.get('SOCIAL_AUTH_GITHUB_BASE_URL', 'htt
 SOCIAL_AUTH_GITHUB_API_URL = os.environ.get('SOCIAL_AUTH_GITHUB_BASE_URL', 'https://api.github.com')
 SOCIAL_AUTH_GITHUB_KEY = os.environ.get('SOCIAL_AUTH_GITHUB_KEY')
 SOCIAL_AUTH_GITHUB_SECRET = os.environ.get('SOCIAL_AUTH_GITHUB_SECRET')
+
+# Ensure cookies are only sent on https connections
+CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
### What is this PR doing:

This ensures cookies are only sent on secure / https connections.

Issue: AAH-1322
Related: AAH-1277


<!-- Describe your changes giving context and all the needed details. -->

The django settings CSRF_COOKIE_SECURE is used by the django method 
`ensure_csrf_cookie` which is used by the login process. The CSRF_COOKIE_SECURE
will add an additional attribute to the SetCookie header 'secure'


#### Reviewers must know:
Tests are mostly comparing the response from logging into https://GALAXY_NG_SERVER/ui/ 

Before: No 'secure' attribute in SetCookie
After: There will be a 'secure' attribute in SetCookie

