### PR TITLE
Fix AttributeError in index_registry task

### DIFF
--- a/CHANGES/1966.bugfix
+++ b/CHANGES/1966.bugfix
@@ -1,0 +1,1 @@
+Fix AttributeError in index_registry task when handing serializer errors

--- a/galaxy_ng/app/tasks/index_registry.py
+++ b/galaxy_ng/app/tasks/index_registry.py
@@ -6,6 +6,8 @@ from django.core import exceptions
 from django.utils.translation import gettext_lazy as _
 from django.http.request import HttpRequest
 
+from rest_framework.exceptions import ValidationError
+
 from pulpcore.plugin.tasking import dispatch
 
 from pulp_container.app import models as container_models
@@ -110,7 +112,7 @@ def create_or_update_remote_container(container_data, registry_pk, request_data)
 
         try:
             serializer.is_valid(raise_exception=True)
-        except serializers.ValidationError as e:
+        except ValidationError as e:
             CouldNotCreateContainerError(
                 container_data['name'],
                 error=str(e)


### PR DESCRIPTION

#### What is this PR doing:

The task was previously attempting to use a ValidationError from a 'serializers' import that didn't define it.

Use the rest_framework.exceptions.ValidationError instead.

Issue: AAH-1966



#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->
To reproduce:

1. Bring a standalone env  (./compose up)
1. run integration tests ( HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh)
1. watch/grep the logs for above traceback  (there should be some before the fix, but none after)
