### PR TITLE
Insights dev - disable RUN_ANSIBLE_TEST

### DIFF
--- a/dev/insights/galaxy-importer/galaxy-importer.cfg
+++ b/dev/insights/galaxy-importer/galaxy-importer.cfg
@@ -1,6 +1,6 @@
 [galaxy-importer]
 LOG_LEVEL_MAIN = INFO
-RUN_ANSIBLE_TEST = True
+RUN_ANSIBLE_TEST = False
 INFRA_PULP = True
 INFRA_OSD = False
 ANSIBLE_LOCAL_TMP = '/tmp/ansible'

--- a/profiles/insights/galaxy-importer/galaxy-importer.cfg
+++ b/profiles/insights/galaxy-importer/galaxy-importer.cfg
@@ -1,6 +1,6 @@
 [galaxy-importer]
 LOG_LEVEL_MAIN = INFO
-RUN_ANSIBLE_TEST = True
+RUN_ANSIBLE_TEST = False
 INFRA_PULP = True
 INFRA_OSD = False
 ANSIBLE_LOCAL_TMP = '/tmp/ansible'


### PR DESCRIPTION
RUN_ANSIBLE_TEST needs to run containers,
which fails from within both the compose dev env and oci_env

That causes collection upload in insights dev and insights tests to take ages and fail...

    Running ansible-test sanity on admin-collection_dep_a_mrvrowhp-1.0.0 ...
    /usr/bin/env ANSIBLE_LOCAL_TEMP='/tmp/ansible' ansible-test sanity --docker --color yes --failure-ok
    Starting new "ansible-test-controller-8Slg3UTx" container.
    time="2022-12-05T20:11:53Z" level=warning msg="\"/\" is not a shared mount, this could cause issues or missing mounts with rootless containers"
    cannot clone: Operation not permitted
    Error: cannot re-exec process
    [35mWARNING: Failed to pull docker image "quay.io/ansible/default-test-container:5.9.0". Waiting a few seconds before trying again.[0m
    time="2022-12-05T20:11:57Z" level=warning msg="\"/\" is not a shared mount, this could cause issues or missing mounts with rootless containers"
    cannot clone: Operation not permitted
    Error: cannot re-exec process
    ...
    [31mERROR: Host <ansible_test._internal.host_profiles.DockerProfile object at 0x7fe9874ea070> job failed: Failed to pull docker image "quay.io/ansible/default-test-container:5.9.0".
    File "/usr/local/lib/python3.8/site-packages/ansible_test/_internal/provisioning.py", line 190, in dispatch_jobs
    thread.wait_for_result()
    File "/usr/local/lib/python3.8/site-packages/ansible_test/_internal/thread.py", line 44, in wait_for_result
    raise exception[1].with_traceback(exception[2])
    File "/usr/local/lib/python3.8/site-packages/ansible_test/_internal/thread.py", line 31, in run
    self._result.put((self.action(), None))
    File "/usr/local/lib/python3.8/site-packages/ansible_test/_internal/provisioning.py", line 128, in provision
    profile.provision()
    File "/usr/local/lib/python3.8/site-packages/ansible_test/_internal/host_profiles.py", line 346, in provision
    container = run_support_container(
    File "/usr/local/lib/python3.8/site-packages/ansible_test/_internal/containers.py", line 184, in run_support_container
    docker_pull(args, image)
    File "/usr/local/lib/python3.8/site-packages/ansible_test/_internal/docker_util.py", line 278, in docker_pull
    raise ApplicationError('Failed to pull docker image "%s".' % image)
    [0m
    [31mFATAL: Host job(s) failed. See previous error(s) for details.[0m
    An exception occurred in /usr/bin/env ANSIBLE_LOCAL_TEMP='/tmp/ansible' ansible-test sanity --docker --color yes --failure-ok, returncode=1, collection=admin-collection_dep_a_mrvrowhp-1.0.0

=> Dropping from insights dev profiles.
(Unless anyone knows how to convince galaxy-importer to run this in a venv, instead of docker?)

Before:

```
$ time galaxykit --ignore-certs --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token' -s http://localhost:8002/api/automation-hub/ collection upload
{"namespace": "admin", "name": "collection_dep_a_yqorguhb", "version": "1.0.0", "published": false}

real	0m30.837s
user	0m0.812s
sys	0m0.091s
```

After:

```
$ time galaxykit --ignore-certs --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token' -s http://localhost:8002/api/automation-hub/ collection upload
{"namespace": "admin", "name": "collection_dep_a_kicqbjhr", "version": "1.0.0", "published": false}

real	0m2.056s
user	0m0.703s
sys	0m0.052s
```