### PR TITLE
Use ansible-core instead of ansible-base as integration client.

### DIFF
--- a/integration_requirements.txt
+++ b/integration_requirements.txt
@@ -1,7 +1,7 @@
 epdb
 requests
-#ansible-core
-ansible-base
+ansible-core
+#ansible-base
 pytest
 orionutils
 openapi-spec-validator


### PR DESCRIPTION
No-Issue

Signed-off-by: James Tanner <tanner.jc@gmail.com>

#### What is this PR doing:
Bump from ansible from 2.10.x to 2.13+

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit