### PR TITLE
Improve skipping the validate_commit_message check

### DIFF
--- a/.ci/scripts/validate_commit_message_custom.py
+++ b/.ci/scripts/validate_commit_message_custom.py
@@ -142,12 +142,15 @@ def main():
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     github_user = os.environ.get("GITHUB_USER")
+    github_actor = os.environ.get("GITHUB_ACTOR")
     github_pr_commits_url = os.environ["GITHUB_PR_COMMITS_URL"]
     start_commit = os.environ["START_COMMIT"]
     end_commit = os.environ["END_COMMIT"]
     skip_users = ['dependabot[bot]', 'patchback[bot]']
 
-    if github_user in skip_users:
+    if github_user in skip_users:  ## NOTE: patchback[bot] not included in GITHUB_USER
+        is_valid = True
+    elif github_actor in skip_users:
         is_valid = True
     elif github_pr_commits_url:
         is_valid = validate_pr_commits(github_pr_commits_url)


### PR DESCRIPTION
#### What is this PR doing:
PR's opened by patchback don't skip the validate_commit_message check as intended. Adding GITHUB_ACTOR check in addition to GITHUB_USER check which may not always be populated.

<!-- Add Jira issue link -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

#### Notes: 

**PR Author**: Add a QE reviewer ([exceptions](https://docs.engineering.redhat.com/display/AUTOHUB/Other+Team+Processes#OtherTeamProcesses-galaxy_ngrepo)); 
**Reviewers**: look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit