### PR TITLE
Import IQE rbac tests

### DIFF
--- a/.github/workflows/ci_standalone-iqe-rbac-tests.yml
+++ b/.github/workflows/ci_standalone-iqe-rbac-tests.yml
@@ -1,0 +1,61 @@
+---
+name: Standalone IQE RBAC tests
+on: 
+  pull_request:
+    branches:
+      - '**'
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'CHANGES/**'
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Update apt
+        run: sudo apt -y update
+
+      - name: Install LDAP requirements
+        run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
+
+      - name: Install docker-compose
+        run: pip3 install --upgrade docker-compose
+
+      - name: create the .compose.env file
+        run: rm -f .compose.env; cp .compose.env.example .compose.env
+
+      - name: workaround github worker permissions issues
+        run: sed -i.bak 's/PIP_EDITABLE_INSTALL=1/PIP_EDITABLE_INSTALL=0/' .compose.env
+
+      - name: workaround github worker permissions issues
+        run: sed -i.bak 's/WITH_DEV_INSTALL=1/WITH_DEV_INSTALL=0/' .compose.env
+
+      - name: build stack
+        run: make docker/all
+
+      - name: start the compose stack
+        run: ./compose up -d
+
+      - name: give stack some time to spin up
+        run: sleep 120
+
+      - name: set keyring on staging repo for signature upload
+        run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y
+
+      #- name: install python 3.10
+      #  run: sudo apt install software-properties-common -y; sudo add-apt-repository --yes ppa:deadsnakes/ppa; sudo apt install python3.10
+
+      - name: run the integration tests
+        run: ./dev/standalone-iqe-rbac-tests/RUN_INTEGRATION.sh

--- a/CHANGES/2033.misc
+++ b/CHANGES/2033.misc
@@ -1,0 +1,1 @@
+Import RBAC tests from IQE plugin repo

--- a/dev/common/RUN_INTEGRATION.sh
+++ b/dev/common/RUN_INTEGRATION.sh
@@ -35,8 +35,12 @@ echo "PYTHON: $(which python)"
 $VENVPATH/bin/pip install -r integration_requirements.txt
 $VENVPATH/bin/pip show epdb || pip install epdb
 
-echo "Setting up test data"
-docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
+if ! [ -x "$(command -v docker)" ]; then
+    echo "Docker not available, skipping test data."
+else
+    echo "Setting up test data"
+    docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
+fi
 
 # when running user can specify extra pytest arguments such as
 # export HUB_LOCAL=1

--- a/dev/common/RUN_INTEGRATION.sh
+++ b/dev/common/RUN_INTEGRATION.sh
@@ -35,21 +35,17 @@ echo "PYTHON: $(which python)"
 $VENVPATH/bin/pip install -r integration_requirements.txt
 $VENVPATH/bin/pip show epdb || pip install epdb
 
-if ! [ -x "$(command -v docker)" ]; then
-    echo "Docker not available, skipping test data."
-else
-    echo "Setting up test data"
-    docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
-fi
+echo "Setting up test data"
+docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
 
 # when running user can specify extra pytest arguments such as
 # export HUB_LOCAL=1
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 if [[ -z $HUB_LOCAL ]]; then
-    $VENVPATH/bin/pytest --capture=no -m "not standalone_only and not community_only and not rbac_roles" $@ -v galaxy_ng/tests/integration
+    $VENVPATH/bin/pytest --capture=no -m "not standalone_only and not community_only and not rbac_roles and not iqe_rbac_test" $@ -v galaxy_ng/tests/integration
     RC=$?
 else
-    $VENVPATH/bin/pytest --capture=no -m "not cloud_only and not community_only and not rbac_roles" -v $@ galaxy_ng/tests/integration
+    $VENVPATH/bin/pytest --capture=no -m "not cloud_only and not community_only and not rbac_roles and not iqe_rbac_test" -v $@ galaxy_ng/tests/integration
     RC=$?
 
     if [[ $RC != 0 ]]; then

--- a/dev/common/RUN_INTEGRATION_STAGE.sh
+++ b/dev/common/RUN_INTEGRATION_STAGE.sh
@@ -28,4 +28,4 @@ pip3 install --upgrade pip wheel
 
 pip3 install -r integration_requirements.txt
 
-pytest --log-cli-level=DEBUG -m "not standalone_only and not community_only and not rbac_roles and not slow_in_cloud" --junitxml=galaxy_ng-results.xml -v galaxy_ng/tests/integration
+pytest --log-cli-level=DEBUG -m "not standalone_only and not community_only and not rbac_roles and not slow_in_cloud and not iqe_rbac_test" --junitxml=galaxy_ng-results.xml -v galaxy_ng/tests/integration

--- a/dev/common/setup_test_data.py
+++ b/dev/common/setup_test_data.py
@@ -61,6 +61,13 @@ admin.is_superuser = True
 admin.is_staff = True
 admin.save()
 
+# in ephemeral keycloak this user is part of customer account: 6089726
+iqe_admin, _ = User.objects.get_or_create(username="iqe_admin")
+iqe_admin.set_password("redhat")
+iqe_admin.is_superuser = True
+iqe_admin.is_staff = True
+iqe_admin.save()
+
 # Note: this user is not a part of ephemeral keycloak users
 ee_admin, _ = User.objects.get_or_create(username="ee_admin")
 ee_admin.set_password("redhat")

--- a/dev/insights/RUN_INTEGRATION.sh
+++ b/dev/insights/RUN_INTEGRATION.sh
@@ -31,7 +31,7 @@ pip show epdb || pip install epdb
 # export HUB_LOCAL=1
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 
-pytest --capture=no --tb=short -m "not standalone_only and not community_only and not rbac_roles" $@ -v galaxy_ng/tests/integration
+pytest --capture=no --tb=short -m "not standalone_only and not community_only and not rbac_roles and not iqe_rbac_test" $@ -v galaxy_ng/tests/integration
 RC=$?
 
 exit $RC

--- a/dev/standalone-iqe-rbac-tests/Dockerfile
+++ b/dev/standalone-iqe-rbac-tests/Dockerfile
@@ -1,0 +1,10 @@
+ARG DEV_IMAGE_SUFFIX
+
+FROM localhost/galaxy_ng/galaxy_ng:base${DEV_IMAGE_SUFFIX:-}
+
+COPY requirements/requirements.standalone.txt /tmp/requirements.standalone.txt
+
+RUN set -ex; \
+    if [[ "${LOCK_REQUIREMENTS}" -eq "1" ]]; then \
+    pip install --no-cache-dir --requirement /tmp/requirements.standalone.txt; \
+    fi

