### PR TITLE
Add extra validation and use PYPI_RELEASE_TOKEN

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -24,6 +24,13 @@ jobs:
       shell: bash
       run: echo "galaxy_ng_version=$(python3 setup.py --version)" >> $GITHUB_ENV
 
+    - name: Validate tag and galaxy_ng version match
+      shell: bash 
+      if: env.galaxy_ng_version != github.ref_name
+      run: |
+        echo "::error::Tag ${{ github.ref_name }} and galaxy_ng version ${{ env.galaxy_ng_version }} doesn't match."
+        exit 1
+
     - name: Install LDAP requirements
       run: sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev build-essential gettext python-setuptools
 
@@ -63,11 +70,8 @@ jobs:
     - name: Install twine
       run: "pip install twine"
 
-    # - name: Verify correct PyPI package 
-    #  run: "twine check dist/*" 
-
     - name: Publish galaxy_ng to PyPI
       run: "python3 -m twine upload --repository testpypi dist/*"
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_RELEASE_TOKEN }}


### PR DESCRIPTION
No-Issue

- Validate that galaxy_ng version matches tag
- Use `PYPI_RELEASE_TOKEN`

