### PR TITLE
Integration: Do not upload to the distribution by default.

### DIFF
--- a/galaxy_ng/tests/integration/utils/collections.py
+++ b/galaxy_ng/tests/integration/utils/collections.py
@@ -224,12 +224,18 @@ def build_collection(
 
 
 def upload_artifact(
-    config, client, artifact, hash=True, no_filename=False, no_file=False, use_distribution=True
+    config, client, artifact, hash=True, no_filename=False, no_file=False, use_distribution=False
 ):
     """
     Publishes a collection to a Galaxy server and returns the import task URI.
 
-    :param collection_path: The path to the collection tarball to publish.
+    :param config: The ansibleconfig object.
+    :param client: The galaxyclient object.
+    :param artifact: The artifact object.
+    :param hash: compute and send a sha256 sum for the payload.
+    :param no_filename: Skip sending the filename in the form.
+    :param no_file: Skip sneding the file in the form.
+    :param use_distribution: If true, upload to the inbound-<namespace> endpoint.
     :return: The import task URI that contains the import results.
     """
     collection_path = artifact.filename


### PR DESCRIPTION
> When someone configures the galaxy client to upload to Automation Hub, they just need the token and the URL to the server correct? or should they use the inbound URL that is shown in the CLI configuration tab of their namespace?

> they don't need that, prob should not use it in case we remove those inbound repos in the future so use https://console.redhat.com/api/automation-hub/

> maybe at least one test should use the inbound repo to show you can upload to a repo. but our CRC workflow is to not need an inbound repo, and for the server to pick the repo it will go in, so the remainder of tests should do that

https://github.com/ansible/galaxy_ng/blob/master/galaxy_ng/tests/integration/api/test_artifact_upload.py#L52-L53

The test_api_publish function tries True&False for use_distribution, so the distribution upload is still covered by testing.