### PR TITLE
Test `Failed validating 'format' in schema` in test_galaxy_openapi_validation

### DIFF
--- a/galaxy_ng/tests/integration/api/test_openapi.py
+++ b/galaxy_ng/tests/integration/api/test_openapi.py
@@ -50,6 +50,10 @@ def test_galaxy_openapi_no_pulp_variables(ansible_config):
 
 
 @pytest.mark.openapi
+@pytest.mark.skip(
+    reason="uncomment after https://github.com/pulp/pulpcore/pull/3564 is merged"
+           " and pulpcore version is upgraded"
+)
 def test_galaxy_openapi_validation(ansible_config):
     """Tests whether openapi.json passes openapi linter"""
 


### PR DESCRIPTION
No-Issue

Comment out `test_galaxy_openapi_validation`

Error: 
```=================================== FAILURES ===================================
________________________ test_galaxy_openapi_validation ________________________
galaxy_ng/tests/integration/api/test_openapi.py:65: in test_galaxy_openapi_validation
    validate_spec(galaxy_spec)
/tmp/gng_testing/lib/python3.10/site-packages/openapi_spec_validator/shortcuts.py:17: in validate_spec
    return validator.validate(spec, spec_url=spec_url)
/tmp/gng_testing/lib/python3.10/site-packages/openapi_spec_validator/validation/proxies.py:28: in validate
    raise err
E   openapi_spec_validator.validation.exceptions.OpenAPIValidationError: '2023-01-14' is not a 'date-time'
E   
E   Failed validating 'format' in schema:
E       {'default': '2023-01-14',
E        'description': 'Purge tasks completed earlier than this timestamp. '
E                       "Format '%Y-%m-%d[T%H:%M:%S]'",
E        'format': 'date-time',
E        'type': 'string'}
E   
E   On instance:
E       '2023-01-14'
=========================== short test summary info ============================
FAILED galaxy_ng/tests/integration/api/test_openapi.py::test_galaxy_openapi_validation - openapi_spec_validator.validation.exceptions.OpenAPIValidationError: '2023-01-14' is not a 'date-time'
```