### PR TITLE
Sync tests against stage

### DIFF
--- a/CHANGES/1270.misc
+++ b/CHANGES/1270.misc
@@ -1,0 +1,1 @@
+Add sync tests against stage

--- a/Dockerfile.sync_tests_stage
+++ b/Dockerfile.sync_tests_stage
@@ -1,0 +1,23 @@
+FROM registry.access.redhat.com/ubi8/python-39
+WORKDIR /opt/app-root/src
+COPY . /opt/app-root/src
+ENV VENVS=$HOME/venvs
+ENV VENV_PATH=$HOME/venvs/ahub-tests-venv
+RUN \
+    mkdir -p $VENVS && \
+    python3 -m venv $VENV_PATH && \
+    source $VENV_PATH/bin/activate
+
+RUN pip install --upgrade pip wheel
+RUN pip install -r integration_requirements.txt
+ENV SYNC_TESTS_STAGE=true \
+    HTTPS_PROXY="http://squid.corp.redhat.com:3128" \
+    HUB_UPLOAD_SIGNATURES=true \
+    IQE_VAULT_GITHUB_TOKEN=$IQE_VAULT_GITHUB_TOKEN \
+    IQE_VAULT_ROLE_ID=$IQE_VAULT_ROLE_ID \
+    IQE_VAULT_SECRET_ID=$IQE_VAULT_SECRET_ID \
+    TESTS_AGAINST_STAGE=true \
+    HUB_USE_MOVE_ENDPOINT=true \
+    HUB_API_ROOT="https://console.stage.redhat.com/api/automation-hub/" \
+    HUB_AUTH_URL="https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token/"
+CMD ["pytest", "--log-cli-level=DEBUG", "-m", "sync", "--junitxml=galaxy_ng-results.xml", "-v", "galaxy_ng/tests/integration"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include integration_requirements.txt
 include unittest_requirements.txt
 include pyproject.toml
 include requirements/requirements.common.txt
+include Dockerfile.sync_tests_stage
 recursive-include galaxy_ng *.md
 graft galaxy_ng/app/webserver_snippets
 graft galaxy_ng/app/static

--- a/dev/common/RUN_INTEGRATION.sh
+++ b/dev/common/RUN_INTEGRATION.sh
@@ -46,10 +46,10 @@ fi
 # export HUB_LOCAL=1
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 if [[ -z $HUB_LOCAL ]]; then
-    $VENVPATH/bin/pytest --capture=no -m "not standalone_only and not community_only and not rbac_roles and not iqe_rbac_test" $@ -v galaxy_ng/tests/integration
+    $VENVPATH/bin/pytest --capture=no -m "not standalone_only and not community_only and not rbac_roles and not iqe_rbac_test and not sync" $@ -v galaxy_ng/tests/integration
     RC=$?
 else
-    $VENVPATH/bin/pytest --capture=no -m "not cloud_only and not community_only and not rbac_roles and not iqe_rbac_test" -v $@ galaxy_ng/tests/integration
+    $VENVPATH/bin/pytest --capture=no -m "not cloud_only and not community_only and not rbac_roles and not iqe_rbac_test and not sync" -v $@ galaxy_ng/tests/integration
     RC=$?
 
     if [[ $RC != 0 ]]; then

--- a/dev/common/RUN_INTEGRATION_STAGE.sh
+++ b/dev/common/RUN_INTEGRATION_STAGE.sh
@@ -28,4 +28,4 @@ pip3 install --upgrade pip wheel
 
 pip3 install -r integration_requirements.txt
 
-pytest --log-cli-level=DEBUG -m "not standalone_only and not community_only and not rbac_roles and not slow_in_cloud and not iqe_rbac_test" --junitxml=galaxy_ng-results.xml -v galaxy_ng/tests/integration
+pytest --log-cli-level=DEBUG -m "not standalone_only and not community_only and not rbac_roles and not slow_in_cloud and not iqe_rbac_test and not sync" --junitxml=galaxy_ng-results.xml -v galaxy_ng/tests/integration

--- a/dev/ephemeral/run_tests.sh
+++ b/dev/ephemeral/run_tests.sh
@@ -12,7 +12,7 @@ ${VENV_PATH}/bin/pip install -r integration_requirements.txt
 
 echo "Running pytest ..."
 ${VENV_PATH}/bin/pytest \
-    --capture=no -m "cloud_only or (not standalone_only and not community_only)" \
+    --capture=no -m "cloud_only or (not standalone_only and not community_only and not sync)" \
     -v \
     galaxy_ng/tests/integration $@
 RC=$?

--- a/dev/insights/RUN_INTEGRATION.sh
+++ b/dev/insights/RUN_INTEGRATION.sh
@@ -31,7 +31,7 @@ pip show epdb || pip install epdb
 # export HUB_LOCAL=1
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 
-pytest --capture=no --tb=short -m "not standalone_only and not community_only and not rbac_roles and not iqe_rbac_test" $@ -v galaxy_ng/tests/integration
+pytest --capture=no --tb=short -m "not standalone_only and not community_only and not rbac_roles and not iqe_rbac_test and not sync" $@ -v galaxy_ng/tests/integration
 RC=$?
 
 exit $RC

--- a/dev/standalone/RUN_INTEGRATION.sh
+++ b/dev/standalone/RUN_INTEGRATION.sh
@@ -32,7 +32,7 @@ export HUB_USE_MOVE_ENDPOINT=true
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
 pytest \
     --capture=no \
-    -m "not cloud_only and not community_only and not rbac_roles and not iqe_rbac_test" \
+    -m "not cloud_only and not community_only and not rbac_roles and not iqe_rbac_test and not sync" \
     -v $@ galaxy_ng/tests/integration
 RC=$?
 exit $RC

--- a/galaxy_ng/tests/integration/api/test_sync_stage.py
+++ b/galaxy_ng/tests/integration/api/test_sync_stage.py
@@ -1,0 +1,78 @@
+import logging
+
+import pytest
+from galaxykit.collections import upload_artifact, delete_collection
+
+from ..conftest import get_galaxy_client, get_ansible_config_sync
+from ..utils import wait_for_task, get_client, set_certification
+from orionutils.generator import build_collection
+from ..utils.iqe_utils import is_sync_testing, get_all_collections, retrieve_collection
+from ..utils.tools import generate_random_artifact_version, uuid4
+
+pytestmark = pytest.mark.qa  # noqa: F821
+
+logger = logging.getLogger(__name__)
+
+
+def start_sync(api_client, repo):
+    logger.debug(f"Syncing {repo} repo")
+    url = f'content/{repo}/v3/sync/'
+    resp = api_client(url, method="POST")
+    resp = wait_for_task(api_client, resp["task"], raise_on_error=True)
+    logger.debug(f"Response from wait_for_task_id {resp}!")
+
+
+@pytest.mark.sync
+@pytest.mark.skipif(not is_sync_testing(), reason="This test can only be run on sync-tests mode")
+def test_sync():
+    config_sync = get_ansible_config_sync()
+    galaxy_client = get_galaxy_client(config_sync)
+    gc_remote = galaxy_client("remote_admin", remote=True)
+    user_stage = gc_remote.username
+    pass_stage = gc_remote.password
+    # upload artifact to stage
+    test_version = generate_random_artifact_version()
+    namespace_name = f"namespace_{uuid4()}"
+    namespace_name = namespace_name.replace("-", "")
+    gc_remote.create_namespace(namespace_name, "system:partner-engineers")
+
+    artifact = build_collection(
+        "skeleton",
+        config={"namespace": namespace_name, "version": test_version},
+    )
+    logger.debug(f"Uploading artifact name {artifact.name} version {artifact.version}")
+    resp = upload_artifact(None, gc_remote, artifact)
+    api_client_remote = get_client(
+        {"url": "https://console.stage.redhat.com/api/automation-hub/",
+         "username": user_stage, "password": pass_stage,
+         "use_move_endpoint": True, "upload_signatures": True},
+        request_token=True, require_auth=True)
+    resp = wait_for_task(api_client_remote, resp, raise_on_error=True)
+    assert resp["state"] == "completed"
+
+    set_certification(api_client_remote, artifact)
+
+    # sync and check
+    api_client = get_client({"url": "http://localhost:5001/api/automation-hub/",
+                             "username": "admin", "password": "admin"},
+                            request_token=True, require_auth=True)
+
+    body = {
+        "url": "https://console.stage.redhat.com/api/"
+               "automation-hub/content/1237261-synclist/",
+        "username": user_stage,
+        "password": pass_stage,
+        "tls_validation": False,
+        "signed_only": False,
+        "proxy_url": "http://squid.corp.redhat.com:3128",
+        "requirements_file":
+            f"---\ncollections:\n- {artifact.namespace}.{artifact.name}"
+    }
+    url = "content/community/v3/sync/config/"
+    api_client(url, method="PUT", args=body)
+
+    start_sync(api_client, 'community')
+    local_collections = get_all_collections(api_client, 'community')
+    assert retrieve_collection(artifact, local_collections)
+
+    delete_collection(gc_remote, artifact.namespace, artifact.name)

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -20,7 +20,7 @@ from .utils import (
     set_certification,
 )
 from .utils import upload_artifact as _upload_artifact
-from .utils.iqe_utils import GalaxyKitClient, get_hub_version, is_stage_environment
+from .utils.iqe_utils import GalaxyKitClient, get_hub_version, is_stage_environment, is_sync_testing
 
 # from orionutils.generator import build_collection
 
@@ -61,6 +61,7 @@ slow_in_cloud: tests that take too long to be run against stage
 max_hub_version: This marker takes an argument that indicates the maximum hub version
 min_hub_version: This marker takes an argument that indicates the minimum hub version
 iqe_rbac_test: imported iqe tests checking role permissions
+sync: sync tests against stage
 """
 
 
@@ -317,7 +318,14 @@ def ansible_config():
 
 
 def get_ansible_config():
-    return AnsibleConfigFixture
+    if is_sync_testing():
+        return AnsibleConfigSync
+    else:
+        return AnsibleConfigFixture
+
+
+def get_ansible_config_sync():
+    return AnsibleConfigSync
 
 
 @pytest.fixture(scope="function")
@@ -496,6 +504,55 @@ def get_vault_loader():
 @pytest.fixture(scope="session")
 def galaxy_client(ansible_config):
     return get_galaxy_client(ansible_config)
+
+
+class AnsibleConfigSync(AnsibleConfigFixture):
+    PROFILES = {
+        "remote_admin": {
+            "username": {"vault_path": "secrets/qe/stage/users/ansible_insights",
+                         "vault_key": "username"},
+            "password": {"vault_path": "secrets/qe/stage/users/ansible_insights",
+                         "vault_key": "password"},
+            "token": {"vault_path": "secrets/qe/stage/users/ansible_insights",
+                      "vault_key": "token"},
+        },
+        "local_admin": {  # this is a superuser
+            "username": "admin",
+            "password": "admin",
+            "token": None,
+        }
+    }
+
+    def __init__(self, profile=None, namespace=None):
+        super().__init__(profile, namespace)
+
+    def __getitem__(self, key):
+        if key == 'remote_hub':
+            # The "url" key is actually the full url to the api root.
+            return os.environ.get(
+                'REMOTE_HUB',
+                'https://console.stage.redhat.com/api/automation-hub/'
+            )
+        if key == 'remote_auth_url':
+            # The "url" key is actually the full url to the api root.
+            return os.environ.get(
+                'REMOTE_AUTH_URL',
+                'https://sso.stage.redhat.com/auth/realms/'
+                'redhat-external/protocol/openid-connect/token/'
+            )
+        if key == 'local_hub':
+            # The "url" key is actually the full url to the api root.
+            return os.environ.get(
+                'LOCAL_HUB',
+                'http://localhost:5001/api/automation-hub/'
+            )
+        if key == 'local_auth_url':
+            # The "url" key is actually the full url to the api root.
+            return os.environ.get(
+                'LOCAL_AUTH_URL',
+                None
+            )
+        return super().__getitem__(key)
 
 
 def get_galaxy_client(ansible_config):

--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -99,6 +99,7 @@ class GalaxyKitClient:
         *,
         ignore_cache=False,
         token=None,
+        remote=False
     ):
         config = self.config()
         # role can be either be the name of a user (like `ansible_insights`)
@@ -110,9 +111,10 @@ class GalaxyKitClient:
             cache_key = (role, container_engine, container_registry, token)
         ssl_verify = config.get("ssl_verify")
         if cache_key not in client_cache or ignore_cache:
-            url = config.get("url")
-            if isinstance(role, str):
-                profile_config = self.config(role)
+            if is_sync_testing():
+                url = config.get("remote_hub") if remote else config.get("local_hub")
+                profile_config = self.config("remote_admin") \
+                    if remote else self.config("local_admin")
                 user = profile_config.get_profile_data()
                 if profile_config.get("auth_url"):
                     token = profile_config.get("token")
@@ -124,15 +126,34 @@ class GalaxyKitClient:
                 auth = {
                     "username": user["username"],
                     "password": user["password"],
-                    "auth_url": profile_config.get("auth_url"),
+                    "auth_url": profile_config.get("remote_auth_url")
+                    if remote else profile_config.get("local_auth_url"),
                     "token": token,
                 }
             else:
-                token = get_standalone_token(
-                    role, url, ignore_cache=ignore_cache, ssl_verify=ssl_verify
-                )  # ignore_cache=True
-                role.update(token=token)
-                auth = role
+                url = config.get("url")
+                if isinstance(role, str):
+                    profile_config = self.config(role)
+                    user = profile_config.get_profile_data()
+                    if profile_config.get("auth_url"):
+                        token = profile_config.get("token")
+                    if token is None:
+                        token = get_standalone_token(
+                            user, url, ssl_verify=ssl_verify, ignore_cache=ignore_cache
+                        )
+
+                    auth = {
+                        "username": user["username"],
+                        "password": user["password"],
+                        "auth_url": profile_config.get("auth_url"),
+                        "token": token,
+                    }
+                else:
+                    token = get_standalone_token(
+                        role, url, ignore_cache=ignore_cache, ssl_verify=ssl_verify
+                    )  # ignore_cache=True
+                    role.update(token=token)
+                    auth = role
 
             container_engine = config.get("container_engine")
             container_registry = config.get("container_registry")
@@ -201,3 +222,38 @@ def is_ephemeral_env():
 
 def is_stage_environment():
     return os.getenv('TESTS_AGAINST_STAGE', False)
+
+
+def is_sync_testing():
+    return os.getenv('SYNC_TESTS_STAGE', False)
+
+
+def get_all_collections(api_client, repo):
+    """
+    This will get a maximum of 100 collections. If the system has more,
+    we'll only get 100 so tests using this method might fail as the
+    order of the collections is not guaranteed and the expected collection
+    might not be returned within the 100 collections.
+    """
+    url = f'content/{repo}/v3/collections/?limit=100&offset=0'
+    return api_client(url)
+
+
+def retrieve_collection(artifact, collections):
+    """looks for a given artifact in the collections list and returns
+     the element if found or None otherwise
+
+    Args:
+        artifact: The artifact to be found.
+        collections: List of collections to iterate over.
+
+    Returns:
+        If the artifact is present in the list, it returns the artifact.
+        It returns None if the artifact is not found in the list.
+    """
+    local_collection_found = None
+    for local_collection in collections["data"]:
+        if local_collection["name"] == artifact.name and \
+                local_collection["namespace"] == artifact.namespace:
+            local_collection_found = local_collection
+    return local_collection_found

--- a/galaxy_ng/tests/integration/utils/tasks.py
+++ b/galaxy_ng/tests/integration/utils/tasks.py
@@ -1,5 +1,5 @@
 """Utility functions for AH tests."""
-
+import logging
 import time
 
 from ansible.galaxy.api import GalaxyError
@@ -10,22 +10,32 @@ from .errors import (
     TaskWaitingTimeout
 )
 
+logger = logging.getLogger(__name__)
 
-def wait_for_task(api_client, resp, timeout=300):
+
+def wait_for_task(api_client, task, timeout=300, raise_on_error=False):
+    if isinstance(task, dict):
+        url = url_safe_join(api_client.config["url"], task["task"])
+    else:
+        url = f"v3/tasks/{task}/"
+
     ready = False
-    url = url_safe_join(api_client.config["url"], resp["task"])
     wait_until = time.time() + timeout
     while not ready:
         if wait_until < time.time():
             raise TaskWaitingTimeout()
         try:
             resp = api_client(url)
+            if resp["state"] == "failed":
+                logger.error(resp["error"])
+                if raise_on_error:
+                    raise TaskFailed(resp["error"])
         except GalaxyError as e:
             if "500" not in str(e):
                 raise
         else:
             ready = resp["state"] not in ("running", "waiting")
-        time.sleep(SLEEP_SECONDS_POLLING)
+        time.sleep(5)
     return resp
 
 
@@ -44,3 +54,8 @@ def wait_for_task_ui_client(uclient, task):
             break
         time.sleep(SLEEP_SECONDS_POLLING)
     assert state == 'completed'
+
+
+class TaskFailed(Exception):
+    def __init__(self, message):
+        self.message = message


### PR DESCRIPTION
Add sync test against stage. This test is to be run by a Jenkins job. For example this one:
https://main-jenkins-csb-aap.apps.ocp-c1.prod.psi.redhat.com/job/AAPQA/job/Sandbox/job/christian/job/galaxy_ng_sync_test_stage/
or
https://main-jenkins-csb-aap.apps.ocp-c1.prod.psi.redhat.com/job/AAPQA/job/Sandbox/job/christian/job/sync_fedora/

More tests will be added in the future

Issue: [AAH-1270](https://issues.redhat.com/browse/AAH-1270)