### PR TITLE
fix nginx error in ephemeral/crc

### DIFF
--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -95,6 +95,10 @@ objects:
             value: "automation-hub-galaxy-api${SUFFIX}"
           - name: GALAXY_API_PORT
             value: '8000'
+          - name: CONTENT_APP_HOST
+            value: "automation-hub-pulp-content-app${SUFFIX}"
+          - name: CONTENT_APP_PORT
+            value: '10000'
         volumeMounts:
           - name: cache
             mountPath: /var/cache/nginx


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
add CONTENT_APP_HOST and CONTENT_APP_PORT envvars to nginx to prevent any impact of https://github.com/ansible/automation-hub-deploy/pull/11

Otherwise this error prevents the clowdapp to deploy:
```nginx: [emerg] host not found in upstream "galaxy-api:5001" in /opt/app-root/etc/nginx.d/default.conf:9```

<!-- Add Jira issue link or replace with No-Issue -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
