### PR TITLE
Restrict access to copy/move collection version endpoints

### DIFF
--- a/CHANGES/2223.bugfix
+++ b/CHANGES/2223.bugfix
@@ -1,0 +1,1 @@
+Added access policy condition restricting access to the copy_collection_version endpoint

--- a/CHANGES/2224.bugfix
+++ b/CHANGES/2224.bugfix
@@ -1,0 +1,1 @@
+Added access policy condition restricting access to the move_collection_version endpoint

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -300,7 +300,7 @@ class AccessPolicyBase(AccessPolicyFromDB):
         if request.user.has_perm(permission):
             return True
 
-        # accumulate all the objects to check for permission    
+        # accumulate all the objects to check for permission
         repos_to_check = []
         # add source repo to the list of repos to check
         obj = view.get_object()
@@ -312,9 +312,8 @@ class AccessPolicyBase(AccessPolicyFromDB):
         serializer.is_valid(raise_exception=True)
         repos_to_check.extend(list(serializer.validated_data["destination_repositories"]))
 
-        # here the repos_to_check have all the objects and we want to ensure user has permission on all
-        # all returns a bool
-        # have to check `repos_to_check and all(...)` because `all([])` on an empty list would return True
+        # have to check `repos_to_check and all(...)` because `all([])` on an empty
+        # list would return True
         return repos_to_check and all(
             request.user.has_perm(permission, repo) for repo in repos_to_check
         )

--- a/galaxy_ng/app/access_control/statements/pulp.py
+++ b/galaxy_ng/app/access_control/statements/pulp.py
@@ -281,7 +281,10 @@ PULP_ANSIBLE_VIEWSETS = {
                 ],
                 "principal": "authenticated",
                 "effect": "allow",
