### PR TITLE
Use correct PyPI index in gha release process

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -71,7 +71,7 @@ jobs:
       run: "pip install twine"
 
     - name: Publish galaxy_ng to PyPI
-      run: "python3 -m twine upload --repository testpypi dist/*"
+      run: "python3 -m twine upload dist/*"
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_RELEASE_TOKEN }}


### PR DESCRIPTION
No-Issue

Correct PyPI index from testing to main.
