### PR TITLE
Steal the polling logic from oci-env.

### DIFF
--- a/.github/workflows/ci_insights.yml
+++ b/.github/workflows/ci_insights.yml
@@ -58,7 +58,7 @@ jobs:
         run: ./compose up -d
 
       - name: give stack some time to spin up
-        run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py
+        run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py http://localhost:8080/api/automation-hub/pulp/api/v3/status/
 
       - name: run the integration tests
         run: ./dev/insights/RUN_INTEGRATION.sh

--- a/.github/workflows/ci_insights.yml
+++ b/.github/workflows/ci_insights.yml
@@ -58,7 +58,7 @@ jobs:
         run: ./compose up -d
 
       - name: give stack some time to spin up
-        run: sleep 120
+        run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py
 
       - name: run the integration tests
         run: ./dev/insights/RUN_INTEGRATION.sh

--- a/.github/workflows/ci_insights.yml
+++ b/.github/workflows/ci_insights.yml
@@ -58,7 +58,8 @@ jobs:
         run: ./compose up -d
 
       - name: give stack some time to spin up
-        run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py http://localhost:8080/api/automation-hub/pulp/api/v3/status/
+        # run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py http://localhost:8080/api/automation-hub/pulp/api/v3/status/
+        run: sleep 120
 
       - name: run the integration tests
         run: ./dev/insights/RUN_INTEGRATION.sh

--- a/.github/workflows/ci_standalone-community.yml
+++ b/.github/workflows/ci_standalone-community.yml
@@ -64,7 +64,7 @@ jobs:
         run: ./compose up -d
 
       - name: give stack some time to spin up
-        run: sleep 120
+        run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py
 
       - name: run the integration tests
         run: DUMP_LOGS=1 ./dev/standalone-community/RUN_INTEGRATION.sh

--- a/.github/workflows/ci_standalone-iqe-rbac-tests.yml
+++ b/.github/workflows/ci_standalone-iqe-rbac-tests.yml
@@ -49,7 +49,7 @@ jobs:
         run: ./compose up -d
 
       - name: give stack some time to spin up
-        run: sleep 120
+        run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py
 
       - name: set keyring on staging repo for signature upload
         run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y

--- a/.github/workflows/ci_standalone-ldap.yml
+++ b/.github/workflows/ci_standalone-ldap.yml
@@ -55,7 +55,7 @@ jobs:
         run: ./compose up -d
 
       - name: give stack some time to spin up
-        run: sleep 120
+        run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py
 
       - name: set keyring on staging repo for signature upload
         run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y

--- a/.github/workflows/ci_standalone-rbac-roles.yml
+++ b/.github/workflows/ci_standalone-rbac-roles.yml
@@ -52,7 +52,7 @@ jobs:
         run: ./compose up -d
 
       - name: give stack some time to spin up
-        run: sleep 120
+        run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py
 
       - name: set keyring on staging repo for signature upload
         run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -49,7 +49,7 @@ jobs:
         run: ./compose up -d
 
       - name: give stack some time to spin up
-        run: sleep 120
+        run: python dev/common/poll.py
 
       - name: set keyring on staging repo for signature upload
         run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -49,7 +49,7 @@ jobs:
         run: ./compose up -d
 
       - name: give stack some time to spin up
-        run: python dev/common/poll.py
+        run: COMPOSE_INTERACTIVE_NO_CLI=1 python dev/common/poll.py
 
       - name: set keyring on staging repo for signature upload
         run: ./compose exec -T api ./entrypoint.sh manage set-repo-keyring --repository staging --keyring /etc/pulp/certs/galaxy.kbx -y

--- a/dev/common/poll.py
+++ b/dev/common/poll.py
@@ -11,85 +11,15 @@ import yaml
 from json import JSONEncoder
 
 
-class DynaConfEncoder(JSONEncoder):
-    '''Special encoder for a dynaconf structure'''
-    def default(self, o):
-        if isinstance(o, PosixPath):
-            return o.path
-        return o.__dict__
-
-
-class PosixPath:
-    '''Evalable class for dynaconf posixpath thingies'''
-    def __init__(self, path):
-        self.path = path
-
-    def toJSON(self):
-        return self.path
-
-
-def parse_dynaconf_list(rawtxt):
-    '''Parse the magical dynaconf list output'''
-
-    ds = {}
-
-    # get rid of color codes ...
-    rawtxt = rawtxt.replace('\x1b[37m\x1b[100m', '')
-    rawtxt = rawtxt.replace('\x1b[97m\x1b[104m\x1b[1m', '')
-    rawtxt = rawtxt.replace('\x1b[97m\x1b[45m', '')
-    rawtxt = rawtxt.replace('\x1b[0m\x1b[97m\x1b[100m', '')
-    rawtxt = rawtxt.replace('\x1b[0m', '')
-    rawtxt = rawtxt.replace('Working in development environment', '')
-    rawtxt = rawtxt.replace('Django app detected', '')
-
-    # split all the key&vals
-    lines = rawtxt.split('\n')
-    bits = ['']
-    for idx, x in enumerate(lines):
-        if '<' in x and '>' in x:
-            bits.append('')
-        bits[-1] += x
-
-    # parse all the key&vals
-    bits = [x.strip() for x in bits if x.strip()]
-    for bit in bits:
-        var_name = bit.split('<', 1)[0]
-        var_type = bit.replace(var_name, '').split('>', 1)[0].replace('<', '')
-
-        var_raw = bit.split('>', 1)[-1].strip()
-
-        val = None
-        if var_type in ['str']:
-            val = var_raw.replace("'", '')
-        elif var_type == 'NoneType':
-            val = None
-        elif var_type in ['int', 'list', 'bool', 'dict', 'PosixPath']:
-            val = eval(var_raw)
-        else:
-            raise Exception(f'{var_name} is {var_type} which is not yet parseable')
-        ds[var_name] = {
-            'name': var_name,
-            'type': var_type,
-            'value': val
-        }
-
-    # force back to stdlib types
-    ds = json.dumps(ds, cls=DynaConfEncoder)
-    ds = json.loads(ds)
-
-    return ds
-
-
 def get_dynaconf_variable(varname):
-    '''Run the dynaconf list command and get a specific key'''
-    cmd = 'dynaconf list'
+    '''Run the dynaconf get subcommand for a specific key'''
+    cmd = f'dynaconf get {varname}'
     cmd = f'./compose exec api bash -c "{cmd}"'
     pid = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout = pid.stdout.decode('utf-8')
-    parsed = parse_dynaconf_list(stdout)
-    if varname not in parsed:
+    if pid.returncode != 0:
         return None
-    return parsed[varname]['value']
+    stdout = pid.stdout.decode('utf-8')
+    return stdout.strip()
 
 
 def get_compose_config():

--- a/dev/common/poll.py
+++ b/dev/common/poll.py
@@ -2,13 +2,10 @@
 
 # Poll the api until it is ready.
 
-import json
 import requests
 import subprocess
 import time
 import yaml
-
-from json import JSONEncoder
 
 
 def get_dynaconf_variable(varname):

--- a/dev/common/poll.py
+++ b/dev/common/poll.py
@@ -88,6 +88,8 @@ def get_dynaconf_variable(varname):
     pid = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout = pid.stdout.decode('utf-8')
     parsed = parse_dynaconf_list(stdout)
+    if varname not in parsed:
+        return None
     return parsed[varname]['value']
 
 
@@ -119,6 +121,11 @@ def poll(attempts=100, wait_time=1):
         # re request the api root each time because it's not alwasy available until the
         # app boots
         api_root = get_dynaconf_variable("API_ROOT")
+        if api_root is None:
+            print(f'\tAPI_ROOT is null')
+            time.sleep(wait_time)
+            continue
+
         url = f"{hostname}{api_root}api/v3/status/"
         print(f'\tenumerated url: {url}')
         try:

--- a/dev/common/poll.py
+++ b/dev/common/poll.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+
+# Poll the api until it is ready.
+
+import json
+import re
+import requests
+import subprocess
+import time
+import yaml
+
+from json import JSONEncoder
+
+
+class DynaConfEncoder(JSONEncoder):
+    '''Special encoder for a dynaconf structure'''
+    def default(self, o):
+        if isinstance(o, PosixPath):
+            return o.path
+        return o.__dict__
+
+
+class PosixPath:
+    '''Evalable class for dynaconf posixpath thingies'''
+    def __init__(self, path):
+        self.path = path
+
+    def toJSON(self):
+        return self.path
+
+
+def parse_dynaconf_list(rawtxt):
+    '''Parse the magical dynaconf list output'''
+
+    ds = {}
+
+    # get rid of color codes ...
+    rawtxt = rawtxt.replace('\x1b[37m\x1b[100m', '')
+    rawtxt = rawtxt.replace('\x1b[97m\x1b[104m\x1b[1m', '')
+    rawtxt = rawtxt.replace('\x1b[97m\x1b[45m', '')
+    rawtxt = rawtxt.replace('\x1b[0m\x1b[97m\x1b[100m', '')
+    rawtxt = rawtxt.replace('\x1b[0m', '')
+    rawtxt = rawtxt.replace('Working in development environment', '')
+    rawtxt = rawtxt.replace('Django app detected', '')
+
+    # split all the key&vals
+    lines = rawtxt.split('\n')
+    bits = ['']
+    for idx,x in enumerate(lines):
+        if '<' in x and '>' in x:
+            bits.append('')
+        bits[-1]+= x
+
+    # parse all the key&vals
+    bits = [x.strip() for x in bits if x.strip()]
+    for bit in bits:
+        var_name = bit.split('<', 1)[0]
+        var_type = bit.replace(var_name, '').split('>', 1)[0].replace('<', '')
+
+        var_raw = bit.split('>', 1)[-1].strip()
+
+        val = None
+        if var_type in ['str']:
+            val = var_raw.replace("'", '')
+        elif var_type == 'NoneType':
+            val = None
+        elif var_type in ['int', 'list', 'bool', 'dict', 'PosixPath']:
+            val = eval(var_raw)
+        else:
+            raise Exception(f'{var_name} is {var_type} which is not yet parseable')
+        ds[var_name] = {
+            'name': var_name,
+            'type': var_type,
+            'value': val
+        }
+
+    # force back to stdlib types
+    ds = json.dumps(ds, cls=DynaConfEncoder)
+    ds = json.loads(ds)
+
+    return ds
+
+
+def get_dynaconf_variable(varname):
+    '''Run the dynaconf list command and get a specific key'''
+    cmd = 'dynaconf list'
+    cmd = f'./compose exec api bash -c "{cmd}"'
+    pid = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout = pid.stdout.decode('utf-8')
+    parsed = parse_dynaconf_list(stdout)
+    return parsed[varname]['value']
+
+
+def get_compose_config():
+    '''Get a dump of the running|aggregated compose config'''
+    cmd = './compose config'
+    pid = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout = pid.stdout.decode('utf-8')
+    config = yaml.safe_load(stdout)
+    return config
+
+
+def poll(attempts=100, wait_time=1):
+    '''Wait for the API to report status or abnormal exit'''
+    # get the compose config
+    config = get_compose_config()
+
+    # extract the api service
+    api = config['services']['api']
+
+    # get the api's env
+    env = api['environment']
+
+    # hostname includes the prefix
+    hostname = env['PULP_ANSIBLE_API_HOSTNAME']
+
+    for i in range(attempts):
+        print(f"Waiting for API to start (attempt {i+1} of {attempts})")
+        # re request the api root each time because it's not alwasy available until the
+        # app boots
+        api_root = get_dynaconf_variable("API_ROOT")
+        url = f"{hostname}{api_root}api/v3/status/"
+        print(f'\tenumerated url: {url}')
+        try:
+            rr = requests.get(url)
+            print(f'\tresponse: {rr.status_code}')
+            if rr.status_code == 200:
+                print(f"{url} online after {(i * wait_time)} seconds")
+                return
+        except Exception as e:
+            print(e)
+            time.sleep(wait_time)
+
+    raise Exception(f"polling the api service failed to complete in the allowed timeframe")
+
+
+def main():
+    poll()
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/common/poll.py
+++ b/dev/common/poll.py
@@ -46,14 +46,18 @@ def poll(attempts=100, wait_time=1):
         print(f"Waiting for API to start (attempt {i+1} of {attempts})")
         # re request the api root each time because it's not alwasy available until the
         # app boots
+
+        print(f'\tHOSTNAME: {hostname}')
+
         api_root = get_dynaconf_variable("API_ROOT")
+        print(f'\tAPI_ROOT: {api_root}')
         if api_root is None:
             print('\tAPI_ROOT is null')
             time.sleep(wait_time)
             continue
 
         url = f"{hostname}{api_root}api/v3/status/"
-        print(f'\tenumerated url: {url}')
+        print(f'\tURL: {url}')
         try:
             rr = requests.get(url)
             print(f'\tresponse: {rr.status_code}')

--- a/dev/common/poll.py
+++ b/dev/common/poll.py
@@ -11,7 +11,7 @@ import yaml
 def get_dynaconf_variable(varname):
     '''Run the dynaconf get subcommand for a specific key'''
     cmd = f'dynaconf get {varname}'
-    cmd = f'./compose exec api bash -c "{cmd}"'
+    cmd = f'./compose exec -T api bash -c "{cmd}"'
     pid = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if pid.returncode != 0:
         print(f'ERROR: {pid.stderr.decode("utf-8")}')

--- a/dev/common/poll.py
+++ b/dev/common/poll.py
@@ -3,7 +3,6 @@
 # Poll the api until it is ready.
 
 import json
-import re
 import requests
 import subprocess
 import time
@@ -46,10 +45,10 @@ def parse_dynaconf_list(rawtxt):
     # split all the key&vals
     lines = rawtxt.split('\n')
     bits = ['']
-    for idx,x in enumerate(lines):
+    for idx, x in enumerate(lines):
         if '<' in x and '>' in x:
             bits.append('')
-        bits[-1]+= x
+        bits[-1] += x
 
     # parse all the key&vals
     bits = [x.strip() for x in bits if x.strip()]
@@ -122,7 +121,7 @@ def poll(attempts=100, wait_time=1):
         # app boots
         api_root = get_dynaconf_variable("API_ROOT")
         if api_root is None:
-            print(f'\tAPI_ROOT is null')
+            print('\tAPI_ROOT is null')
             time.sleep(wait_time)
             continue
 
@@ -138,7 +137,7 @@ def poll(attempts=100, wait_time=1):
             print(e)
             time.sleep(wait_time)
 
-    raise Exception(f"polling the api service failed to complete in the allowed timeframe")
+    raise Exception("polling the api service failed to complete in the allowed timeframe")
 
 
 def main():

--- a/dev/common/poll.py
+++ b/dev/common/poll.py
@@ -14,6 +14,7 @@ def get_dynaconf_variable(varname):
     cmd = f'./compose exec api bash -c "{cmd}"'
     pid = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if pid.returncode != 0:
+        print(f'ERROR: {pid.stderr.decode("utf-8")}')
         return None
     stdout = pid.stdout.decode('utf-8')
     return stdout.strip()


### PR DESCRIPTION
We can make using of polling instead of sleeping 120s when spinning up the CI stacks.