### PR TITLE
Move oci-env+sync testing to a separate file.

### DIFF
--- a/.github/workflows/ci_standalone-certified-sync.yml
+++ b/.github/workflows/ci_standalone-certified-sync.yml
@@ -1,5 +1,5 @@
 ---
-name: Standalone Sync
+name: Standalone Certified Sync
 on: 
   pull_request:
     branches:
@@ -15,7 +15,7 @@ on:
 
 jobs:
 
-  sync_integration:
+  integration:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -64,4 +64,4 @@ jobs:
           oci-env -e dev/oci_env_configs/sync-test.compose.env poll
 
       - name: run the integration tests
-        run: HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh
+        run: ./dev/standalone-certified-sync/RUN_INTEGRATION.sh

--- a/.github/workflows/ci_standalone-certified-sync.yml
+++ b/.github/workflows/ci_standalone-certified-sync.yml
@@ -1,5 +1,5 @@
 ---
-name: Standalone Certified Sync
+name: Local Standalone Sync Against Local Insights
 on: 
   pull_request:
     branches:

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -55,4 +55,4 @@ jobs:
         run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y
 
       - name: run the integration tests
-        run: HUB_LOCAL=1 ./dev/standalone/RUN_INTEGRATION.sh
+        run: DUMP_LOGS=1 ./dev/standalone/RUN_INTEGRATION.sh

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
 
-  integration:
+  standalone_integration:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,12 +23,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-
-      # Note: COMPOSE_INTERACTIVE_NO_CLI=1 is required for oci-env to work correctly when there's no interactive terminal
-      - name: Set environment variables
-        run: |
-          echo "OCI_ENV_PATH=${HOME}/work/galaxy_ng/oci_env" >> $GITHUB_ENV
-          echo "COMPOSE_INTERACTIVE_NO_CLI=1" >> $GITHUB_ENV
 
       - name: Update apt
         run: sudo apt -y update
@@ -39,29 +33,26 @@ jobs:
       - name: Install docker-compose
         run: pip3 install --upgrade docker-compose
 
-      - name: setup oci-env
-        run: |
-          git clone https://github.com/pulp/oci_env.git $OCI_ENV_PATH
-          pip install -e $OCI_ENV_PATH/client/
-          mkdir $OCI_ENV_PATH/db_backup/
-          cp dev/data/insights-fixture.tar.gz $OCI_ENV_PATH/db_backup/insights-fixture.tar.gz
+      - name: create the .compose.env file
+        run: rm -f .compose.env; cp .compose.env.example .compose.env
 
-      - name: launch test instances
-        run: |
-          oci-env -e dev/oci_env_configs/sync-test.compose.env compose build
-          oci-env -e dev/oci_env_configs/sync-test.compose.env compose up -d
-          oci-env -e dev/oci_env_configs/standalone.compose.env compose up -d
+      - name: workaround github worker permissions issues
+        run: sed -i.bak 's/PIP_EDITABLE_INSTALL=1/PIP_EDITABLE_INSTALL=0/' .compose.env
 
-      - name: wait for test instances to come online
-        run: |
-          oci-env -e dev/oci_env_configs/standalone.compose.env poll --wait 10 --attempts 30
-          oci-env -e dev/oci_env_configs/sync-test.compose.env poll
+      - name: workaround github worker permissions issues
+        run: sed -i.bak 's/WITH_DEV_INSTALL=1/WITH_DEV_INSTALL=0/' .compose.env
 
-      - name: finish insights instance setup
-        run: |
-          oci-env -e dev/oci_env_configs/sync-test.compose.env db restore -f insights-fixture
-          oci-env -e dev/oci_env_configs/sync-test.compose.env pulpcore-manager migrate
-          oci-env -e dev/oci_env_configs/sync-test.compose.env poll
+      - name: build stack
+        run: make docker/all
+
+      - name: start the compose stack
+        run: ./compose up -d
+
+      - name: give stack some time to spin up
+        run: sleep 120
+
+      - name: set keyring on staging repo for signature upload
+        run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y
 
       - name: run the integration tests
