### PR TITLE
Hide synclist repos on the distribution list API.

### DIFF
--- a/CHANGES/2281.misc
+++ b/CHANGES/2281.misc
@@ -1,0 +1,1 @@
+Hide synclist repos on the distribution list API.

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -12,6 +12,7 @@ from rest_framework.exceptions import NotFound, ValidationError
 from pulpcore.plugin.access_policy import AccessPolicyFromDB
 from pulpcore.plugin.models.role import GroupRole, UserRole
 from pulpcore.plugin import models as core_models
+from pulpcore.plugin.util import get_objects_for_user
 
 from pulp_ansible.app import models as ansible_models
 
@@ -199,6 +200,22 @@ class AccessPolicyBase(AccessPolicyFromDB):
             )
 
         return qs
+
+    def scope_synclist_distributions(self, view, qs):
+        if not view.request.user.has_perm("galaxy.view_synclist"):
+            my_synclists = get_objects_for_user(
+                view.request.user,
+                "galaxy.view_synclist",
+                qs=models.SyncList.objects.all(),
+            )
+            my_synclists = my_synclists.values_list("distribution", flat=True)
+            qs = qs.exclude(Q(base_path__endswith="-synclist") & ~Q(pk__in=my_synclists))
+        return self.scope_by_view_repository_permissions(
+            view,
+            qs,
+            field_name="repository",
+            is_generic=True
+        )
 
     # if not defined, defaults to parent qs of None breaking Group Detail
     def scope_queryset(self, view, qs):

--- a/galaxy_ng/app/access_control/statements/pulp.py
+++ b/galaxy_ng/app/access_control/statements/pulp.py
@@ -395,11 +395,8 @@ PULP_ANSIBLE_VIEWSETS = {
             },
         ],
         "queryset_scoping": {
-            "function": "scope_by_view_repository_permissions",
-            "parameters": {
-                "is_generic": True,
-                "field_name": "repository"
-            },
+            "function": "scope_synclist_distributions",
+            "parameters": {},
         },
     },
     "repositories/ansible/ansible/versions": {

--- a/galaxy_ng/tests/integration/api/test_synclist.py
+++ b/galaxy_ng/tests/integration/api/test_synclist.py
@@ -155,3 +155,20 @@ def test_edit_synclist_see_in_excludes(ansible_config, upload_artifact):
     resp = paginated_query(api_client, url, key="data")
     collections_after = [(c["namespace"], c["name"]) for c in resp["data"]]
     assert collections_before == collections_after
+
+
+@pytest.mark.synclist
+@pytest.mark.cloud_only
+@pytest.mark.slow_in_cloud
+def test_synclist_distributions(ansible_config, upload_artifact):
+    """
+    Test that only one synclist shows up for the user.
+    """
+
+    config = ansible_config("basic_user")
+    api_client = get_client(config, request_token=True, require_auth=True)
+
+    results = api_client(
+        "pulp/api/v3/distributions/ansible/ansible/?name__icontains=synclist")
+
+    assert results["count"] == 1


### PR DESCRIPTION
Issue: AAH-2281

#### What is this PR doing:
Filter out synclists on the pulp ansible distribution list.