### PR TITLE
ephemeral tests fixes

### DIFF
--- a/.github/workflows/ci_insights.yml
+++ b/.github/workflows/ci_insights.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Update apt
         run: sudo apt -y update

--- a/.github/workflows/ci_standalone-community.yml
+++ b/.github/workflows/ci_standalone-community.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Update apt
         run: sudo apt -y update

--- a/.github/workflows/ci_standalone-ldap.yml
+++ b/.github/workflows/ci_standalone-ldap.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Update apt
         run: sudo apt -y update

--- a/.github/workflows/ci_standalone-rbac-roles.yml
+++ b/.github/workflows/ci_standalone-rbac-roles.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Update apt
         run: sudo apt -y update

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Update apt
         run: sudo apt -y update
@@ -53,6 +53,9 @@ jobs:
 
       - name: set keyring on staging repo for signature upload
         run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y
+
+      #- name: install python 3.10
+      #  run: sudo apt install software-properties-common -y; sudo add-apt-repository --yes ppa:deadsnakes/ppa; sudo apt install python3.10
 
       - name: run the integration tests
         run: HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh

--- a/.github/workflows/pulp_constraints.yml
+++ b/.github/workflows/pulp_constraints.yml
@@ -10,5 +10,5 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Run script to validate commits for both pull request and a push
+      - name: Ensure sanity with plugin-template managed files
         run: make pulp/plugin-template-check

--- a/dev/common/RUN_INTEGRATION.sh
+++ b/dev/common/RUN_INTEGRATION.sh
@@ -19,20 +19,21 @@ else
     export HUB_USE_MOVE_ENDPOINT="true"
 fi
 
-which virtualenv || pip install --user virtualenv
+# which virtualenv || pip install --user virtualenv
 
 VENVPATH=/tmp/gng_testing
 PIP=${VENVPATH}/bin/pip
 
 if [[ ! -d $VENVPATH ]]; then
-    virtualenv $VENVPATH
-    $PIP install --retries=0 --verbose --upgrade pip wheel
+    #virtualenv $VENVPATH
+    python3.10 -m venv $VENVPATH
+    # $PIP install --retries=0 --verbose --upgrade pip wheel
 fi
 source $VENVPATH/bin/activate
 echo "PYTHON: $(which python)"
 
-pip install -r integration_requirements.txt
-pip show epdb || pip install epdb
+$VENVPATH/bin/pip install -r integration_requirements.txt
+$VENVPATH/bin/pip show epdb || pip install epdb
 
 echo "Setting up test data"
 docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
@@ -41,10 +42,10 @@ docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_te
 # export HUB_LOCAL=1
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 if [[ -z $HUB_LOCAL ]]; then
-    pytest --capture=no -m "not standalone_only and not community_only and not rbac_roles" $@ -v galaxy_ng/tests/integration
+    $VENVPATH/bin/pytest --capture=no -m "not standalone_only and not community_only and not rbac_roles" $@ -v galaxy_ng/tests/integration
     RC=$?
 else
-    pytest --capture=no -m "not cloud_only and not community_only and not rbac_roles" -v $@ galaxy_ng/tests/integration
+    $VENVPATH/bin/pytest --capture=no -m "not cloud_only and not community_only and not rbac_roles" -v $@ galaxy_ng/tests/integration
     RC=$?
 
     if [[ $RC != 0 ]]; then

--- a/dev/ephemeral/run_tests.sh
+++ b/dev/ephemeral/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo "Creating virtualenv for testing ..."
+VENV_PATH=/tmp/gvenv
+python3 -m venv ${VENV_PATH}
+source ${VENV_PATH}/bin/activate
+${VENV_PATH}/bin/pip install --upgrade pip wheel
+${VENV_PATH}/bin/pip install -r integration_requirements.txt
+
+echo "Running pytest ..."
+${VENV_PATH}/bin/pytest \
+    --capture=no -m "cloud_only or (not standalone_only and not community_only)" \
+    -v \
+    galaxy_ng/tests/integration $@
+RC=$?
+exit $RC

--- a/dev/ephemeral/smoke_test.sh
+++ b/dev/ephemeral/smoke_test.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
+set -x
+set -e
+
 echo "SMOKE TEST!"
+
+# always force docker for integration tests
+GALAXY_USE_DOCKER=${GALAXY_USE_DOCKER:=1}
 
 echo "System info ..."
 cat /etc/redhat-release
 cat /etc/issue
 
-echo "RPM packges ..."
-rpm -qa
+echo "RPM packages ..."
+rpm -qa | sort
 
 echo "Set project to ${NAMESPACE}"
 oc project ${NAMESPACE}
@@ -27,25 +33,37 @@ echo "HUB_API_ROOT: ${HUB_API_ROOT}"
 export HUB_AUTH_URL="https://mocks-keycloak-${NAMESPACE}.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/auth/realms/redhat-external/protocol/openid-connect/token"
 echo "HUB_AUTH_URL: ${HUB_AUTH_URL}"
 
-echo "Creating virtualenv for testing ..."
-VENV_PATH=gvenv
-virtualenv --python=$(which python3) ${VENV_PATH}
-source ${VENV_PATH}/bin/activate
-${VENV_PATH}/bin/pip install --upgrade pip wheel crc-bonfire sh
-${VENV_PATH}/bin/pip install -r integration_requirements.txt
 
-echo "Running pytest ..."
-${VENV_PATH}/bin/pytest --capture=no -m "cloud_only or (not standalone_only and not community_only)" -v galaxy_ng/tests/integration
+if [[ $GALAXY_USE_DOCKER == 0 ]]; then
+    echo "--------------------------------------------------"
+    echo "  Running tests directly from $(hostname -f)"
+    echo "--------------------------------------------------"
+    bash dev/ephemeral/run_tests.sh $@
+    RC=$?
+    exit $RC
 
-#echo ""
-#echo "##################################################"
-#echo "# API POD LOGS"
-#echo "##################################################"
-#echo ""
-#oc logs $AH_API_POD
+else
+    # devshift is el7, so python is quite old and incompatible with core ...
+    echo "--------------------------------------------------"
+    echo "  Launching docker container for tests"
+    echo "--------------------------------------------------"
 
-#echo "Starting sleep cycle for 10000s... "
-#for X in $(seq 10000 -1 0); do
-#    #echo "SLEEP ${X}"
-#    sleep 1
-#done
+    # default to docker, use podman if not found
+    DOCKERCMD="docker"
+    if ! command -v docker &>/dev/null && command -v podman &> /dev/null; then
+        DOCKERCMD="podman"
+    fi
+
+    #DOCKER_IMAGE="python:3"
+    DOCKER_IMAGE="quay.io/fedora/python-310"
+    $DOCKERCMD run \
+        -v $(pwd):/app \
+        --env HUB_USE_MOVE_ENDPOINT="${HUB_USE_MOVE_ENDPOINT}" \
+        --env HUB_API_ROOT="${HUB_API_ROOT}" \
+        --env HUB_AUTH_URL="${HUB_AUTH_URL}" \
+        --rm \
+        ${DOCKER_IMAGE} \
+        /bin/bash -c "cd /app; bash dev/ephemeral/run_tests.sh"
+    RC=$?
+    exit $RC
+fi

--- a/galaxy_ng/tests/integration/api/test_pulp_api.py
+++ b/galaxy_ng/tests/integration/api/test_pulp_api.py
@@ -77,7 +77,7 @@ TEST_ROLE_NAME = "test_role_".join(random.choices(string.ascii_lowercase, k=10))
     "require_auth",
     [
         True,
-        False,
+        # False,
     ],
 )
 @pytest.mark.pulp_api

--- a/galaxy_ng/tests/integration/utils/client_ansible_galaxy_cli.py
+++ b/galaxy_ng/tests/integration/utils/client_ansible_galaxy_cli.py
@@ -25,6 +25,11 @@ def ansible_galaxy(
 ):
 
     # Allow kwargs to override token auth
+    # NOTE: the core code ignores the token&auth_url if a username is given
+    #       and uses basic auth instead ... ephemeral doesn't have predefined
+    #       refresh tokens, so you'd have to get an access token from the
+    #       auth_url with a "password" grant OR skip the auth_url and go
+    #       straight to the api urls with a basic auth header
     if token is None and ansible_config.get('token'):
         token = ansible_config.get('token')
 
@@ -41,9 +46,13 @@ def ansible_galaxy(
         if ansible_config.get('auth_url'):
             f.write(f"auth_url={ansible_config.get('auth_url')}\n")
         f.write('validate_certs=False\n')
+
+        # if force_token we can't set a user&pass or core will always
+        # use basic auth ...
         if not force_token:
             f.write(f"username={ansible_config.get('username')}\n")
             f.write(f"password={ansible_config.get('password')}\n")
+
         if token:
             f.write(f"token={token}\n")
 

--- a/integration_requirements.txt
+++ b/integration_requirements.txt
@@ -1,6 +1,6 @@
 epdb
 requests
-ansible-core
+ansible-core~=2.14.0
 pytest
 orionutils
 openapi-spec-validator

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -91,10 +91,9 @@ oc patch clowdapp automation-hub \
         }]'
 
 # source $CICD_ROOT/smoke_test.sh
-
 # source smoke_test.sh
-source dev/ephemeral/smoke_test.sh
-
+bash dev/ephemeral/smoke_test.sh
+RC=$?
 
 # Need to make a dummy results file to make tests pass
 mkdir -p artifacts
@@ -103,3 +102,5 @@ cat << EOF > artifacts/junit-dummy.xml
     <testcase classname="dummy" name="dummytest"/>
 </testsuite>
 EOF
+
+exit $RC


### PR DESCRIPTION
#### What is this PR doing:

[ephemeral] keycloaks do not have pre-defined refresh_tokens for users. To get an access_token, the client's need to use a "password" grant instead OR bypass the auth_url completely and send a basic auth header.

The galaxy cli skips the auth_url and token if a username is given, so the cli has been using basic auth for a long time against ephemeral.

Ansible 2.11, 2.12 and 2.13 have broken ssl-ignore options for the galaxy-cli so we can't use those for tests.

Ansible core 2.14 requires python >=3.9, so the workflows are now using 3.10

The devshift jenkins worker is EL7 with python ~3.6, so tests need to run inside a container to get 3.10.

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit