### PR TITLE
Add `django_guid.middleware.guid_middleware` to `MIDDLEWARE` settings

### DIFF
--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -14,6 +14,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'django_guid.middleware.guid_middleware',
     # END: Pulp standard middleware
     'django_prometheus.middleware.PrometheusAfterMiddleware',
     'django_currentuser.middleware.ThreadLocalUserMiddleware',

--- a/galaxy_ng/tests/integration/api/test_tasks.py
+++ b/galaxy_ng/tests/integration/api/test_tasks.py
@@ -1,0 +1,31 @@
+import pytest
+
+from ..utils import get_client, UIClient
+
+
+@pytest.mark.pulp_api
+@pytest.mark.standalone_only
+def test_logging_cid_value_in_task(ansible_config):
+    config = ansible_config("admin")
+    api_prefix = config.get("api_prefix").rstrip("/")
+    api_client = get_client(config, request_token=True)
+
+    ans_repo = api_client(
+        f"{api_prefix}/pulp/api/v3/repositories/ansible/ansible/?name=community",
+        method="GET"
+    )['results'][0]
+
+    # extract pulp_id from pulp_href
+    pulp_id = ans_repo["pulp_href"].split('/ansible/ansible/')[1].rstrip('/')
+
+    # use UIClient to get Correlation-ID from req headers
+    with UIClient(config=config) as uic:
+        sync_req = uic.post(
+            f"pulp/api/v3/repositories/ansible/ansible/{pulp_id}/sync/",
+            payload={})
+
+    sync_task = sync_req.json()["task"]
+    logging_cid = api_client(sync_task)["logging_cid"]
+
+    assert logging_cid != ""
+    assert sync_req.headers["Correlation-ID"] == logging_cid


### PR DESCRIPTION
No-Issue

#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
`logging_cid` fails with `null` value. 


```
pulp_1   | django.db.utils.IntegrityError: null value in column "logging_cid" of relation "core_task" violates not-null constraint
pulp_1   | DETAIL:  Failing row contains (f9d4f0b4-16f0-47ff-b55b-db437b3c41cf, 2023-01-16 15:38:50.537753+00, 2023-01-16 15:38:50.537775+00, waiting, pulp_ansible.app.tasks.collections.sync, null, null, null, null, null, null, null, null, {"mirror": false, "optimize": true, "remote_pk": "5421af5a-5d70-..., {/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/3d...)
```

#### How to reproduce: 
Dispatch any `sync, modify, sign` task (for example on endpoint: `/pulp/api/v3/repositories/ansible/ansible/<pk>/sync/`)

Issue appears on latest pulpcore `3.23.0` (Started happening after https://github.com/pulp/pulpcore/pull/3258) 

```
diff --git a/pulpcore/tasking/tasks.py b/pulpcore/tasking/tasks.py
index 4dc6c503a..dc16dc8a9 100644
--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -88,7 +88,7 @@ def dispatch(
     with transaction.atomic():
         task = Task.objects.create(
             state=TASK_STATES.WAITING,
-            logging_cid=(get_guid() or ""),
+            logging_cid=(get_guid()),
             task_group=task_group,
             name=func,
             args=args,
```


Pulp discussion: https://github.com/pulp/pulp_ansible/issues/1323 (PR: https://github.com/pulp/pulp_ansible/pull/1324)

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
