### PR TITLE
Update to pulp-ansible==0.13.5

### DIFF
--- a/.github/workflows/scripts/before_install.sh
+++ b/.github/workflows/scripts/before_install.sh
@@ -122,7 +122,7 @@ fi
 cd ..
 
 
-git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.13.2
+git clone --depth=1 https://github.com/pulp/pulp_ansible.git --branch 0.13.5
 cd pulp_ansible
 
 if [ -n "$PULP_ANSIBLE_PR_NUMBER" ]; then

--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -29,7 +29,7 @@ TAG=ci_build
 if [ -e $REPO_ROOT/../pulp_ansible ]; then
   PULP_ANSIBLE=./pulp_ansible
 else
-  PULP_ANSIBLE=git+https://github.com/pulp/pulp_ansible.git@0.13.2
+  PULP_ANSIBLE=git+https://github.com/pulp/pulp_ansible.git@0.13.5
 fi
 
 if [ -e $REPO_ROOT/../pulp_container ]; then

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -214,7 +214,7 @@ prometheus-client==0.14.1
     # via django-prometheus
 psycopg2==2.9.3
     # via pulpcore
-pulp-ansible==0.13.2
+pulp-ansible==0.13.5
     # via galaxy-ng (setup.py)
 pulp-container==2.10.7
     # via galaxy-ng (setup.py)

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -234,7 +234,7 @@ prometheus-client==0.14.1
     # via django-prometheus
 psycopg2==2.9.3
     # via pulpcore
-pulp-ansible==0.13.2
+pulp-ansible==0.13.5
     # via galaxy-ng (setup.py)
 pulp-container==2.10.7
     # via galaxy-ng (setup.py)

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -214,7 +214,7 @@ prometheus-client==0.14.1
     # via django-prometheus
 psycopg2==2.9.3
     # via pulpcore
-pulp-ansible==0.13.2
+pulp-ansible==0.13.5
     # via galaxy-ng (setup.py)
 pulp-container==2.10.7
     # via galaxy-ng (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ class BuildPyCommand(_BuildPyCommand):
 requirements = [
     "galaxy-importer==0.4.5",
     "pulpcore>=3.18.6,<3.19.0",
-    "pulp-ansible>=0.13.2,<0.14.0",
+    "pulp-ansible>=0.13.5,<0.14.0",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
     "pulp-container>=2.10.7,<2.11.0",

--- a/template_config.yml
+++ b/template_config.yml
@@ -5,7 +5,7 @@
 
 additional_repos:
 - bindings: true
-  branch: 0.13.2
+  branch: 0.13.5
   name: pulp_ansible
   org: pulp
 - bindings: true


### PR DESCRIPTION
No-Issue

Ran `make/requirements` in python3.9 with pip-tools==6.1.0 to preserve requirements.txt sorting

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit