### PR TITLE
Add management command to edit database tableowners

### DIFF
--- a/galaxy_ng/app/management/commands/reassign-owned-db-role.py
+++ b/galaxy_ng/app/management/commands/reassign-owned-db-role.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    """This command reassigns database tableowners.
+
+    This is meant for the CRC instance where older tables are owned by `galaxy_ng`,
+    and newer tables are owned by `postgres`.
+
+    It will update all database objects owned by old_role (galaxy_ng)
+    to be owned by new_role (postgres).
+
+    https://www.postgresql.org/docs/current/sql-reassign-owned.html
+    REASSIGN OWNED requires membership on both the source role(s) and the target role.
+
+    """
+
+    def handle(self, *args, **options):
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "REASSIGN OWNED BY galaxy_ng TO postgres;"
+        )

--- a/galaxy_ng/app/management/commands/reassign-owned-db-role.py
+++ b/galaxy_ng/app/management/commands/reassign-owned-db-role.py
@@ -19,6 +19,4 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         with connection.cursor() as cursor:
-            cursor.execute(
-                "REASSIGN OWNED BY galaxy_ng TO postgres;"
-        )
+            cursor.execute("REASSIGN OWNED BY galaxy_ng TO postgres;")


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->

This is meant for the CRC instance where older tables are owned by `galaxy_ng`, and newer tables are owned by `postgres`.

It will update all database objects owned by old_role (galaxy_ng) to be owned by new_role (postgres).

<!-- Add Jira issue link -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit