### PR TITLE
clowder: tune health checks

### DIFF
--- a/CHANGES/1965.misc
+++ b/CHANGES/1965.misc
@@ -1,0 +1,1 @@
+Tune health checks to reduce false negatives on liveness probe

--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -68,6 +68,26 @@ objects:
           requests:
             cpu: ${{NGINX_CPU_REQUEST}}
             memory: ${{NGINX_MEMORY_REQUEST}}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 6
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
         env:
           - name: LISTEN_PORT
             value: '8000'
@@ -101,6 +121,26 @@ objects:
           requests:
             cpu: ${{GALAXY_API_CPU_REQUEST}}
             memory: ${{GALAXY_API_MEMORY_REQUEST}}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 6
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
         env:
           - name: PULP_GALAXY_DEPLOYMENT_MODE
             value: 'insights'
@@ -179,18 +219,18 @@ objects:
             path: /api/automation-hub/v3/artifacts/collections/
             port: 10000
             scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
           periodSeconds: 30
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 6
         readinessProbe:
           httpGet:
             path: /api/automation-hub/v3/artifacts/collections/
             port: 10000
             scheme: HTTP
           initialDelaySeconds: 30
-          timeoutSeconds: 1
+          timeoutSeconds: 10
           periodSeconds: 30
           successThreshold: 1
           failureThreshold: 3


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
* adds health checks to the backend and api to override clowder defaults.
* updates the health checks on the content-app to match the backend and api.

The readiness probe timeout is increased from 1 to 10 seconds to allow for variance based on historical loads.
The liveness probe timeout is increased from 1 to 30 seconds to match upstream network infra timeouts.
The liveness probe failureThreshold is increased from 3 to 6 so that both probes do not fail simultaneously.

<!-- Add Jira issue link -->
Issue: AAH-1965

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit