### PR TITLE
Allow env to override test cases in RUN_INTEGRATION.sh

### DIFF
--- a/dev/common/RUN_INTEGRATION.sh
+++ b/dev/common/RUN_INTEGRATION.sh
@@ -23,6 +23,7 @@ which virtualenv || pip install --user virtualenv
 
 VENVPATH=/tmp/gng_testing
 PIP=${VENVPATH}/bin/pip
+TEST_CASES=${TEST_CASES:-galaxy_ng/tests/integration}
 
 if [[ ! -d $VENVPATH ]]; then
     virtualenv $VENVPATH
@@ -41,10 +42,10 @@ docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_te
 # export HUB_LOCAL=1
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 if [[ -z $HUB_LOCAL ]]; then
-    pytest --capture=no -m "not standalone_only and not community_only and not rbac_roles" $@ -v galaxy_ng/tests/integration
+    pytest --capture=no -m "not standalone_only and not community_only and not rbac_roles" $@ -v "${TEST_CASES}"
     RC=$?
 else
-    pytest --capture=no -m "not cloud_only and not community_only and not rbac_roles" -v $@ galaxy_ng/tests/integration
+    pytest --capture=no -m "not cloud_only and not community_only and not rbac_roles" -v $@ "${TEST_CASES}"
     RC=$?
 
     if [[ $RC != 0 ]]; then

--- a/dev/ephemeral/smoke_test.sh
+++ b/dev/ephemeral/smoke_test.sh
@@ -9,6 +9,9 @@ cat /etc/issue
 echo "RPM packges ..."
 rpm -qa
 
+# let env override the default test cases to run
+TEST_CASES=${TEST_CASES:-galaxy_ng/tests/integration}
+
 echo "Set project to ${NAMESPACE}"
 oc project ${NAMESPACE}
 
@@ -35,7 +38,7 @@ ${VENV_PATH}/bin/pip install --upgrade pip wheel crc-bonfire sh
 ${VENV_PATH}/bin/pip install -r integration_requirements.txt
 
 echo "Running pytest ..."
-${VENV_PATH}/bin/pytest --capture=no -m "cloud_only or (not standalone_only and not community_only)" -v galaxy_ng/tests/integration
+${VENV_PATH}/bin/pytest --capture=no -m "cloud_only or (not standalone_only and not community_only)" -v "${TEST_CASES}"
 
 #echo ""
 #echo "##################################################"

--- a/dev/insights/RUN_INTEGRATION.sh
+++ b/dev/insights/RUN_INTEGRATION.sh
@@ -16,6 +16,7 @@ which virtualenv || pip install --user virtualenv
 
 VENVPATH=/tmp/gng_testing
 PIP=${VENVPATH}/bin/pip
+TEST_CASES=${TEST_CASES:-galaxy_ng/tests/integration}
 
 if [[ ! -d $VENVPATH ]]; then
     virtualenv $VENVPATH
@@ -31,7 +32,7 @@ pip show epdb || pip install epdb
 # export HUB_LOCAL=1
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 
-pytest --capture=no --tb=short -m "not standalone_only and not community_only and not rbac_roles" $@ -v galaxy_ng/tests/integration
+pytest --capture=no --tb=short -m "not standalone_only and not community_only and not rbac_roles" $@ -v "${TEST_CASES}"
 RC=$?
 
 exit $RC

--- a/dev/standalone-community/RUN_INTEGRATION.sh
+++ b/dev/standalone-community/RUN_INTEGRATION.sh
@@ -8,6 +8,7 @@ which virtualenv || pip install --user virtualenv
 
 VENVPATH=/tmp/gng_testing
 PIP=${VENVPATH}/bin/pip
+TEST_CASES=${TEST_CASES:-galaxy_ng/tests/integration}
 
 if [[ ! -d $VENVPATH ]]; then
     virtualenv $VENVPATH
@@ -27,7 +28,7 @@ export SOCIAL_AUTH_GITHUB_BASE_URL='http://localhost:8082'
 export SOCIAL_AUTH_GITHUB_API_URL='http://localhost:8082'
 
 export HUB_API_ROOT='http://localhost:5001/api/'
-pytest --capture=no -m "community_only" $@ -v galaxy_ng/tests/integration
+pytest --capture=no -m "community_only" $@ -v "${TEST_CASES}"
 RC=$?
 
 if [[ $RC != 0 && ! -z $DUMP_LOGS ]]; then

--- a/dev/standalone-ldap/RUN_INTEGRATION.sh
+++ b/dev/standalone-ldap/RUN_INTEGRATION.sh
@@ -11,6 +11,7 @@ which virtualenv || pip install --user virtualenv
 
 VENVPATH=/tmp/gng_testing
 PIP=${VENVPATH}/bin/pip
+TEST_CASES=${TEST_CASES:-galaxy_ng/tests/integration/}
 
 if [[ ! -d $VENVPATH ]]; then
     virtualenv $VENVPATH
@@ -27,7 +28,7 @@ docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_te
 
 
 #export HUB_API_ROOT='http://localhost:5001/api/'
-pytest --capture=no --tb=short -m "standalone_only and ldap" $@ -v galaxy_ng/tests/integration
+pytest --capture=no --tb=short -m "standalone_only and ldap" $@ -v "${TEST_CASES}"
 RC=$?
 
 exit $RC

--- a/dev/standalone-rbac-roles/RUN_INTEGRATION.sh
+++ b/dev/standalone-rbac-roles/RUN_INTEGRATION.sh
@@ -14,6 +14,7 @@ which virtualenv || pip install --user virtualenv
 
 VENVPATH=/tmp/gng_testing
 PIP=${VENVPATH}/bin/pip
+TEST_CASES=${TEST_CASES:-galaxy_ng/tests/integration}
 
 if [[ ! -d $VENVPATH ]]; then
     virtualenv $VENVPATH
@@ -30,7 +31,7 @@ docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_te
 
 
 #export HUB_API_ROOT='http://localhost:5001/api/'
-pytest --capture=no --tb=short -m "rbac_roles" $@ -v galaxy_ng/tests/integration
+pytest --capture=no --tb=short -m "rbac_roles" $@ -v "${TEST_CASES}"
 RC=$?
 
 exit $RC


### PR DESCRIPTION

#### What is this PR doing:

Allow the env variable TEST_CASES to be passed into env to override the default pattern or file path for finding test cases.

Let's dev or ci specify a more specific location of tests. For example, running a specific test module instead of everything in galaxy_ng/tests/integration.

   TEST_CASES=galaxy_ng/tests/integration/api/test_auth.py RUN_INTEGRATION.sh

No-Issue

Main intended use is to speed up local running of integration tests when dev only needs to run a subset of test cases.

``` shell
   TEST_CASES="galaxy_ng/tests/integration/api/test_pulp_api.py::test_pulp_roles_endpoint galaxy_ng/tests/integration/api/test_auth.py" HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh --log-level=DEBUG --exitfirst -r Pp
```