### PR TITLE
Change social auth created group name to "namespace:<namespace_name>".

### DIFF
--- a/galaxy_ng/social/__init__.py
+++ b/galaxy_ng/social/__init__.py
@@ -101,7 +101,7 @@ class GalaxyNGOAuth2(GithubOAuth2):
         """Create a group in the form of <namespace>:<namespae_name>"""
         with transaction.atomic():
             group, created = \
-                Group.objects.get_or_create_identity(namespace_name, user.username)
+                Group.objects.get_or_create_identity('namespace', namespace_name)
             if created:
                 rbac.add_user_to_group(user, group)
         return group, created

--- a/galaxy_ng/social/__init__.py
+++ b/galaxy_ng/social/__init__.py
@@ -133,7 +133,8 @@ class GalaxyNGOAuth2(GithubOAuth2):
                 )
 
             # add the user to the owners
-            legacy_namespace.owners.add(user)
+            if created:
+                legacy_namespace.owners.add(user)
 
         return legacy_namespace, created
 

--- a/galaxy_ng/social/__init__.py
+++ b/galaxy_ng/social/__init__.py
@@ -98,7 +98,7 @@ class GalaxyNGOAuth2(GithubOAuth2):
         return name.replace('-', '_').lower()
 
     def _ensure_group(self, namespace_name, user):
-        """Create a group in the form of <namespace>:<namespae_name>"""
+        """Create a group in the form of <namespace>:<namespace_name>"""
         with transaction.atomic():
             group, created = \
                 Group.objects.get_or_create_identity('namespace', namespace_name)

--- a/galaxy_ng/social/__init__.py
+++ b/galaxy_ng/social/__init__.py
@@ -64,8 +64,8 @@ class GalaxyNGOAuth2(GithubOAuth2):
         legacy_namespace, _ = self._ensure_legacynamespace(login)
 
         # define namespace, validate and create ...
-        namespace_name = transform_namespace_name(login)
-        if validate_namespace_name(namespace_name):
+        namespace_name = self.transform_namespace_name(login)
+        if self.validate_namespace_name(namespace_name):
 
             # Need user for group and rbac binding
             user = User.objects.filter(username=login).first()
@@ -97,11 +97,11 @@ class GalaxyNGOAuth2(GithubOAuth2):
         """Convert namespace name to valid v3 name."""
         return name.replace('-', '_').lower()
 
-    def _ensure_group(self, namespace_name, user, namespace_name):
-        """Create a group in the form of <namespace>:<login>"""
+    def _ensure_group(self, namespace_name, user):
+        """Create a group in the form of <namespace>:<namespae_name>"""
         with transaction.atomic():
             group, created = \
-                Group.objects.get_or_create_identity(namespace_name, login)
+                Group.objects.get_or_create_identity(namespace_name, user.username)
             if created:
                 rbac.add_user_to_group(user, group)
         return group, created

--- a/galaxy_ng/tests/integration/api/test_community.py
+++ b/galaxy_ng/tests/integration/api/test_community.py
@@ -74,7 +74,7 @@ def cleanup_social_user(username, ansible_config):
     # cleanup the group
     delete_group(username, api_client=get_client(config=ansible_config("admin")))
     delete_group(
-        namespace_name + ':' + username,
+        'namespace:' + namespace_name,
         api_client=get_client(config=ansible_config("admin"))
     )
 

--- a/galaxy_ng/tests/integration/api/test_community.py
+++ b/galaxy_ng/tests/integration/api/test_community.py
@@ -73,7 +73,10 @@ def cleanup_social_user(username, ansible_config):
 
     # cleanup the group
     delete_group(username, api_client=get_client(config=ansible_config("admin")))
-    delete_group(namespace_name  + ':' + username, api_client=get_client(config=ansible_config("admin")))
+    delete_group(
+        namespace_name + ':' + username,
+        api_client=get_client(config=ansible_config("admin"))
+    )
 
     # cleanup the user
     delete_user(username, api_client=get_client(config=ansible_config("admin")))

--- a/galaxy_ng/tests/integration/api/test_community.py
+++ b/galaxy_ng/tests/integration/api/test_community.py
@@ -66,12 +66,14 @@ def cleanup_social_user(username, ansible_config):
     resp = admin_client(f'/api/v1/namespaces/?name={username}', method='GET')
     assert resp['count'] == 0
 
+    namespace_name = username.replace('-', '_').lower()
+
     # cleanup the v3 namespace
-    cleanup_namespace(username, api_client=get_client(config=ansible_config("admin")))
+    cleanup_namespace(namespace_name, api_client=get_client(config=ansible_config("admin")))
 
     # cleanup the group
     delete_group(username, api_client=get_client(config=ansible_config("admin")))
-    delete_group('github:' + username, api_client=get_client(config=ansible_config("admin")))
+    delete_group(namespace_name  + ':' + username, api_client=get_client(config=ansible_config("admin")))
 
     # cleanup the user
     delete_user(username, api_client=get_client(config=ansible_config("admin")))
@@ -216,7 +218,7 @@ def test_social_auth_creates_group(ansible_config):
     with SocialGithubClient(config=cfg) as client:
         resp = client.get('_ui/v1/me/')
         uinfo = resp.json()
-        assert uinfo['groups'][0]['name'] == 'github:gh01'
+        assert uinfo['groups'][0]['name'] == 'namespace:gh01'
 
 
 @pytest.mark.community_only


### PR DESCRIPTION
#### What is this PR doing:
After building scripts to create users and groups, the "github:<login>" format made less sense when trying to associate the new group name to the namespace that was created after the hypen and lowercase transformations.



#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit