### PR TITLE
Update pulp ci to use older image

### DIFF
--- a/.ci/ansible/Containerfile.j2
+++ b/.ci/ansible/Containerfile.j2
@@ -1,4 +1,4 @@
-FROM {{ ci_base | default("ghcr.io/pulp/pulp-ci-centos:" + pulp_container_tag) }}
+FROM {{ ci_base | default("ghcr.io/pulp/pulp-ci-centos@sha256:66dc18a2f201ae9359629b2bcbe0ea67d05fbc8efb9151fab5c6ca0c711eea34") }}
 
 # Add source directories to container
 {% for item in plugins %}


### PR DESCRIPTION
#### What is this PR doing:
Attempt to fix pulp ci by using an older image. 

This will require temporarily disabling this check: `Verify pulp imposed constraints / check_pulp_template_plugin`

<!-- Add Jira issue link -->
No-Issue

#### Notes: 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit