### PR TITLE
Switch to `python3` package for LDAP requirements

### DIFF
--- a/.github/workflows/ci_insights.yml
+++ b/.github/workflows/ci_insights.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt -y update
 
       - name: Install LDAP requirements
-        run: sudo apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev build-essential
+        run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
         run: pip3 install --upgrade docker-compose

--- a/.github/workflows/ci_standalone-community.yml
+++ b/.github/workflows/ci_standalone-community.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt -y update
 
       - name: Install LDAP requirements
-        run: sudo apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev build-essential
+        run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
         run: pip3 install --upgrade docker-compose

--- a/.github/workflows/ci_standalone-ldap.yml
+++ b/.github/workflows/ci_standalone-ldap.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt -y update
 
       - name: Install LDAP requirements
-        run: sudo apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev build-essential
+        run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
         run: pip3 install --upgrade docker-compose

--- a/.github/workflows/ci_standalone-rbac-roles.yml
+++ b/.github/workflows/ci_standalone-rbac-roles.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt -y update
 
       - name: Install LDAP requirements
-        run: sudo apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev build-essential
+        run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
         run: pip3 install --upgrade docker-compose

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt -y update
 
       - name: Install LDAP requirements
-        run: sudo apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev build-essential
+        run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
         run: pip3 install --upgrade docker-compose


### PR DESCRIPTION
No-Issue

#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->

Integration tests fail on Install LDAP requirements
```
Run sudo apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev build-essential
Reading package lists...
Building dependency tree...
Reading state information...
Package python-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python2-dev python2 python-dev-is-python3

E: Package 'python-dev' has no installation candidate
Error: Process completed with exit code [10](https://github.com/ansible/galaxy_ng/actions/runs/3583299911/jobs/6028565906#step:5:11)0.
```

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit