### PR TITLE
adapt RUN_INTEGRATION_STAGE.sh script to new container with python 3.9

### DIFF
--- a/dev/common/RUN_INTEGRATION_STAGE.sh
+++ b/dev/common/RUN_INTEGRATION_STAGE.sh
@@ -12,7 +12,7 @@ export HUB_USE_MOVE_ENDPOINT=true
 export HUB_API_ROOT="https://console.stage.redhat.com/api/automation-hub/"
 export HUB_AUTH_URL="https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token/"
 
-which virtualenv || pip3 install --user virtualenv
+which virtualenv || pip3 install virtualenv
 
 VENVPATH=/tmp/gng_testing
 PIP=${VENVPATH}/bin/pip
@@ -26,6 +26,6 @@ echo "PYTHON: $(which python)"
 
 pip3 install --upgrade pip wheel
 
-pip3 install -r galaxy_ng/integration_requirements.txt
+pip3 install -r integration_requirements.txt
 
-pytest --log-cli-level=DEBUG -m "not standalone_only and not community_only and not rbac_roles and not slow_in_cloud" --junitxml=galaxy_ng-results.xml -v galaxy_ng/galaxy_ng/tests/integration
+pytest --log-cli-level=DEBUG -m "not standalone_only and not community_only and not rbac_roles and not slow_in_cloud" --junitxml=galaxy_ng-results.xml -v galaxy_ng/tests/integration


### PR DESCRIPTION
No-Issue

This pipeline (galaxy-ng-integration-tests-stage) needs to use python 3.9 to get past this error
https://jenkins-insights-qe-ci.apps.ocp4.prod.psi.redhat.com/job/galaxy-ng-integration-tests-stage/6/console
To do so, the jenkins job now spins up a container with python 3.9 to run the tests (PR pending to be merged https://github.com/RedHatInsights/iqe-jenkins/pull/667). So that everything works together, this little change in the RUN_INTEGRATION_STAGE.sh  (this PR) is needed.