### PR TITLE
Add upper limit to ansible-lint to resolve dependency mismatch

### DIFF
--- a/CHANGES/2137.misc
+++ b/CHANGES/2137.misc
@@ -1,0 +1,1 @@
+Add upper range to ansible-lint to resolve dependency mismatch

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ def _format_pulp_requirement(plugin, specifier=None, ref=None, gh_namespace="pul
 
 requirements = [
     "galaxy-importer==0.4.5",
+    "ansible-lint<=6.12.0",
     "pulpcore>=3.21.1,<3.22.0",
     "pulp_ansible>=0.15.0,<0.16.0",
     "django-prometheus>=2.0.0",


### PR DESCRIPTION
Dependency mismatch found in pulp_installer CI

Possibly related issue: AAH-2094

Issue: AAH-2137