### PR TITLE
Call get_guid() as a function in set-repo-keyring

### DIFF
--- a/galaxy_ng/app/management/commands/set-repo-keyring.py
+++ b/galaxy_ng/app/management/commands/set-repo-keyring.py
@@ -13,7 +13,7 @@ from pulpcore.plugin.constants import TASK_FINAL_STATES, TASK_STATES
 from pulpcore.plugin.tasking import dispatch
 
 # Set logging_uid, this does not seem to get generated when task called via management command
-django_guid.set_guid(django_guid.utils.generate_guid)
+django_guid.set_guid(django_guid.utils.generate_guid())
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
No-Issue

#### What is this PR doing:
Call get_guid() as a function in set-repo-keyring

Fixes issue where the logging_cid ends up being the python id of the get_guid method name.


