### PR TITLE
Add option to customize ldap group params

### DIFF
--- a/CHANGES/1957.bugfix
+++ b/CHANGES/1957.bugfix
@@ -1,0 +1,1 @@
+Add option to customize ldap group params

--- a/dev/standalone-ldap/galaxy_ng.env
+++ b/dev/standalone-ldap/galaxy_ng.env
@@ -34,6 +34,7 @@ PULP_AUTH_LDAP_GROUP_SEARCH_BASE_DN="ou=people,dc=planetexpress,dc=com"
 PULP_AUTH_LDAP_GROUP_SEARCH_SCOPE="SUBTREE"
 PULP_AUTH_LDAP_GROUP_SEARCH_FILTER = "(objectClass=Group)"
 PULP_AUTH_LDAP_GROUP_TYPE_CLASS="django_auth_ldap.config:GroupOfNamesType"
+PULP_AUTH_LDAP_GROUP_TYPE_PARAMS={name_attr="cn"}
 
 # User attribute settings
 PULP_AUTH_LDAP_ALWAYS_UPDATE_USER =true

--- a/docs/config/options.md
+++ b/docs/config/options.md
@@ -56,7 +56,7 @@ export PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=true
 ```
 
 !!! tip
-    Pulp uses [dynaconf](dynaconf.com) to manage its settings, so environment variables have its
+    Pulp uses [dynaconf](https://dynaconf.com) to manage its settings, so environment variables have its
     data types inferred, for example: `PULP_NUMBER=4.2` will be available under `django.conf.settings.NUMBER` 
     as a value of type `float`, if you need to force a string enclose on quotes. `PULP_TEXT='4.2'`
 

--- a/docs/integration/ldap.md
+++ b/docs/integration/ldap.md
@@ -59,14 +59,18 @@ https://docs.pulpproject.org/pulp_container/authentication.html
 PULP_TOKEN_AUTH_DISABLED=true
 ```
 
+### Required setting
+
 `django_auth_ldap` must be included as the first authentication backend, there is a preset called
-`ldap` (you can set it to `custom` if you really want to override `PULP_AUTHENTICATION_BACKENDS` variable)
+`ldap`
 
 ```bash
 PULP_AUTHENTICATION_BACKEND_PRESET=ldap
 ```
 
-Specific django_auth_ldap settings
+> You can set it to `custom` if you really want to override `PULP_AUTHENTICATION_BACKENDS` variable.
+
+### Required Specific django_auth_ldap settings
 
 !!! tip
     depending on the LDAP server some of the following settings might need change.
@@ -86,7 +90,23 @@ PULP_AUTH_LDAP_GROUP_SEARCH_FILTER = "(objectClass=Group)"
 PULP_AUTH_LDAP_GROUP_TYPE_CLASS="django_auth_ldap.config:GroupOfNamesType"
 ```
 
-Optional variables:
+### Customizing Group Type
+
+In some cases you might want to use a different group type class, for example if you want to use
+`MemberDNGroupType` you can set it but also have to set AUTH_LDAP_GROUP_TYPE_PARAMS as follows:
+
+```bash
+PULP_AUTH_LDAP_GROUP_TYPE_CLASS="django_auth_ldap.config:MemberDNGroupType"
+PULP_AUTH_LDAP_GROUP_TYPE_PARAMS={name_attr="cn", member_attr="member"}
+```
+
+> NOTE: the above example exports data as environment variables so it uses the TOML format
+> to describe a dictionary object, if you are adding those settings to `/etc/pulp/settings.py`
+> you need to declare it as a regular python dictionary object.
+> another option is to export as 
+> `PULP_AUTH_LDAP_GROUP_TYPE_PARAMS='@json {"name_attr": "cn", "member_attr": "member"}'`
+
+### Optional variables:
 
 ```bash
 PULP_AUTH_LDAP_USER_ATTR_MAP={first_name="givenName", last_name="sn", email="mail"}
@@ -138,7 +158,7 @@ AUTH_LDAP_USER_FLAGS_BY_GROUP = {
 }
 ```
 
-TLS verification
+### TLS verification
 
 ```bash
 # Make ldap to call start_tls on connections
@@ -148,14 +168,14 @@ PULP_AUTH_LDAP_START_TLS=true
 PULP_GALAXY_LDAP_SELF_SIGNED_CERT=true
 ```
 
-Logging:
+### Logging:
 
 ```bash
 # Enable LDAP logging handler
 PULP_GALAXY_LDAP_LOGGING=true
 ```
 
-Cache
+### Cache
 
 ```bash
 # Change the caching lifetime in seconds (for groups and users search)

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -485,7 +485,11 @@ def configure_ldap(settings: Dynaconf) -> Dict[str, Any]:
             group_type_class = pkg_resources.EntryPoint.parse(
                 f"__name = {classpath}"
             ).resolve()
-            data["AUTH_LDAP_GROUP_TYPE"] = group_type_class(name_attr="cn")
+            group_type_params = settings.get(
+                "AUTH_LDAP_GROUP_TYPE_PARAMS",
+                default={"name_attr": "cn"}
+            )
+            data["AUTH_LDAP_GROUP_TYPE"] = group_type_class(**group_type_params)
 
         if isinstance(AUTH_LDAP_USER_ATTR_MAP, str):
             try:

--- a/galaxy_ng/tests/integration/api/test_ldap.py
+++ b/galaxy_ng/tests/integration/api/test_ldap.py
@@ -27,12 +27,7 @@ def test_ldap_is_enabled(ansible_config, settings):
 
     config = ansible_config("admin")
     api_client = get_client(config, request_token=False, require_auth=True)
-    assert (
-        api_client("/api/automation-hub/_ui/v1/settings/")[
-            "GALAXY_AUTH_LDAP_ENABLED"
-        ]
-        is True
-    )
+    assert api_client("/api/automation-hub/_ui/v1/settings/")["GALAXY_AUTH_LDAP_ENABLED"] is True
 
 
 @pytest.mark.standalone_only


### PR DESCRIPTION
Issue: AAH-1957

#### What is this PR doing:
Add settings `AUTH_LDAP_GROUP_TYPE_PARAMS` as a hashmap

```bash
export PULP_AUTH_LDAP_GROUP_TYPE_PARAMS={name_attr="cn", member_attr="member"}
```

To allow customization og group class params.

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit