### PR TITLE
Fix make docker/build on the dev environment.

### DIFF
--- a/dev/Dockerfile.base
+++ b/dev/Dockerfile.base
@@ -52,8 +52,11 @@ RUN set -ex; \
     && chown ${USER_NAME}:${USER_GROUP} /app
 
 # Install entr so we can have reload on worker processes
+# the checkout is to fix a compilation error caused by this commit 
+# https://github.com/eradman/entr/commit/f9ac92d17e42236fe6b5e8492e087620173c7b24
 RUN git clone https://github.com/eradman/entr && \
     cd entr && \
+    git checkout 0d2d92d6052624a1e03a2a654e98e1c49f9955d9 && \
     cp Makefile.linux Makefile && \
     make && \
     make install


### PR DESCRIPTION
`make docker/build` was failing with this error:

```
 > [ 4/12] RUN git clone https://github.com/eradman/entr &&     cd entr &&     cp Makefile.linux Makefile &&     make &&     make install:
#7 0.290 Cloning into 'entr'...
#7 2.437 cc  -D_GNU_SOURCE -D_LINUX_PORT -Imissing -DRELEASE=\"5.4\"  missing/strlcpy.c missing/kqueue_inotify.c entr.c -o entr
#7 2.497 missing/kqueue_inotify.c:32:10: fatal error: ../data.h: No such file or directory
#7 2.497  #include "../data.h"
#7 2.497           ^~~~~~~~~~~
#7 2.497 compilation terminated.
#7 2.598 make: *** [Makefile.bsd:15: entr] Error 1
```

No-Issue

#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAH-####

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
