### PR TITLE
Update integration tests to use api_prefix

### DIFF
--- a/galaxy_ng/tests/integration/api/test_collection_signing.py
+++ b/galaxy_ng/tests/integration/api/test_collection_signing.py
@@ -143,7 +143,7 @@ def test_collection_auto_sign_on_approval(api_client, config, settings, flags, u
 
     # Assert that the collection is signed on UI API
     collection_on_ui = api_client(
-        "/api/automation-hub/_ui/v1/repo/published/"
+        f"{api_prefix}/_ui/v1/repo/published/"
         f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
         f"&sign_state=signed&version={artifact.version}"
     )["data"][0]
@@ -230,7 +230,7 @@ def test_collection_sign_on_demand(api_client, config, settings, flags, upload_a
 
     # Assert that the collection is signed on UI API
     collection_on_ui = api_client(
-        "/api/automation-hub/_ui/v1/repo/staging/"
+        f"{api_prefix}/_ui/v1/repo/staging/"
         f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
         f"&sign_state=signed&version={artifact.version}"
     )["data"][0]
@@ -244,7 +244,7 @@ def test_collection_sign_on_demand(api_client, config, settings, flags, upload_a
 
     # Assert that the collection is signed on UI API (detail )
     collection_on_ui = api_client(
-        f"/api/automation-hub/_ui/v1/repo/staging/{NAMESPACE}/{artifact.name}"
+        f"{api_prefix}/_ui/v1/repo/staging/{NAMESPACE}/{artifact.name}"
         f"/?version={artifact.version}"
     )
     assert collection_on_ui["sign_state"] == "signed"
@@ -335,7 +335,7 @@ def test_collection_move_with_signatures(api_client, config, settings, flags, up
 
     # # Assert that the collection is signed on UI API
     collection_on_ui = api_client(
-        "/api/automation-hub/_ui/v1/repo/published/"
+        f"{api_prefix}/_ui/v1/repo/published/"
         f"?deprecated=false&namespace={NAMESPACE}&name={artifact.name}"
         f"&sign_state=signed&version={artifact.version}"
     )["data"][0]

--- a/galaxy_ng/tests/integration/api/test_container_ldap.py
+++ b/galaxy_ng/tests/integration/api/test_container_ldap.py
@@ -13,8 +13,9 @@ from galaxy_ng.tests.integration.utils import get_client
 @pytest.fixture(scope="function")
 def settings(ansible_config):
     config = ansible_config("admin")
+    api_prefix = config.get("api_prefix").rstrip("/")
     api_client = get_client(config, request_token=False, require_auth=True)
-    return api_client("/api/automation-hub/_ui/v1/settings/")
+    return api_client(f"{api_prefix}/_ui/v1/settings/")
 
 
 @pytest.mark.ldap

--- a/galaxy_ng/tests/integration/api/test_landing_page.py
+++ b/galaxy_ng/tests/integration/api/test_landing_page.py
@@ -12,8 +12,9 @@ def test_landing_page(ansible_config):
     api_client = get_client(
         config=ansible_config("basic_user"), request_token=True, require_auth=True
     )
+    api_prefix = api_client.config.get("api_prefix").rstrip("/")
 
-    resultsDict = api_client("/api/automation-hub/_ui/v1/landing-page")
+    resultsDict = api_client(f"{api_prefix}/_ui/v1/landing-page")
 
     assert resultsDict["estate"]["items"][0]
     assert resultsDict["estate"]["items"][0]["shape"]["title"] == "Collections"

--- a/galaxy_ng/tests/integration/api/test_ldap.py
+++ b/galaxy_ng/tests/integration/api/test_ldap.py
@@ -14,8 +14,9 @@ log = logging.getLogger(__name__)
 @pytest.fixture(scope="function")
 def settings(ansible_config):
     config = ansible_config("admin")
+    api_prefix = config.get("api_prefix").rstrip("/")
     api_client = get_client(config, request_token=False, require_auth=True)
-    return api_client("/api/automation-hub/_ui/v1/settings/")
+    return api_client(f"{api_prefix}/_ui/v1/settings/")
 
 
 @pytest.mark.standalone_only
@@ -26,8 +27,9 @@ def test_ldap_is_enabled(ansible_config, settings):
         pytest.skip("GALAXY_AUTH_LDAP_ENABLED is not enabled")
 
     config = ansible_config("admin")
+    api_prefix = config.get("api_prefix").rstrip("/")
     api_client = get_client(config, request_token=False, require_auth=True)
-    assert api_client("/api/automation-hub/_ui/v1/settings/")["GALAXY_AUTH_LDAP_ENABLED"] is True
+    assert api_client(f"{api_prefix}/_ui/v1/settings/")["GALAXY_AUTH_LDAP_ENABLED"] is True
 
 
 @pytest.mark.standalone_only
@@ -39,11 +41,12 @@ def test_ldap_login(ansible_config, settings):
         pytest.skip("GALAXY_AUTH_LDAP_ENABLED is not enabled")
 
     config = ansible_config("ldap")
+    api_prefix = config.get("api_prefix").rstrip("/")
     api_client = get_client(config, request_token=False, require_auth=True)
 
     # This test assumes the running ldap server is the
     # testing image from: rroemhild/test-openldap
-    data = api_client("/api/automation-hub/_ui/v1/me/")
+    data = api_client(f"{api_prefix}/_ui/v1/me/")
     assert data["username"] == "professor"
     assert data["email"] == "professor@planetexpress.com"
     assert data["first_name"] == "Hubert"

--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -27,6 +27,7 @@ def test_move_collection_version(ansible_config, upload_artifact):
     """Tests whether a colleciton can be moved from repo to repo"""
 
     config = ansible_config("partner_engineer")
+    api_prefix = config.get("api_prefix").rstrip("/")
     api_client = get_client(
         config=config,
         request_token=True,
@@ -39,7 +40,7 @@ def test_move_collection_version(ansible_config, upload_artifact):
             'published': {}
         }
         for repo in collections.keys():
-            next_page = f'/api/automation-hub/_ui/v1/collection-versions/?repository={repo}'
+            next_page = f'{api_prefix}/_ui/v1/collection-versions/?repository={repo}'
             while next_page:
                 resp = api_client(next_page)
                 for _collection in resp['data']:
@@ -107,6 +108,7 @@ def test_copy_collection_version(ansible_config, upload_artifact):
     """Tests whether a colleciton can be copied from repo to repo"""
 
     config = ansible_config("partner_engineer")
+    api_prefix = config.get("api_prefix").rstrip("/")
     api_client = get_client(
         config=config,
         request_token=True,
@@ -119,7 +121,7 @@ def test_copy_collection_version(ansible_config, upload_artifact):
             'community': {}
         }
         for repo in collections.keys():
-            next_page = f'/api/automation-hub/_ui/v1/collection-versions/?repository={repo}'
+            next_page = f'{api_prefix}/_ui/v1/collection-versions/?repository={repo}'
             while next_page:
                 resp = api_client(next_page)
                 for _collection in resp['data']:

--- a/galaxy_ng/tests/integration/api/test_pulp_api.py
+++ b/galaxy_ng/tests/integration/api/test_pulp_api.py
@@ -160,7 +160,7 @@ def test_pulp_task_endpoint(ansible_config, local_container, require_auth):
     delete_resp = api_client(
         f"{api_prefix}/v3/plugin/execution-environments/repositories/{name}/", method="DELETE"
     )
-    task_url = delete_resp["task"][len('/api/automation-hub/'):]
+    task_url = delete_resp["task"][len(f'{api_prefix}/'):]
 
     task_detail = api_client(f"{api_prefix}/{task_url}", method="GET")
     validate_json(instance=task_detail, schema=schema_task_detail)

--- a/galaxy_ng/tests/integration/api/test_remote_sync.py
+++ b/galaxy_ng/tests/integration/api/test_remote_sync.py
@@ -26,6 +26,7 @@ def test_api_ui_v1_remote_sync(ansible_config):
 
     # update the community remote
     cfg = ansible_config('admin')
+    api_prefix = cfg.get("api_prefix").rstrip("/")
     payload = {
         'url': 'https://galaxy.ansible.com/api/',
         'auth_url': None,
@@ -54,14 +55,13 @@ def test_api_ui_v1_remote_sync(ansible_config):
 
     # sync
     resp = api_client("content/community/v3/sync/", args=payload, method="POST")
-    task = {'task': f'/api/automation-hub/pulp/api/v3/tasks/{resp["task"]}/'}
+    task = {'task': f'{api_prefix}/pulp/api/v3/tasks/{resp["task"]}/'}
     validate_json(instance=task, schema=schema_task)
     resp = wait_for_task(api_client, task)
 
     # search collections for synced collection
-    cfg = ansible_config('admin')
     resp = api_client(
-        "_ui/v1/repo/community/?namespace=newswangerd&name=collection_demo",
+        f"{api_prefix}/_ui/v1/repo/community/?namespace=newswangerd&name=collection_demo",
         args={},
         method="GET"
     )

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -735,9 +735,10 @@ def test_api_ui_v1_users_by_id(ansible_config):
 @pytest.mark.api_ui
 def test_users_list_insights_access(ansible_config):
     """Check insights mode access to users endpoint"""
-    url = "/api/automation-hub/_ui/v1/users/"
 
     config = ansible_config("basic_user")
+    api_prefix = config.get("api_prefix").rstrip("/")
+    url = f"{api_prefix}/_ui/v1/users/"
     api_client = get_client(config, request_token=True, require_auth=True)
 
     with pytest.raises(GalaxyError, match=REGEX_403):
@@ -761,9 +762,10 @@ def test_users_list_insights_access(ansible_config):
 @pytest.mark.api_ui
 def test_users_detail_insights_access(ansible_config):
     """Check insights mode access to users endpoint"""
-    url = "/api/automation-hub/_ui/v1/users/1/"
 
     config = ansible_config("basic_user")
+    api_prefix = config.get("api_prefix").rstrip("/")
+    url = f"{api_prefix}/_ui/v1/users/1/"
     api_client = get_client(config, request_token=True, require_auth=True)
 
     with pytest.raises(GalaxyError, match=REGEX_403):

--- a/galaxy_ng/tests/integration/api/test_v3_plugin_paths.py
+++ b/galaxy_ng/tests/integration/api/test_v3_plugin_paths.py
@@ -26,11 +26,12 @@ def test_api_v3_plugin_execution_environments_repositories_content_history(
 ):
     name = local_container.get_container()['name']
     cfg = ansible_config('ee_admin')
+    api_prefix = cfg.get("api_prefix").rstrip("/")
     api_client = get_client(cfg)
 
     # get the view
     resp = api_client(
-        f'v3/plugin/execution-environments/repositories/{name}/_content/history/',
+        f'{api_prefix}/v3/plugin/execution-environments/repositories/{name}/_content/history/',
         method="GET")
 
     # assert the correct response serializer
@@ -50,9 +51,12 @@ def test_api_v3_plugin_execution_environments_repositories_content_images(
     name = local_container.get_container()['name']
     manifest = local_container.get_manifest()
     cfg = ansible_config('ee_admin')
+    api_prefix = cfg.get("api_prefix").rstrip("/")
     api_client = get_client(cfg)
     # get the view
-    resp = api_client(f'v3/plugin/execution-environments/repositories/{name}/_content/images/')
+    resp = api_client(
+        f'{api_prefix}/v3/plugin/execution-environments/repositories/{name}/_content/images/'
+    )
 
     # assert the correct response serializer
     validate_json(instance=resp, schema=schema_objectlist)
@@ -69,10 +73,12 @@ def test_api_v3_plugin_execution_environments_repositories_content_readme(
 ):
     name = local_container.get_container()['name']
     cfg = ansible_config('ee_admin')
-    url = f'v3/plugin/execution-environments/repositories/{name}/_content/readme/'
+    api_prefix = cfg.get("api_prefix").rstrip("/")
+    url = f'{api_prefix}/v3/plugin/execution-environments/repositories/{name}/_content/readme/'
     api_client = get_client(cfg)
     # get the view
     resp = api_client(url, method="GET")
+    print(f'\n\n\n resp:{resp} \n\n\n')
 
     # assert the correct response serializer
     validate_json(instance=resp, schema=schema_remote_readme)
@@ -108,11 +114,12 @@ def test_api_v3_plugin_execution_environments_repositories_content_tags(
     manifest = local_container.get_manifest()
     name = local_container.get_container()['name']
     cfg = ansible_config('ee_admin')
+    api_prefix = cfg.get("api_prefix").rstrip("/")
     api_client = get_client(cfg)
 
     # get the view
     resp = api_client(
-        f'v3/plugin/execution-environments/repositories/{name}/_content/tags/',
+        f'{api_prefix}/v3/plugin/execution-environments/repositories/{name}/_content/tags/',
         method="GET")
 
     # assert the correct response serializer
@@ -131,10 +138,14 @@ def test_api_v3_plugin_execution_environments_repositories(ansible_config, local
     ns_name = local_container.get_namespace()['name']
     name = local_container.get_container()['name']
     cfg = ansible_config('admin')
+    api_prefix = cfg.get("api_prefix").rstrip("/")
     api_client = get_client(cfg)
 
     # get the ee repositories view
-    repository_resp = api_client('v3/plugin/execution-environments/repositories/', method="GET")
+    repository_resp = api_client(
+        f'{api_prefix}/v3/plugin/execution-environments/repositories/',
+        method="GET"
+    )
 
     # assert the correct response serializer
     validate_json(instance=repository_resp, schema=schema_objectlist)
@@ -172,7 +183,7 @@ def test_api_v3_plugin_execution_environments_repositories(ansible_config, local
 
     # delete the respository
     delete_repository_resp = api_client(
-        f'v3/plugin/execution-environments/repositories/{name}/',
+        f'{api_prefix}/v3/plugin/execution-environments/repositories/{name}/',
         method="DELETE"
     )
     # assert delete_repository_resp.status_code == 202
@@ -180,7 +191,10 @@ def test_api_v3_plugin_execution_environments_repositories(ansible_config, local
     wait_for_task(api_client, task)
 
     # # get the repositories list again
-    repository_resp = api_client('v3/plugin/execution-environments/repositories/', method="GET")
+    repository_resp = api_client(
+        f'{api_prefix}/v3/plugin/execution-environments/repositories/',
+        method="GET"
+    )
 
     # assert the new repository has been deleted
     repository_names = [x['name'] for x in repository_resp['data']]


### PR DESCRIPTION
#### What is this PR doing:
Updates remaining integration tests not using `api_prefix` from the `config` object to do so in place of hard-coded `/api/automation-hub`.

<!-- Add Jira issue link -->
No-Issue


#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit