### PR TITLE
Remove errant pytest mark

### DIFF
--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -363,7 +363,6 @@ def test_api_ui_v1_execution_environments_repositories_content_tags(
 # /api/automation-hub/_ui/v1/execution-environments/repositories/{base_path}/
 # /api/automation-hub/_ui/v1/execution-environments/namespaces/
 # /api/automation-hub/_ui/v1/execution-environments/namespaces/{name}/
-@pytest.mark.ee_repo
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
 def test_api_ui_v1_execution_environments_repositories(ansible_config, local_container):


### PR DESCRIPTION
#### What is this PR doing:
Removes a pytest mark, currently throwing warnings in CI,  that I missed removing in a previous PR.

<!-- Add Jira issue link -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit