### PR TITLE
Allow libldap referral chasing to be disabled.

### DIFF
--- a/CHANGES/2150.bugfix
+++ b/CHANGES/2150.bugfix
@@ -1,0 +1,1 @@
+Allow ldap.OPT_REFERRALS to be set

--- a/docs/integration/ldap.md
+++ b/docs/integration/ldap.md
@@ -86,7 +86,7 @@ PULP_AUTH_LDAP_USER_SEARCH_SCOPE="SUBTREE"
 PULP_AUTH_LDAP_USER_SEARCH_FILTER="(uid=%(user)s)"
 PULP_AUTH_LDAP_GROUP_SEARCH_BASE_DN="ou=people,dc=planetexpress,dc=com"
 PULP_AUTH_LDAP_GROUP_SEARCH_SCOPE="SUBTREE"
-PULP_AUTH_LDAP_GROUP_SEARCH_FILTER = "(objectClass=Group)"
+PULP_AUTH_LDAP_GROUP_SEARCH_FILTER="(objectClass=Group)"
 PULP_AUTH_LDAP_GROUP_TYPE_CLASS="django_auth_ldap.config:GroupOfNamesType"
 ```
 
@@ -114,6 +114,8 @@ PULP_AUTH_LDAP_USER_ATTR_MAP={first_name="givenName", last_name="sn", email="mai
 
 PULP_AUTH_LDAP_MIRROR_GROUPS=true
 # The above is what enabled group mirroring
+# the same variable also accepts a list of groups to mirror
+PULP_AUTH_LDAP_MIRROR_GROUPS=['admin_staff', 'ship_crew']
 ```
 
 You can limit which groups are mirrored if you don't want all the groups to be added do Hub.
@@ -182,5 +184,18 @@ PULP_GALAXY_LDAP_LOGGING=true
 PULP_AUTH_LDAP_CACHE_TIMEOUT=3600
 ```
 
+### LDAP REferrals
+
+MS Active Directory but search operation may result in the exception `ldap.OPERATIONS_ERROR` with the diagnostic message text “In order to perform this operation a successful bind must be completed on the connection.” Alternatively, a Samba 4 AD returns the diagnostic message “Operation unavailable without authentication”. 
+
+To fix that problem the LDAP REFERALS lookup can be disabled:
+
+```bash
+PULP_GALAXY_LDAP_DISABLE_REFERRALS=true
+```
+
+The above will set the proper option to `AUTH_LDAP_CONNECTION_OPTIONS` in the settings.
+
+---
 
 More settings can be found on https://django-auth-ldap.readthedocs.io/en/latest/reference.html#settings

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -506,6 +506,11 @@ def configure_ldap(settings: Dynaconf) -> Dict[str, Any]:
                 "loggers": {"django_auth_ldap": {"level": "DEBUG", "handlers": ["console"]}},
             }
 
+        connection_options = settings.get("AUTH_LDAP_CONNECTION_OPTIONS", {})
+        if settings.get("GALAXY_LDAP_DISABLE_REFERRALS"):
+            connection_options[ldap.OPT_REFERRALS] = 0
+        data["AUTH_LDAP_CONNECTION_OPTIONS"] = connection_options
+
     return data
 
 

--- a/galaxy_ng/tests/integration/api/test_ldap.py
+++ b/galaxy_ng/tests/integration/api/test_ldap.py
@@ -1,6 +1,13 @@
 """test_ldap.py - tests related to ldap authentication.
 
 See: AAH-1593
+
+These tests cases must run and pass also when
+the LDAP server has REFERRALS enabled
+python-ldap can't chase the referral links
+so the galaxy system might be set with
+GALAXY_LDAP_DISABLE_REFERRALS=True
+See: AAH-2150
 """
 import pytest
 import logging


### PR DESCRIPTION
MS Active Directory search operation results in the exception [ldap.OPERATIONS_ERROR](https://www.python-ldap.org/en/python-ldap-3.4.0/reference/ldap.html#ldap.OPERATIONS_ERROR) with the diagnostic message text “In order to perform this operation a successful bind must be completed on the connection.” Alternatively, a Samba 4 AD returns the diagnostic message “Operation unavailable without authentication”. What’s happening here?

Solution: When searching from the domain level, MS AD returns referrals (search continuations) for some objects to indicate to the client where to look for these objects. Client-chasing of referrals is a broken concept, since LDAPv3 does not specify which credentials to use when chasing the referral. Windows clients are supposed to simply use their Windows credentials, but this does not work in general when chasing referrals received from and pointing to arbitrary LDAP servers.

Therefore, per default, libldap automatically chases the referrals internally with an anonymous access which fails with MS AD.

So, the best thing to do is to switch this behaviour off Note that setting the above option does NOT prevent search continuations from being returned, rather only that libldap won’t attempt to resolve referrals.

Issue: AAH-2150

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

Specific testing will be performed as part of a separate workflow

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