--- a/dev/standalone-iqe-rbac-tests/RUN_INTEGRATION.sh
+++ b/dev/standalone-iqe-rbac-tests/RUN_INTEGRATION.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+unset NAMESPACE
+unset HUB_AUTH_URL
+export HUB_USE_MOVE_ENDPOINT="true"
+
+
+VENVPATH=/tmp/gng_testing
+PIP=${VENVPATH}/bin/pip
+
+if [[ ! -d $VENVPATH ]]; then
+    python3.10 -m venv $VENVPATH
+fi
+source $VENVPATH/bin/activate
+echo "PYTHON: $(which python)"
+
+$VENVPATH/bin/pip install -r integration_requirements.txt
+$VENVPATH/bin/pip show epdb || pip install epdb
+
+echo "Setting up test data"
+docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
+
+$VENVPATH/bin/pytest --capture=no -m "iqe_rbac_test" -v $@ galaxy_ng/tests/integration
+RC=$?
+
+if [[ $RC != 0 ]]; then
+    # dump the api logs
+    docker logs galaxy_ng_api_1
+
+    # dump the worker logs
+    docker logs galaxy_ng_worker_1
+fi
+
+exit $RC

--- a/dev/standalone-iqe-rbac-tests/docker-compose-ui.yaml
+++ b/dev/standalone-iqe-rbac-tests/docker-compose-ui.yaml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  ui:
+    environment:
+      - "API_PROXY_HOST=api"
+      - "API_PROXY_PORT=8000"
+      - "DEPLOYMENT_MODE=${COMPOSE_PROFILE}"

--- a/dev/standalone-iqe-rbac-tests/docker-compose.yml
+++ b/dev/standalone-iqe-rbac-tests/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+version: "3.7"
+
+services:
+  api:
+    env_file:
+      - './standalone/galaxy_ng.env'
+      - '../.compose.env'
+  worker:
+    env_file:
+      - './standalone/galaxy_ng.env'
+      - '../.compose.env'
+  content-app:
+    env_file:
+      - './standalone/galaxy_ng.env'
+      - '../.compose.env'

--- a/dev/standalone-iqe-rbac-tests/galaxy_ng.env
+++ b/dev/standalone-iqe-rbac-tests/galaxy_ng.env
@@ -1,0 +1,31 @@
+PULP_CONTENT_PATH_PREFIX=/api/automation-hub/v3/artifacts/collections/
+
+PULP_GALAXY_API_PATH_PREFIX=/api/automation-hub/
+PULP_GALAXY_DEPLOYMENT_MODE=standalone
+
+# Commenting this out so local cypress can pass.
+# If needed can be specified in the `.compose.env` file.
+# PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false
+# PULP_GALAXY_AUTO_SIGN_COLLECTIONS=true
+
+PULP_GALAXY_COLLECTION_SIGNING_SERVICE=ansible-default
+PULP_GALAXY_CONTAINER_SIGNING_SERVICE='container-default'
+PULP_RH_ENTITLEMENT_REQUIRED=insights
+
+PULP_ANSIBLE_API_HOSTNAME=http://localhost:5001
+PULP_ANSIBLE_CONTENT_HOSTNAME=http://localhost:24816/api/automation-hub/v3/artifacts/collections
+
+PULP_TOKEN_AUTH_DISABLED=true
+PULP_CONTENT_ORIGIN="http://localhost:24816"
+
+
+# Pulp container requires this to be set in order to provide docker registry
+# compatible token authentication.
+# https://docs.pulpproject.org/pulp_container/workflows/authentication.html
+
+PULP_TOKEN_AUTH_DISABLED=false
+PULP_TOKEN_SERVER=http://localhost:5001/token/
+PULP_TOKEN_SIGNATURE_ALGORITHM=ES256
+PULP_PUBLIC_KEY_PATH=/src/galaxy_ng/dev/common/container_auth_public_key.pem
+PULP_PRIVATE_KEY_PATH=/src/galaxy_ng/dev/common/container_auth_private_key.pem
+PULP_TELEMETRY=false

--- a/dev/standalone-iqe-rbac-tests/integration-test-dockerfile
+++ b/dev/standalone-iqe-rbac-tests/integration-test-dockerfile
@@ -1,0 +1,22 @@
+FROM python
+
+WORKDIR /app/
+
+# Install test requirements first to make running the tests faster
+SHELL ["/bin/bash", "-c"] 
+RUN apt-get -y update && apt-get -y install podman
+COPY integration_requirements.txt /app/integration_requirements.txt
+RUN pip install virtualenv && \
+    virtualenv /tmp/gng_testing && \
+    source /tmp/gng_testing/bin/activate && \
+    pip install -r integration_requirements.txt && \
+    # hack to get around bug where some tests fail when ~/.ansible is missing.
+    mkdir /root/.ansible
+
+ENV HUB_LOCAL=1
+ENV HUB_API_ROOT=http://localhost:5001/api/automation-hub/
+
+# This layer should come last as it is most likely to change
+COPY . /app/
+
+ENTRYPOINT [ "/app/dev/common/RUN_INTEGRATION.sh" ]

--- a/dev/standalone/RUN_INTEGRATION.sh
+++ b/dev/standalone/RUN_INTEGRATION.sh
@@ -32,7 +32,7 @@ export HUB_USE_MOVE_ENDPOINT=true
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 pytest \
     --capture=no \
-    -m "not cloud_only and not community_only and not rbac_roles" \
+    -m "not cloud_only and not community_only and not rbac_roles and not iqe_rbac_test" \
     -v $@ galaxy_ng/tests/integration
 RC=$?
 exit $RC

