### PR TITLE
Update integration test make target to use standalone script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,9 @@ docker/test/integration:      ## Run integration tests with optional MARK param 
 		exit 1;\
 	fi
 	if [ "$(MARK)" ]; then\
-	  HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh "-m $(MARK)";\
+	  HUB_LOCAL=1 ./dev/standalone/RUN_INTEGRATION.sh "-m $(MARK)";\
 	else\
-		HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh;\
+		HUB_LOCAL=1 ./dev/standalone/RUN_INTEGRATION.sh;\
 	fi
 
 .PHONY: docker/test/integration/container

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -61,6 +61,7 @@ max_hub_version: This marker takes an argument that indicates the maximum hub ve
 min_hub_version: This marker takes an argument that indicates the minimum hub version
 iqe_rbac_test: imported iqe tests checking role permissions
 sync: sync tests against stage
+certified_sync: sync tests container against container
 """
 
 


### PR DESCRIPTION
#### What is this PR doing:
* Standalone script skips certified_sync, allows make target to pass without extra setup
* Add pytest mark for certified_sync

No-Issue