### PR TITLE
Use top level created field for default v1 roles ordering.

### DIFF
--- a/galaxy_ng/app/api/v1/viewsets/roles.py
+++ b/galaxy_ng/app/api/v1/viewsets/roles.py
@@ -58,6 +58,12 @@ class LegacyRolesViewSet(viewsets.ModelViewSet):
     permission_classes = [LegacyAccessPolicy]
     authentication_classes = GALAXY_AUTHENTICATION_CLASSES
 
+    def get_queryset(self, *args, **kwargs):
+        order_by = self.request.query_params.get('order_by')
+        if order_by is not None:
+            return self.queryset.order_by(order_by)
+        return self.queryset
+
     def destroy(self, request, pk=None):
         """Delete a single role."""
         role = LegacyRole.objects.filter(id=pk).first()

--- a/galaxy_ng/app/api/v1/viewsets/roles.py
+++ b/galaxy_ng/app/api/v1/viewsets/roles.py
@@ -46,9 +46,9 @@ class LegacyRolesSetPagination(PageNumberPagination):
 class LegacyRolesViewSet(viewsets.ModelViewSet):
     """A list of legacy roles."""
 
-    queryset = LegacyRole.objects.all().order_by('full_metadata__created')
-    ordering_fields = ('full_metadata__created')
-    ordering = ('full_metadata__created')
+    queryset = LegacyRole.objects.all().order_by('created')
+    ordering_fields = ('created')
+    ordering = ('created')
     filter_backends = (DjangoFilterBackend,)
     filterset_class = LegacyRoleFilter
 

--- a/galaxy_ng/tests/integration/api/test_community.py
+++ b/galaxy_ng/tests/integration/api/test_community.py
@@ -466,7 +466,6 @@ def test_v1_autocomplete_search(ansible_config):
 def test_v1_role_pagination(ansible_config):
     """" Tests if v1 roles are auto-sorted by created """
 
-
     config = ansible_config("admin")
     api_client = get_client(
         config=config,

--- a/galaxy_ng/tests/integration/api/test_community.py
+++ b/galaxy_ng/tests/integration/api/test_community.py
@@ -38,7 +38,7 @@ def clean_all_roles(ansible_config):
     )
 
     pre_existing = []
-    next_url = f'/api/v1/roles/'
+    next_url = '/api/v1/roles/'
     while next_url:
         resp = admin_client(next_url)
         pre_existing.extend(resp['results'])


### PR DESCRIPTION
Ordering by full_metadata properties doesn't seem to work and nothing in the default modelviewset seems to alter the querset for ordering. This is a quick fix to add ordering by any field with created by default.