### PR TITLE
[backport] Require a requirements.yaml file when syncing from galaxy.ansible.com…

### DIFF
--- a/CHANGES/2280.misc
+++ b/CHANGES/2280.misc
@@ -1,0 +1,1 @@
+Require a requirements.yaml file when syncing from galaxy.ansible.com.

--- a/galaxy_ng/app/access_control/statements/pulp.py
+++ b/galaxy_ng/app/access_control/statements/pulp.py
@@ -288,12 +288,20 @@ PULP_ANSIBLE_VIEWSETS = {
                     "copy_collection_version",
                     "move_collection_version",
                     "modify",
-                    "sync",
                     "sign"
                 ],
                 "principal": "authenticated",
                 "effect": "allow",
                 "condition": "has_ansible_repo_perms:ansible.modify_ansible_repo_content"
+            },
+            {
+                "action": ["sync", ],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_ansible_repo_perms:ansible.modify_ansible_repo_content",
+                    "require_requirements_yaml",
+                ],
             },
             {
                 "action": [

--- a/galaxy_ng/tests/integration/api/test_tasks.py
+++ b/galaxy_ng/tests/integration/api/test_tasks.py
@@ -11,7 +11,7 @@ def test_logging_cid_value_in_task(ansible_config):
     api_client = get_client(config, request_token=True)
 
     ans_repo = api_client(
-        f"{api_prefix}/pulp/api/v3/repositories/ansible/ansible/?name=community",
+        f"{api_prefix}/pulp/api/v3/repositories/ansible/ansible/?name=rh-certified",
         method="GET"
     )['results'][0]
 


### PR DESCRIPTION
…. (#1673)

* Require a requirements.yaml file when syncing from galaxy.ansible.com.

Issue: AAH-2280

* Fix integration tests

(cherry picked from commit 347bb01acf3604449f235d445cb14231ccfcb96d)