### PR TITLE
labeler: react only when a PR is opened, not on updates

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,7 @@ name: "Add labels to pull request"
 on:
   pull_request_target:
     branches: [ "master" ]
+    types: [ "opened" ]
 
 jobs:
   triage:


### PR DESCRIPTION
Follow-up to #1449 

Only add labels when the PR is first opened, instead of on all updates.

( full list of activity types in https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target )

Cc @awcrosby @jctanner 