### PR TITLE
Add `-x` option to RUN_INTEGRATION.sh

### DIFF
--- a/dev/common/RUN_INTEGRATION.sh
+++ b/dev/common/RUN_INTEGRATION.sh
@@ -5,7 +5,7 @@
 # - Developer Env makefile commands for DeploymentMode.STANDALONE
 # - TODO: Ephemeral Env pr_check.sh (merge smoke_test.sh into this) for DeploymentMode.INSIGHTS
 
-set -e
+set -ex
 
 if [[ -z $HUB_LOCAL ]]; then
     export NAMESPACE="ephemeral-1riioj"

--- a/galaxy_ng/tests/integration/package/test_package_install.py
+++ b/galaxy_ng/tests/integration/package/test_package_install.py
@@ -27,7 +27,7 @@ def test_package_install(env_vars):
     with tempfile.TemporaryDirectory(prefix='galaxy_ng_testing_') as basedir:
 
         # make a venv
-        pid = subprocess.run(f'python3 -m venv {basedir}/venv', shell=True)
+        pid = subprocess.run(f'python3.10 -m venv {basedir}/venv', shell=True)
         assert pid.returncode == 0
 
         # install the package


### PR DESCRIPTION
#### What is this PR doing:
This adds the `-x` flag to the RUN_INTEGRATION.sh script, so that it's explicit which line of output comes from which line of the script. This allows for easier debugging in remote environments like Jenkins agents.

Issue: AAH-2079

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