--- a/galaxy_ng/tests/integration/api/test_iqe_rbac.py
+++ b/galaxy_ng/tests/integration/api/test_iqe_rbac.py
@@ -1,0 +1,929 @@
+"""
+(iqe) tests for rbac
+Imported from https://gitlab.cee.redhat.com/insights-qe/iqe-automation-hub-plugin/
+"""
+import pytest
+from galaxykit.collections import move_collection
+from galaxykit.container_images import delete_container as delete_image_container
+from galaxykit.container_images import get_container_images
+from galaxykit.containers import add_owner_to_ee
+from galaxykit.containers import create_container
+from galaxykit.containers import delete_container
+from galaxykit.namespaces import delete_namespace
+from galaxykit.registries import create_registry
+from galaxykit.registries import delete_registry
+from galaxykit.remotes import community_remote_config
+from galaxykit.remotes import get_community_remote
+from galaxykit.users import delete_user
+from galaxykit.users import get_user
+from galaxykit.users import update_user
+from galaxykit.utils import GalaxyClientError
+
+from galaxy_ng.tests.integration.utils import uuid4
+from galaxy_ng.tests.integration.utils.rbac_utils import add_new_user_to_new_group, \
+    create_test_user, create_local_image_container, create_namespace, \
+    upload_test_artifact, collection_exists, user_exists
+
+
+@pytest.mark.min_hub_version("4.6dev")
+class TestRBAC:
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_create_user(self, galaxy_client):
+        """
+        Verifies that when a user has the role to create users, the user can create users
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.add_user", "galaxy.view_user"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        gc = galaxy_client(user)
+        create_test_user(gc)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_create_user(self, galaxy_client):
+        """
+        Verifies that when a user does not have the role to create users,
+        the user can't create users
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.view_user"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        gc = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            create_test_user(gc)
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_update_user(self, galaxy_client):
+        """
+        Verifies that when a user has the role to update users, the user can modify users
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.change_user", "galaxy.view_user"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        gc_user = galaxy_client(user)
+        resp = get_user(gc_user, user["username"])
+        resp["first_name"] = "changechangechange"
+        resp["password"] = "changechangechange"
+        update_user(gc_user, resp)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_update_user(self, galaxy_client):
+        """
+        Verifies that when a user does not have the role to update users,
+        the user can't modify users
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.delete_user", "galaxy.view_user"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        gc_user = galaxy_client(user)
+        resp = get_user(gc_user, user["username"])
+        resp["first_name"] = "changechangechange"
+        resp["password"] = "changechangechange"
+        with pytest.raises(GalaxyClientError) as ctx:
+            update_user(gc_user, resp)
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_delete_user(self, galaxy_client):
+        """
+        Verifies that when a user has the role to delete users, the user can delete users
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        user_to_delete = create_test_user(gc)
+        permissions = ["galaxy.delete_user", "galaxy.view_user"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        gc = galaxy_client(user)
+        delete_user(gc, user_to_delete["username"])
+        assert not user_exists(user_to_delete["username"], gc)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_delete_user(self, galaxy_client):
+        """
+        Verifies that when a user does not have the role to delete users,
+        the user can't delete users
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        user_to_delete = create_test_user(gc)
+        permissions = ["galaxy.add_user", "galaxy.view_user"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        gc = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            delete_user(gc, user_to_delete["username"])
+        assert ctx.value.args[0] == 403
+        assert user_exists(user_to_delete["username"], gc)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_can_create_group(self, galaxy_client):
+        """
+        Verifies that it's possible to create a group
+        """
+        group_name = f"rbac_test_group_{uuid4()}"
+        group = galaxy_client("iqe_admin").create_group(group_name)
+        assert group
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_cannot_create_group_that_already_exists(self, galaxy_client):
+        """
+        Verifies that it's not possible to create a group that already exists
+        """
+        group_name = f"rbac_test_group_{uuid4()}"
+        gc = galaxy_client("iqe_admin")
+        gc.create_group(group_name)
+        with pytest.raises(GalaxyClientError) as ctx:
+            gc.create_group(group_name)
+        assert ctx.value.args[0]["status"] == "409"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_admin_can_create_role(self, galaxy_client):
+        """
+        Verifies that an admin user can create a role
+        """
+        permissions = ["core.manage_roles_group"]
+        gc = galaxy_client("iqe_admin")
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        resp = gc.create_role(role_name, "any_description", permissions)
+        assert resp
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_admin_cannot_create_duplicate_roles(self, galaxy_client):
+        """
+        Verifies that two roles cannot have the same name
+        """
+        permissions = ["core.manage_roles_group"]
+        gc = galaxy_client("iqe_admin")
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        assert gc.create_role(role_name, "any_description", permissions)
+        with pytest.raises(GalaxyClientError) as ctx:
+            gc.create_role(role_name, "any_description", permissions)
+        assert ctx.value.args[0] == 400
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_can_delete_role(self, galaxy_client):
+        """
+        Verifies that it's possible to delete a role
+        """
+        permissions = ["core.manage_roles_group"]
+        gc = galaxy_client("iqe_admin")
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.get_role(role_name)
+        gc.delete_role(role_name)
+        # verify that role is gone
+        with pytest.raises(IndexError):
+            gc.get_role(role_name)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_can_patch_update_role(self, galaxy_client):
+        """
+        Verifies that it's possible to patch update a role
+        """
+        permissions = ["core.manage_roles_group"]
+        gc = galaxy_client("iqe_admin")
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        updated_body = {"description": "updated description"}
+        gc.patch_update_role(role_name, updated_body)
+        resp = gc.get_role(role_name)
+        assert resp["description"] == "updated description"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_can_put_update_role(self, galaxy_client):
+        """
+        Verifies that it's possible to put update a role
+        """
+        permissions = ["core.manage_roles_group"]
+        gc = galaxy_client("iqe_admin")
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        updated_body = {
+            "name": role_name,
+            "description": "updated description",
+            "permissions": ["core.manage_roles_group"],
+        }
+        gc.put_update_role(role_name, updated_body)
+        resp = gc.get_role(role_name)
+        assert resp["description"] == "updated description"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_add_group(self, galaxy_client):
+        """
+        Verifies that when a user has the role to add groups, the user can create a group
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.add_group"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        gc = galaxy_client(user)
+        new_group_name = f"new_group_{uuid4()}"
+        gc.create_group(new_group_name)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_non_admin_cannot_create_roles(self, galaxy_client):
+        """
+        Verifies that a non admin user can't create roles
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        gc.add_user_to_group(user["username"], group["id"])
+        permissions = [
+            "galaxy.view_user",
+            "galaxy.delete_user",
+            "galaxy.add_user",
+            "galaxy.change_user",
+            "galaxy.view_group",
+            "galaxy.delete_group",
+            "galaxy.add_group",
+            "galaxy.change_group",
+        ]
+        gc_user = galaxy_client(user)
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        with pytest.raises(GalaxyClientError) as ctx:
+            gc_user.create_role(role_name, "any_description", permissions)
+        assert ctx.value.args[0] == 403
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_permission_in_role_to_add_group(self, galaxy_client):
+        """
+        Verifies that when a user doesn't have the role to add groups,
+        the user can't create a group
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        # incorrect permission to create a group (correct is galaxy.add_group)
+        permissions = ["galaxy.view_group"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        new_group_name = f"rbac_test_group_{uuid4()}"
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            gc_user.create_group(new_group_name)
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_permission_add_namespace(self, galaxy_client):
+        """
+        Verifies that when a user doesn't have the role to create a ns,
+        the user can't create a ns
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = [
+            "galaxy.change_namespace",
+            "galaxy.upload_to_namespace",
+        ]  # incorrect permissions to add a namespace (correct is galaxy.add_namespace).
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            create_namespace(gc_user, group)
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_add_namespace(self, galaxy_client):
+        """
+        Verifies that when a user has the role to create a ns, the user can create a ns
+        """
+        gc = galaxy_client("iqe_admin")
+        _, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.add_namespace"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        create_namespace(gc, group)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_delete_namespace(self, galaxy_client):
+        """
+        Verifies that when a user has the role to delete a ns, the user can delete a ns
+        """
+        gc = galaxy_client("iqe_admin")
+        _, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.delete_namespace"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        namespace_name = create_namespace(gc, group=None)
+        delete_namespace(gc, namespace_name)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_delete_namespace(self, galaxy_client):
+        """
+        Verifies that when a user doesn't have the role to delete a ns,
+        the user can't delete a ns
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.view_namespace"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        namespace_name = create_namespace(gc, group=None)
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            delete_namespace(gc_user, namespace_name)
+        assert ctx.value.args[0] == 403
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_object_role_upload_to_namespace(self, galaxy_client):
+        """
+        Verifies that when a user belongs to the same group as the one defined in a namespace
+        and the role assigned to it gives permissions to upload a collection, the user can
+        upload a collection even though the user does not have the (global)
+        galaxy.upload_to_namespace permission
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.upload_to_namespace"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        namespace_name = create_namespace(gc, group, object_roles=[role_name])
+        gc_user = galaxy_client(user)
+        upload_test_artifact(gc_user, namespace_name)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_upload_to_namespace(self, galaxy_client):
+        """
+        Verifies that when a user does not belong to the same group as the one defined in
+        a namespace and the role assigned to it gives permissions to upload a collection,
+        the user can't upload a collection even though the user has the
+        galaxy.upload_to_namespace permission
+        """
+        gc = galaxy_client("iqe_admin")
+        user, _ = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.upload_to_namespace"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+
+        ns2_group_name = f"rbac_test_group_{uuid4()}"
+        ns2_group = gc.create_group(ns2_group_name)
+        ns2_name = create_namespace(gc, ns2_group, object_roles=[role_name])
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            upload_test_artifact(gc_user, ns2_name)
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_global_role_upload_to_namespace(self, galaxy_client):
+        """
+        Verifies that when a user does not belong to the same group as the one defined in
+        a namespace but has the upload_to_namespace permission assigned as a global role,
+        the user can upload a collection
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.upload_to_namespace"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        ns_name = create_namespace(gc, None)
+        gc_user = galaxy_client(user)
+        upload_test_artifact(gc_user, ns_name)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_global_role_delete_collection(self, galaxy_client):
+        """
+        Verifies that when a user has the role to delete collections,
+        the user can delete collections
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["ansible.delete_collection"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        gc.add_role_to_group(role_name, group["id"])
+        namespace_name = create_namespace(gc, None)
+        artifact = upload_test_artifact(gc, namespace_name)
+        move_collection(gc, namespace_name, artifact.name, artifact.version)  # approve collection
+        assert collection_exists(gc, namespace_name, artifact.name, artifact.version)
+        gc_user = galaxy_client(user)
+        gc_user.delete_collection(
+            namespace_name, artifact.name, artifact.version, repository="published"
+        )
+        assert not collection_exists(gc, namespace_name, artifact.name, artifact.version)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_delete_collection(self, galaxy_client):
+        """
+        Verifies that when a user doesn't have the permission to delete collections,
+        the user cannot delete a collection
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.upload_to_namespace"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        namespace_name = create_namespace(gc, group, object_roles=[role_name])
+        artifact = upload_test_artifact(gc, namespace_name)
+        move_collection(gc, namespace_name, artifact.name, artifact.version)  # approve collection
+        assert collection_exists(gc, namespace_name, artifact.name, artifact.version)
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            gc_user.delete_collection(
+                namespace_name, artifact.name, artifact.version, repository="published"
+            )
+        assert ctx.value.args[0] == 403
+        assert collection_exists(gc, namespace_name, artifact.name, artifact.version)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_reject_collection(self, galaxy_client):
+        """
+        Verifies that when a user does not have the role to reject collections,
+        the user cannot reject a collection
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["galaxy.upload_to_namespace"]
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_name, "any_description", permissions)
+        namespace_name = create_namespace(gc, group, object_roles=[role_name])
+        artifact = upload_test_artifact(gc, namespace_name)
+        move_collection(gc, namespace_name, artifact.name, artifact.version)  # approve collection
+        assert collection_exists(gc, namespace_name, artifact.name, artifact.version)
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            # reject collection
+            move_collection(
+                gc_user,
+                namespace_name,
+                artifact.name,
+                artifact.version,
+                source="published",
+                destination="rejected",
+            )
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_reject_collection(self, galaxy_client):
+        """
+        Verifies that when a user has role to reject collections,
+        the user can reject a collection
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["ansible.modify_ansible_repo_content"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        permissions = ["galaxy.upload_to_namespace"]
+        gc.create_role(role_name, "any_description", permissions)
+        namespace_name = create_namespace(gc, group, object_roles=[role_name])
+        artifact = upload_test_artifact(gc, namespace_name)
+        move_collection(gc, namespace_name, artifact.name, artifact.version)  # approve collection
+        assert collection_exists(gc, namespace_name, artifact.name, artifact.version)
+        gc_user = galaxy_client(user)
+        move_collection(
+            gc_user,
+            namespace_name,
+            artifact.name,
+            artifact.version,
+            source="published",
+            destination="rejected",
+        )
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_approve_collection(self, galaxy_client):
+        """
+        Verifies that when a user has role to approve collections,
+        the user can approve a collection
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["ansible.modify_ansible_repo_content"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        permissions = ["galaxy.upload_to_namespace"]
+        gc.create_role(role_name, "any_description", permissions)
+        namespace_name = create_namespace(gc, group, object_roles=[role_name])
+        artifact = upload_test_artifact(gc, namespace_name)
+        gc_user = galaxy_client(user)
+        move_collection(
+            gc_user, namespace_name, artifact.name, artifact.version
+        )  # approve collection
+        assert collection_exists(gc, namespace_name, artifact.name, artifact.version)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_approve_collection(self, galaxy_client):
+        """
+        Verifies that when a user does not have a role to approve collections,
+        the user cannot approve a collection
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = []
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        role_name = f"galaxy.rbac_test_role_{uuid4()}"
+        permissions = ["galaxy.upload_to_namespace"]
+        gc.create_role(role_name, "any_description", permissions)
+        namespace_name = create_namespace(gc, group, object_roles=[role_name])
+        artifact = upload_test_artifact(gc, namespace_name)
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            move_collection(
+                gc_user, namespace_name, artifact.name, artifact.version
+            )  # approve collection
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_add_remote_registry(self, galaxy_client):
+        """
+        Verifies that when a user does not have the role to add a remote registry,
+        the user cannot add a remote registry
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["galaxy.add_group"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            create_registry(gc_user, f"remote_registry_{uuid4()}", "url")
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_add_remote_registry(self, galaxy_client):
+        """
+        Verifies that when a user does not have the role to add a remote registry,
+        the user cannot add a remote registry
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["galaxy.add_containerregistryremote"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        gc_user = galaxy_client(user)
+        create_registry(gc_user, f"remote_registry_{uuid4()}", "url")
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_delete_remote_registry(self, galaxy_client):
+        """
+        Verifies that when a user has the role to delete a remote registry,
+        the user can delete a remote registry
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["galaxy.delete_containerregistryremote"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        remote_registry = f"remote_registry_{uuid4()}"
+        create_registry(gc, remote_registry, "url")
+        gc_user = galaxy_client(user)
+        delete_registry(gc_user, remote_registry)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_delete_remote_registry(self, galaxy_client):
+        """
+        Verifies that when a user does not have the role to delete a remote registry,
+        the user cannot delete a remote registry
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["galaxy.add_group"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        remote_registry = f"remote_registry_{uuid4()}"
+        create_registry(gc, remote_registry, "url")
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            delete_registry(gc_user, remote_registry)
+        assert ctx.value.args[0] == 403
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_add_ee(self, galaxy_client):
+        """
+        Verifies that when a user has the role to create an ee, the user can create an ee
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["container.add_containernamespace"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        remote_registry = f"remote_registry_{uuid4()}"
+        create_registry(gc, remote_registry, "url")
+        gc_user = galaxy_client(user)
+        ee_name = f"ee_{uuid4()}"
+        create_container(gc_user, ee_name, "upstream_name", remote_registry)
+        add_owner_to_ee(gc_user, ee_name, group["name"], [role_user])
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_add_ee(self, galaxy_client):
+        """
+        Verifies that when a user does not have the role to create ee, the user cannot create an ee
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["galaxy.add_group"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        remote_registry = f"remote_registry_{uuid4()}"
+        create_registry(gc, remote_registry, "url")
+        gc_user = galaxy_client(user)
+        ee_name = f"ee_{uuid4()}"
+        with pytest.raises(GalaxyClientError) as ctx:
+            create_container(gc_user, ee_name, "upstream_name", remote_registry)
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_role_delete_ee(self, galaxy_client):
+        """
+        Verifies that when a user has the role to remove an ee, the user can remove an ee
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["container.delete_containerrepository"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        remote_registry = f"remote_registry_{uuid4()}"
+        create_registry(gc, remote_registry, "url")
+        ee_name = f"ee_{uuid4()}"
+        create_container(gc, ee_name, "upstream_name", remote_registry)
+        gc_user = galaxy_client(user)
+        delete_container(gc_user, ee_name)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_role_delete_ee(self, galaxy_client):
+        """
+        Verifies that when a user does not have the role to remove an ee,
+        the user cannot remove an ee
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["galaxy.add_group"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        remote_registry = f"remote_registry_{uuid4()}"
+        create_registry(gc, remote_registry, "url")
+        ee_name = f"ee_{uuid4()}"
+        create_container(gc, ee_name, "upstream_name", remote_registry)
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            delete_container(gc_user, ee_name)
+        assert ctx.value.args[0] == 403
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_user_role_remotes(self, galaxy_client):
+        """
+        Verifies that a user with change collection remote permissions can config remotes
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["ansible.change_collectionremote"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        gc_user = galaxy_client(user)
+        community_remote_config(gc_user, "http://google.com/", "username", "password")
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_user_missing_role_remotes(self, galaxy_client):
+        """
+        Verifies that a user without change collection remote permissions can't config remotes
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = []
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions)
+        gc.add_role_to_group(role_user, group["id"])
+        gc_user = galaxy_client(user)
+        with pytest.raises(GalaxyClientError) as ctx:
+            community_remote_config(gc_user, "http://google.com/", "username", "password")
+        assert ctx.value.args[0]["status"] == "403"
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_user_role_get_remotes(self, galaxy_client):
+        """
+        Verifies that a user with view remotes roles can view remote config
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions = ["ansible.view_collectionremote"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions)
+        gc.add_role_to_group(role_user, group["id"])
+        gc_user = galaxy_client(user)
+        get_community_remote(gc_user)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_object_role_push_image_to_ee(self, galaxy_client, ansible_config):
+        """
+        Verifies that when a user does not have
+        object permissions to push an image, the user can't push an image
+        """
+        gc = galaxy_client("iqe_admin")
+        ee_name = create_local_image_container(ansible_config(), gc)
+        user, _ = add_new_user_to_new_group(gc)
+        gc_user = galaxy_client(user)
+        try:
+            gc_user.push_image(ee_name + ":latest")
+        except GalaxyClientError as e:
+            # We expect the underlying podman command to fail, but we don't
+            # want to accidentally catch any other error, so we check that
+            # the error is the podman return code.
+            assert "retcode" in str(e)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_object_role_push_image_to_ee(self, galaxy_client, ansible_config):
+        """
+        Verifies that when a user has object permissions to push an image,
+        the user can push an image
+        """
+        gc = galaxy_client("iqe_admin")
+        ee_name = create_local_image_container(ansible_config(), gc)
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = ["container.namespace_push_containerdistribution"]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        add_owner_to_ee(gc, ee_name, group["name"], [role_user])
+        gc_user = galaxy_client(user)
+        gc_user.push_image(ee_name + ":latest")
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_global_role_push_image_to_ee(self, galaxy_client, ansible_config):
+        """
+        Verifies that when a user has global permissions
+        to push an image, the user can push an image
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = [
+            "container.add_containernamespace",
+            "container.namespace_push_containerdistribution",
+        ]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        ee_name = create_local_image_container(ansible_config(), gc)
+        gc_user = galaxy_client(user)
+        gc_user.push_image(ee_name + ":latest")
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_global_role_push_image_to_ee(self, galaxy_client, ansible_config):
+        """
+        Verifies that when a user does not have
+        global permissions to push an image, the user can't push an image
+        """
+        gc = galaxy_client("iqe_admin")
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = []
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        ee_name = create_local_image_container(ansible_config(), gc)
+        gc_user = galaxy_client(user)
+        try:
+            gc_user.push_image(ee_name + ":latest")
+        except GalaxyClientError as e:
+            # We expect the underlying podman command to fail, but we don't
+            # want to accidentally catch any other error, so we check that
+            # the error is the podman return code.
+            assert "retcode" in str(e)
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_object_role_delete_image_from_ee(self, galaxy_client, ansible_config):
+        """
+        Verifies that when a user does not have
+        object permissions to delete an image, the user can't delete an image
+        """
+        gc = galaxy_client("iqe_admin")
+        ee_name = create_local_image_container(ansible_config(), gc)
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = [
+            "container.add_containernamespace",
+            "container.namespace_push_containerdistribution",
+        ]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        add_owner_to_ee(gc, ee_name, group["name"], [role_user])
+        gc_user = galaxy_client(user)
+        gc_user.push_image(ee_name + ":latest")
+        all_images = get_container_images(gc_user, ee_name)
+        with pytest.raises(GalaxyClientError) as ctx:
+            delete_image_container(gc_user, ee_name, all_images["data"][0]["digest"])
+        assert ctx.value.args[0] == 403
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_global_role_delete_image_from_ee(self, galaxy_client, ansible_config):
+        """
+        Verifies that when a user has
+        global permissions to delete an image, the user can delete an image
+        """
+        gc = galaxy_client("iqe_admin")
+        ee_name = create_local_image_container(ansible_config(), gc)
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = [
+            "container.delete_containerrepository",
+            "container.namespace_push_containerdistribution",
+        ]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        gc_user = galaxy_client(user)
+        gc_user.push_image(ee_name + ":latest")
+        all_images = get_container_images(gc_user, ee_name)
+        delete_image_container(gc_user, ee_name, all_images["data"][0]["digest"])
+
+    @pytest.mark.iqe_rbac_test
+    @pytest.mark.standalone_only
+    def test_missing_global_role_delete_image_from_ee(self, galaxy_client, ansible_config):
+        """
+        Verifies that when a user does not have
+        global permissions to delete an image, the user can't delete an image
+        """
+        gc = galaxy_client("iqe_admin")
+        ee_name = create_local_image_container(ansible_config(), gc)
+        user, group = add_new_user_to_new_group(gc)
+        permissions_user = [
+            "container.add_containernamespace",
+            "container.namespace_push_containerdistribution",
+        ]
+        role_user = f"galaxy.rbac_test_role_{uuid4()}"
+        gc.create_role(role_user, "any_description", permissions_user)
+        gc.add_role_to_group(role_user, group["id"])
+        gc_user = galaxy_client(user)
+        gc_user.push_image(ee_name + ":latest")
+        all_images = get_container_images(gc_user, ee_name)
+        with pytest.raises(GalaxyClientError) as ctx:
+            delete_image_container(gc_user, ee_name, all_images["data"][0]["digest"])
+        assert ctx.value.args[0] == 403

--- a/galaxy_ng/tests/integration/api/test_v3_plugin_paths.py
+++ b/galaxy_ng/tests/integration/api/test_v3_plugin_paths.py
@@ -143,7 +143,7 @@ def test_api_v3_plugin_execution_environments_repositories(ansible_config, local
 
     # get the ee repositories view
     repository_resp = api_client(
-        f'{api_prefix}/v3/plugin/execution-environments/repositories/',
+        f'{api_prefix}/v3/plugin/execution-environments/repositories/?limit=100',
         method="GET"
     )
 

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import time
@@ -6,6 +7,7 @@ from urllib.parse import urlparse
 
 import pytest
 from orionutils.utils import increment_version
+from pkg_resources import parse_version
 
 from galaxy_ng.tests.integration.constants import SLEEP_SECONDS_ONETIME
 
@@ -18,6 +20,7 @@ from .utils import (
     set_certification,
 )
 from .utils import upload_artifact as _upload_artifact
+from .utils.iqe_utils import GalaxyKitClient, get_hub_version, is_stage_environment
 
 # from orionutils.generator import build_collection
 
@@ -55,7 +58,13 @@ role: Related to RBAC Roles
 rbac_roles: Tests checking Role permissions
 group: Related to Groups
 slow_in_cloud: tests that take too long to be run against stage
+max_hub_version: This marker takes an argument that indicates the maximum hub version
+min_hub_version: This marker takes an argument that indicates the minimum hub version
+iqe_rbac_test: imported iqe tests checking role permissions
 """
+
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_configure(config):
@@ -63,10 +72,6 @@ def pytest_configure(config):
         if not line:
             continue
         config.addinivalue_line('markers', line)
-
-
-def is_stage_environment():
-    return os.getenv('TESTS_AGAINST_STAGE', False)
 
 
 class AnsibleConfigFixture(dict):
@@ -97,6 +102,11 @@ class AnsibleConfigFixture(dict):
             "username": "notifications_admin",
             "password": "redhat",
             "token": "abcdefghijklmnopqrstuvwxyz1234567894",
+        },
+        "iqe_admin": {  # this is a superuser
+            "username": "iqe_admin",
+            "password": "redhat",
+            "token": None,
         },
         "ldap": {  # this is a superuser in ldap profile
             "username": "professor",
@@ -163,10 +173,8 @@ class AnsibleConfigFixture(dict):
             }
         }
 
-    def __init__(self, profile, namespace=None):
+    def __init__(self, profile=None, namespace=None):
         self.profile = profile
-        if profile not in self.PROFILES.keys():
-            raise Exception("AnsibleConfigFixture profile unknown")
         self.namespace = namespace
 
         # workaround for a weird error with the galaxy cli lib ...
@@ -177,13 +185,14 @@ class AnsibleConfigFixture(dict):
             with open(galaxy_token_fn, 'w') as f:
                 f.write('')
 
-        if isinstance(self.PROFILES[self.profile]["username"], dict):
-            # credentials from vault
-            loader = get_vault_loader()
-            self._set_profile_from_vault(loader, self.profile, "username")
-            self._set_profile_from_vault(loader, self.profile, "password")
-            if self.PROFILES[self.profile]["token"]:
-                self._set_profile_from_vault(loader, self.profile, "token")
+        if self.profile:
+            if isinstance(self.PROFILES[self.profile]["username"], dict):
+                # credentials from vault
+                loader = get_vault_loader()
+                self._set_profile_from_vault(loader, self.profile, "username")
+                self._set_profile_from_vault(loader, self.profile, "password")
+                if self.PROFILES[self.profile]["token"]:
+                    self._set_profile_from_vault(loader, self.profile, "token")
 
     def _set_profile_from_vault(self, loader, profile, param):
         param_vault_path = self.PROFILES[profile][param]["vault_path"]
@@ -270,6 +279,24 @@ class AnsibleConfigFixture(dict):
                 'http://localhost:8082'
             )
 
+        elif key == 'ssl_verify':
+            return os.environ.get(
+                'SSL_VERIFY',
+                False
+            )
+
+        elif key == 'container_engine':
+            return os.environ.get(
+                'CONTAINER_ENGINE',
+                'podman'
+            )
+
+        elif key == 'container_registry':
+            return os.environ.get(
+                'CONTAINER_REGISTRY',
+                'localhost:5001'
+            )
+
         else:
             raise Exception(f'Unknown config key: {self.namespace}.{key}')
 
@@ -278,9 +305,18 @@ class AnsibleConfigFixture(dict):
     def get(self, key):
         return self.__getitem__(key)
 
+    def get_profile_data(self):
+        if self.profile:
+            return self.PROFILES[self.profile]
+        raise Exception("No profile has been set")
 
-@pytest.fixture
+
+@pytest.fixture(scope="session")
 def ansible_config():
+    return get_ansible_config()
+
+
+def get_ansible_config():
     return AnsibleConfigFixture
 
 
@@ -455,3 +491,42 @@ def get_vault_loader():
         'IQE_VAULT_MOUNT_POINT': 'insights'
     }
     return VaultSecretFetcher.from_settings(vault_settings)
+
+
+@pytest.fixture(scope="session")
+def galaxy_client(ansible_config):
+    return get_galaxy_client(ansible_config)
+
+
+def get_galaxy_client(ansible_config):
+    """
+    Returns a function that, when called with one of the users listed in the settings.local.yaml
+    file will login using hub and galaxykit, returning the constructed GalaxyClient object.
+    """
+    galaxy_kit_client = GalaxyKitClient(ansible_config)
+    return galaxy_kit_client.gen_authorized_client
+
+
+def pytest_sessionstart(session):
+    hub_version = get_hub_version(get_ansible_config())
+    logger.debug(f"Running tests against hub version {hub_version}")
+
+
+def pytest_runtest_setup(item):
+    test_min_versions = [mark.args[0] for mark in item.iter_markers(name="min_hub_version")]
+    test_max_versions = [mark.args[0] for mark in item.iter_markers(name="max_hub_version")]
+
+    hub_version = get_hub_version(get_ansible_config())
+
+    for min_version in test_min_versions:
+        if parse_version(hub_version) < parse_version(min_version):
+            pytest.skip(
+                f"Minimum hub version to run tests is {min_version} "
+                f"but hub version {hub_version} was found"
+            )
+    for max_version in test_max_versions:
+        if parse_version(hub_version) > parse_version(max_version):
+            pytest.skip(
+                f"Maximum hub version to run tests is {max_version} "
+                f"but hub version {hub_version} was found"
+            )

--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -1,0 +1,203 @@
+"""Utility functions for AH tests."""
+import os
+from unittest.mock import patch
+
+from galaxykit import GalaxyClient
+
+import logging
+from functools import lru_cache
+from pkg_resources import Requirement
+from urllib.parse import urljoin
+
+from ansible.galaxy.api import GalaxyAPI
+from ansible.galaxy.token import BasicAuthToken
+from ansible.galaxy.token import GalaxyToken
+from ansible.galaxy.token import KeycloakToken
+
+from galaxy_ng.tests.integration.utils import get_client
+
+logger = logging.getLogger(__name__)
+
+# FILENAME_INCLUDED
+# FILENAME_EXCLUDED
+# FILENAME_MISSING
+
+
+class KeycloakPassword(KeycloakToken):
+    """
+    Class to request an access token to Keycloak server providing username and password.
+    Used when environment is ephemeral-cloud.
+    """
+
+    def __init__(
+        self, access_token=None, auth_url=None, validate_certs=False, username=None, password=None
+    ):
+        self.username = username
+        self.password = password
+        super().__init__(
+            access_token=access_token, auth_url=auth_url, validate_certs=validate_certs
+        )
+
+    def _form_payload(self):
+        return (
+            f"grant_type=password&client_id=cloud-services&"
+            f"username={self.username}&password={self.password}"
+        )
+
+
+class TaskWaitingTimeout(Exception):
+    pass
+
+
+class CapturingGalaxyError(Exception):
+    def __init__(self, http_error, message):
+        self.http_error = http_error
+        self.message = message
+
+
+class CompletedProcessError(Exception):
+    pass
+
+
+@lru_cache()
+def get_hub_version(ansible_config):
+    if is_standalone():
+        role = "iqe_admin"
+    elif is_ephemeral_env():
+        # TODO: this call should be done by galaxykit
+        config = ansible_config("org_admin")
+        api_client = get_client(config, request_token=True, require_auth=True)
+        return api_client("/", args={}, method="GET")["galaxy_ng_version"]
+    else:
+        role = "admin"
+    gc = GalaxyKitClient(ansible_config).gen_authorized_client(role)
+    return gc.get(gc.galaxy_root)["galaxy_ng_version"]
+
+
+def min_hub_version(ansible_config, spec):
+    version = get_hub_version(ansible_config)
+    return Requirement.parse(f"galaxy_ng<{spec}").specifier.contains(version)
+
+
+def max_hub_version(ansible_config, spec):
+    version = get_hub_version(ansible_config)
+    return Requirement.parse(f"galaxy_ng>{spec}").specifier.contains(version)
+
+
+client_cache = {}
+
+
+class GalaxyKitClient:
+    def __init__(self, ansible_config):
+        self.config = ansible_config
+
+    def gen_authorized_client(
+        self,
+        role,
+        container_engine="podman",
+        container_registry=None,
+        *,
+        ignore_cache=False,
+        token=None,
+    ):
+        config = self.config()
+        # role can be either be the name of a user (like `ansible_insights`)
+        # or a dict containing a username and password:
+        # {"username": "autohubtest2", "password": "p@ssword!"}
+        if isinstance(role, dict):
+            cache_key = (role["username"], container_engine, container_registry, token)
+        else:
+            cache_key = (role, container_engine, container_registry, token)
+        ssl_verify = config.get("ssl_verify")
+        if cache_key not in client_cache or ignore_cache:
+            url = config.get("url")
+            if isinstance(role, str):
+                profile_config = self.config(role)
+                user = profile_config.get_profile_data()
+                if profile_config.get("auth_url"):
+                    token = profile_config.get("token")
+                if token is None:
+                    token = get_standalone_token(
+                        user, url, ssl_verify=ssl_verify, ignore_cache=ignore_cache
+                    )
+
+                auth = {
+                    "username": user["username"],
+                    "password": user["password"],
+                    "auth_url": profile_config.get("auth_url"),
+                    "token": token,
+                }
+            else:
+                token = get_standalone_token(
+                    role, url, ignore_cache=ignore_cache, ssl_verify=ssl_verify
+                )  # ignore_cache=True
+                role.update(token=token)
+                auth = role
+
+            container_engine = config.get("container_engine")
+            container_registry = config.get("container_registry")
+
+            g_client = GalaxyClient(
+                url,
+                auth=auth,
+                container_engine=container_engine,
+                container_registry=container_registry,
+                container_tls_verify=ssl_verify,
+                https_verify=ssl_verify,
+            )
+            if ignore_cache:
+                return g_client
+            else:
+                client_cache[cache_key] = g_client
+        return client_cache[cache_key]
+
+
+token_cache = {}
+
+
+def get_standalone_token(user, server, *, ignore_cache=False, ssl_verify=True):
+    cache_key = f"{server}::{user['username']}"
+
+    if cache_key not in token_cache or ignore_cache:
+        username = user["username"]
+        password = user.get("password")
+        token_value = user.get("token")
+        auth_url = user.get("auth_url")
+
+        if token_value:
+            if auth_url:
+                token = KeycloakToken(token_value, auth_url=auth_url)
+                token_cache[cache_key] = token.get()
+            else:
+                token = GalaxyToken(token_value)
+                token_cache[cache_key] = GalaxyToken(token_value).config["token"]
+        else:
+            token = BasicAuthToken(username, password)
+            if is_ephemeral_env():
+                token_cache[cache_key] = token.get()
+            else:
+                with patch("ansible.context.CLIARGS", {"ignore_certs": True}):
+                    anon_client = GalaxyAPI(
+                        None,
+                        "automation_hub",
+                        url=server,
+                        token=token,
+                        validate_certs=ssl_verify,
+                    )
+                url = urljoin(server, "v3/auth/token/")
+                resp = anon_client._call_galaxy(url, method="POST", auth_required=True)
+                token_cache[cache_key] = resp["token"]
+
+    return token_cache[cache_key]
+
+
+def is_standalone():
+    return os.getenv('HUB_LOCAL', False)
+
+
+def is_ephemeral_env():
+    return 'ephemeral' in os.getenv('HUB_API_ROOT', 'http://localhost:5001/api/automation-hub/')
+
+
+def is_stage_environment():
+    return os.getenv('TESTS_AGAINST_STAGE', False)

--- a/galaxy_ng/tests/integration/utils/rbac_utils.py
+++ b/galaxy_ng/tests/integration/utils/rbac_utils.py
@@ -1,0 +1,90 @@
+import logging
+
+from galaxykit.container_images import get_container_images
+from galaxykit.containerutils import ContainerClient
+from galaxykit.users import get_user
+from galaxykit.utils import GalaxyClientError, wait_for_task
+from galaxykit.container_images import delete_container as delete_image_container
+from orionutils.generator import build_collection
+
+from galaxykit.collections import get_collection, upload_artifact
+
+from galaxy_ng.tests.integration.utils import uuid4
+from galaxy_ng.tests.integration.utils.tools import generate_random_artifact_version
+
+logger = logging.getLogger(__name__)
+
+
+def create_test_user(client):
+    username = f"rbac-user-test_{uuid4()}"
+    password = "p@ssword!"
+    client.get_or_create_user(username, password, group=None)
+    return {
+        "username": username,
+        "password": password,
+    }
+
+
+def add_new_user_to_new_group(client):
+    group_name = f"rbac_test_group_{uuid4()}"
+    group = client.create_group(group_name)
+    user = create_test_user(client)
+    client.add_user_to_group(user["username"], group["id"])
+    return user, group
+
+
+def collection_exists(client, namespace, collection_name, version):
+    try:
+        get_collection(client, namespace, collection_name, version)
+        return True
+    except GalaxyClientError as e:
+        if e.args[0]["status"] == "404":
+            return False
+
+
+def create_namespace(client, group, object_roles=None):
+    namespace_name = f"namespace_{uuid4()}"
+    namespace_name = namespace_name.replace("-", "")
+    group_name = None
+    if group:
+        group_name = group["name"]
+    client.create_namespace(namespace_name, group_name, object_roles)
+    return namespace_name
+
+
+def create_local_image_container(config, client):
+    """
+    This method is used to create an empty container to push images later in the tests.
+    To do so, an image is pushed and deleted afterwards.
+    """
+    container_engine = config.get("container_engine")
+    unauth_ctn = ContainerClient(auth=None, engine=container_engine)
+    unauth_ctn.pull_image("alpine")
+    ee_name = f"ee_{uuid4()}"
+    client.tag_image("alpine", ee_name + ":latest")
+    client.push_image(ee_name + ":latest")
+    info = get_container_images(client, ee_name)
+    delete_image_container(client, ee_name, info["data"][0]["digest"])
+    return ee_name
+
+
+def upload_test_artifact(client, namespace):
+    test_version = generate_random_artifact_version()
+    artifact = build_collection(
+        "skeleton",
+        config={"namespace": namespace, "version": test_version},
+    )
+    logger.debug(f"Uploading artifact {artifact}")
+    resp = upload_artifact(None, client, artifact)
+    logger.debug("Waiting for upload to be completed")
+    resp = wait_for_task(client, resp)
+    assert resp["state"] == "completed"
+    return artifact
+
+
+def user_exists(username, client):
+    try:
+        get_user(client, username)
+        return True
+    except IndexError:
+        return False

--- a/galaxy_ng/tests/integration/utils/tools.py
+++ b/galaxy_ng/tests/integration/utils/tools.py
@@ -2,6 +2,7 @@
 
 import shutil
 import uuid
+from random import randint
 
 
 def is_docker_installed():
@@ -11,3 +12,8 @@ def is_docker_installed():
 def uuid4():
     """Return a random UUID4 as a string."""
     return str(uuid.uuid4())
+
+
+def generate_random_artifact_version():
+    """Return a string with random integers using format xx.yy.xx."""
+    return f"{randint(0, 100)}.{randint(0, 100)}.{randint(1, 100)}"

--- a/integration_requirements.txt
+++ b/integration_requirements.txt
@@ -7,3 +7,4 @@ openapi-spec-validator
 jsonschema
 hvac
 importlib_resources
+galaxykit==0.12


### PR DESCRIPTION
Issue: [AAH-2033](https://issues.redhat.com/browse/AAH-2033)

Import [RBAC tests from IQE repo](https://gitlab.cee.redhat.com/insights-qe/iqe-automation-hub-plugin/-/blob/master/iqe_automation_hub/tests/api/test_rbac.py).

And some required tools too.
They are marked with this decorator @pytest.mark.min_hub_version("4.6dev") so that they get skipped if hub version is lower than 4.6