### PR TITLE
Check for admin group in v1 namespace access policy

### DIFF
--- a/CHANGES/1904.misc
+++ b/CHANGES/1904.misc
@@ -1,0 +1,1 @@
+Check for admin group in v1 namespace access policy

--- a/dev/common/setup_test_data.py
+++ b/dev/common/setup_test_data.py
@@ -114,3 +114,8 @@ GroupRole.objects.get_or_create(
 
 print("Add a group that exists in the testing LDAP container")
 ldap_group, _ = Group.objects.get_or_create(name="admin_staff")
+
+print("Add a namespace admin group for commuinty to manage namespaces")
+namespace_admin_group, _ = Group.objects.get_or_create(name="admin_namespaces")
+gh_user, _ = User.objects.get_or_create(username="gh_user_ns_admin")
+gh_user.groups.add(namespace_admin_group)

--- a/dev/standalone-community/github_mock/flaskapp.py
+++ b/dev/standalone-community/github_mock/flaskapp.py
@@ -64,7 +64,12 @@ USERS = {
         'id': 1004,
         'login': 'geerlingguy',
         'password': 'redhat'
-    }
+    },
+    'gh_user_ns_admin': {
+        'id': 1005,
+        'login': 'gh_user_ns_admin',
+        'password': 'redhat'
+    },
 }
 
 # These are used for initial form GET+POST

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -20,6 +20,8 @@ from galaxy_ng.app.access_control.statements import PULP_VIEWSETS
 
 log = logging.getLogger(__name__)
 
+NAMESPACE_ADMIN_GROUP = "admin_namespaces"
+
 
 # TODO this is a function in pulpcore that needs to get moved ot the plugin api.
 # from pulpcore.plugin.util import get_view_urlpattern
@@ -536,10 +538,12 @@ class LegacyAccessPolicy(AccessPolicyBase):
 
     def is_namespace_owner(self, request, viewset, action):
 
-        # let superusers do whatever they want.
-        user = request.user
-        if user.is_superuser:
-            return True
+        # allow users in namespace admin group to have access
+        namespace_admin_group = models.Group.objects.filter(name=NAMESPACE_ADMIN_GROUP)
+        if namespace_admin_group:
+            user = request.user
+            if namespace_admin_group[0] in user.groups.all():
+                return True
 
         namespace = None
         github_user = None

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -135,6 +135,11 @@ class AnsibleConfigFixture(dict):
             "password": "redhat",
             "token": None,
         },
+        "gh_user_ns_admin": {
+            "username": "gh_user_ns_admin",
+            "password": "redhat",
+            "token": None,
+        },
         "geerlingguy": {
             "username": "geerlingguy",
             "password": "redhat",


### PR DESCRIPTION
#### What is this PR doing:
Currently edits to a v1 namespace owner are allowed by the namespace owners and superusers.

This changes it to be allowed by namespace owners and users in a NAMESPACE_ADMIN_GROUP 

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAH-1904