### PR TITLE
Add `sudo apt -y update` in `build_publish.yml`

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -31,6 +31,9 @@ jobs:
         echo "::error::Tag ${{ github.ref_name }} and galaxy_ng version ${{ env.galaxy_ng_version }} doesn't match."
         exit 1
 
+    - name: Update apt
+      run: sudo apt -y update
+
     - name: Install LDAP requirements
       run: sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev build-essential gettext python-setuptools
 


### PR DESCRIPTION
No-Issue

When releasing `4.7.0`, CI action `build_publish` failed on `Install LDAP requirements`
```
Err:13 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libldap2-dev all 2.5.14+dfsg-0ubuntu0.22.04.1
  404  Not Found [IP: 40.119.46.219 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/o/openldap/libldap-dev_2.5.14%2bdfsg-0ubuntu0.22.04.1_amd64.deb  [40](https://github.com/ansible/galaxy_ng/actions/runs/4724662025/jobs/8382178502#step:6:41)4  Not Found [IP: 40.119.46.219 80]
Fetched 5583 kB in 1s (4040 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/o/openldap/libldap2-dev_2.5.14%2bdfsg-0ubuntu0.22.04.1_all.deb  404  Not Found [IP: 40.119.46.219 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```
(https://github.com/ansible/galaxy_ng/actions/runs/4724662025/jobs/8382178502) 

This was caused by not running `sudo apt -y update` 