-                "condition": "signatures_not_required_for_repo"
+                "condition": [
+                    "can_copy_or_move:ansible.modify_ansible_repo_content",
+                    "signatures_not_required_for_repo",
+                ],
             },
             {
                 "action": [

--- a/galaxy_ng/tests/integration/api/rbac_actions/collections.py
+++ b/galaxy_ng/tests/integration/api/rbac_actions/collections.py
@@ -600,3 +600,85 @@ def private_repo_v3(user, password, expect_pass, extra):
     )
 
     assert_pass(expect_pass, response.status_code, 200, 403)
+
+
+def copy_collection_version(user, password, expect_pass, extra):
+    repo = extra["custom_repo"].get_repo()
+    collection = extra['collection'].get_collection()
+    collection_version_response = requests.get(
+        f"{PULP_API_ROOT}content/ansible/collection_versions/?name={collection['name']}",
+        auth=ADMIN_CREDENTIALS,
+    ).json()
+    ds = collection_version_response["results"]
+    assert len(ds) == 1
+    cv_pulp_href = ds[0]['pulp_href']
+
+    staging_repo_resp = requests.get(
+        f"{PULP_API_ROOT}repositories/ansible/ansible/?name=staging",
+        auth=ADMIN_CREDENTIALS,
+    ).json()
+    assert len(staging_repo_resp['results']) == 1
+    staging_repo = staging_repo_resp["results"][0]
+
+    response = requests.post(
+        f"{SERVER}{staging_repo['pulp_href']}copy_collection_version/",
+        json={
+            "collection_versions": [f"{cv_pulp_href}"],
+            "destination_repositories": [f"{repo['pulp_href']}"]
+        },
+        auth=(user['username'], password),
+    )
+
+    # TODO move logic to _reset_collection()
+    if response.status_code == 202:
+        response = requests.post(
+            f"{SERVER}{repo['pulp_href']}move_collection_version/",
+            json={
+                "collection_versions": [f"{cv_pulp_href}"],
+                "destination_repositories": [f"{staging_repo['pulp_href']}"]
+            },
+            auth=ADMIN_CREDENTIALS,
+        )
+
+    assert_pass(expect_pass, response.status_code, 202, 403)
+
+
+def move_collection_version(user, password, expect_pass, extra):
+    repo = extra["custom_repo"].get_repo()
+    collection = extra['collection'].get_collection()
+    collection_version_response = requests.get(
+        f"{PULP_API_ROOT}content/ansible/collection_versions/?name={collection['name']}",
+        auth=ADMIN_CREDENTIALS,
+    ).json()
+    ds = collection_version_response["results"]
+    assert len(ds) == 1
+    cv_pulp_href = ds[0]['pulp_href']
+
+    staging_repo_resp = requests.get(
+        f"{PULP_API_ROOT}repositories/ansible/ansible/?name=staging",
+        auth=ADMIN_CREDENTIALS,
+    ).json()
+    assert len(staging_repo_resp['results']) == 1
+    staging_repo = staging_repo_resp["results"][0]
+
+    response = requests.post(
+        f"{SERVER}{staging_repo['pulp_href']}move_collection_version/",
+        json={
+            "collection_versions": [f"{cv_pulp_href}"],
+            "destination_repositories": [f"{repo['pulp_href']}"]
+        },
+        auth=(user['username'], password),
+    )
+
+    # TODO move logic to _reset_collection()
+    if response.status_code == 202:
+        response = requests.post(
+            f"{SERVER}{repo['pulp_href']}move_collection_version/",
+            json={
+                "collection_versions": [f"{cv_pulp_href}"],
+                "destination_repositories": [f"{staging_repo['pulp_href']}"]
+            },
+            auth=ADMIN_CREDENTIALS,
+        )
+
+    assert_pass(expect_pass, response.status_code, 202, 403)

--- a/galaxy_ng/tests/integration/api/test_rbac_roles.py
+++ b/galaxy_ng/tests/integration/api/test_rbac_roles.py
@@ -58,6 +58,8 @@ from .rbac_actions.collections import (
     deprecate_collections,
     undeprecate_collections,
     upload_collection_to_other_pipeline_repo,
+    copy_collection_version,
+    move_collection_version,
 
     # ansible repository
     view_ansible_repository,
@@ -166,6 +168,8 @@ GLOBAL_ACTIONS = {
     private_collection_version_list,
     view_private_repository_version,
     private_repo_v3,
+    copy_collection_version,
+    move_collection_version,
 
     # EEs
     # Remotes
@@ -292,6 +296,8 @@ OBJECT_ROLES_TO_TEST = {
         private_collection_version_list,
         view_private_repository_version,
         private_repo_v3,
+        copy_collection_version,
+        move_collection_version,
 
         # ansible repository version
         view_ansible_repository_version,
@@ -370,6 +376,8 @@ ROLES_TO_TEST = {
         private_collection_version_list,
         view_private_repository_version,
         private_repo_v3,
+        copy_collection_version,
+        move_collection_version,
 
         # ansible repository
         view_ansible_repository,
@@ -450,6 +458,8 @@ ROLES_TO_TEST = {
         private_collection_version_list,
         view_private_repository_version,
         private_repo_v3,
+        copy_collection_version,
+        move_collection_version,
 
         # ansible repository
         view_ansible_repository,
@@ -503,6 +513,8 @@ ROLES_TO_TEST = {
         private_collection_version_list,
         view_private_repository_version,
         private_repo_v3,
+        copy_collection_version,
+        move_collection_version,
 
         # ansible repository version
         view_ansible_repository_version,

--- a/galaxy_ng/tests/integration/api/test_rbac_roles.py
+++ b/galaxy_ng/tests/integration/api/test_rbac_roles.py
@@ -59,6 +59,7 @@ from .rbac_actions.collections import (
     undeprecate_collections,
     upload_collection_to_other_pipeline_repo,
     copy_collection_version,
+    copy_multiple_collection_version,
     move_collection_version,
 
     # ansible repository
@@ -169,6 +170,7 @@ GLOBAL_ACTIONS = {
     view_private_repository_version,
     private_repo_v3,
     copy_collection_version,
+    copy_multiple_collection_version,
     move_collection_version,
 
     # EEs
@@ -297,6 +299,7 @@ OBJECT_ROLES_TO_TEST = {
         view_private_repository_version,
         private_repo_v3,
         copy_collection_version,
+        copy_multiple_collection_version,
         move_collection_version,
 
         # ansible repository version
@@ -377,6 +380,7 @@ ROLES_TO_TEST = {
         view_private_repository_version,
         private_repo_v3,
         copy_collection_version,
+        copy_multiple_collection_version,
         move_collection_version,
 
         # ansible repository
@@ -459,6 +463,7 @@ ROLES_TO_TEST = {
         view_private_repository_version,
         private_repo_v3,
         copy_collection_version,
+        copy_multiple_collection_version,
         move_collection_version,
 
         # ansible repository
@@ -514,6 +519,7 @@ ROLES_TO_TEST = {
         view_private_repository_version,
         private_repo_v3,
         copy_collection_version,
+        copy_multiple_collection_version,
         move_collection_version,
 
         # ansible repository version


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Added an access condition to the copy/move collection version endpoints to verify the user has permissions to modify both repositories.  Added rbac tests for the endpoints.

In a follow-up PR, I plan to move some logic from the tests to ReusableCollection._reset_collection function.

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAH-2223, AAH-2224

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