-        run: HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh
+        run: HUB_LOCAL=1 ./dev/standalone/RUN_INTEGRATION.sh

--- a/.github/workflows/ci_standalone_sync.yml
+++ b/.github/workflows/ci_standalone_sync.yml
@@ -1,5 +1,5 @@
 ---
-name: Standalone
+name: Standalone Sync
 on: 
   pull_request:
     branches:
@@ -15,7 +15,7 @@ on:
 
 jobs:
 
-  integration:
+  sync_integration:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci_standalone_sync.yml
+++ b/.github/workflows/ci_standalone_sync.yml
@@ -1,0 +1,67 @@
+---
+name: Standalone
+on: 
+  pull_request:
+    branches:
+      - '**'
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'CHANGES/**'
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      # Note: COMPOSE_INTERACTIVE_NO_CLI=1 is required for oci-env to work correctly when there's no interactive terminal
+      - name: Set environment variables
+        run: |
+          echo "OCI_ENV_PATH=${HOME}/work/galaxy_ng/oci_env" >> $GITHUB_ENV
+          echo "COMPOSE_INTERACTIVE_NO_CLI=1" >> $GITHUB_ENV
+
+      - name: Update apt
+        run: sudo apt -y update
+
+      - name: Install LDAP requirements
+        run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
+
+      - name: Install docker-compose
+        run: pip3 install --upgrade docker-compose
+
+      - name: setup oci-env
+        run: |
+          git clone https://github.com/pulp/oci_env.git $OCI_ENV_PATH
+          pip install -e $OCI_ENV_PATH/client/
+          mkdir $OCI_ENV_PATH/db_backup/
+          cp dev/data/insights-fixture.tar.gz $OCI_ENV_PATH/db_backup/insights-fixture.tar.gz
+
+      - name: launch test instances
+        run: |
+          oci-env -e dev/oci_env_configs/sync-test.compose.env compose build
+          oci-env -e dev/oci_env_configs/sync-test.compose.env compose up -d
+          oci-env -e dev/oci_env_configs/standalone.compose.env compose up -d
+
+      - name: wait for test instances to come online
+        run: |
+          oci-env -e dev/oci_env_configs/standalone.compose.env poll --wait 10 --attempts 30
+          oci-env -e dev/oci_env_configs/sync-test.compose.env poll
+
+      - name: finish insights instance setup
+        run: |
+          oci-env -e dev/oci_env_configs/sync-test.compose.env db restore -f insights-fixture
+          oci-env -e dev/oci_env_configs/sync-test.compose.env pulpcore-manager migrate
+          oci-env -e dev/oci_env_configs/sync-test.compose.env poll
+
+      - name: run the integration tests
+        run: HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh

--- a/dev/standalone-certified-sync/RUN_INTEGRATION.sh
+++ b/dev/standalone-certified-sync/RUN_INTEGRATION.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Expected to be called by:
-# - GitHub Actions ci_standalone.yml for DeploymentMode.STANDALONE
-# - Developer Env makefile commands for DeploymentMode.STANDALONE
-# - TODO: Ephemeral Env pr_check.sh (merge smoke_test.sh into this) for DeploymentMode.INSIGHTS
-
 set -e
 
 unset NAMESPACE

--- a/dev/standalone/RUN_INTEGRATION.sh
+++ b/dev/standalone/RUN_INTEGRATION.sh
@@ -35,4 +35,13 @@ pytest \
     -m "not cloud_only and not community_only and not rbac_roles and not iqe_rbac_test and not sync" \
     -v $@ galaxy_ng/tests/integration
 RC=$?
+
+if [[ ! -z DUMP_LOGS ]] && [[ $RC != 0 ]]; then
+    # dump the api logs
+    docker logs galaxy_ng_api_1
+
+    # dump the worker logs
+    docker logs galaxy_ng_worker_1
+fi
+
 exit $RC


### PR DESCRIPTION
#### What is this PR doing:
oci-env is not ready to replace our default dev stack.

* requires a secondary adjacent checkout of oci-env
* won't work with just a pip install
* doesn't conform to all of the workflows in our Makefile