### PR TITLE
Don't skip required CI jobs for docs PRs

### DIFF
--- a/.github/workflows/ci_insights.yml
+++ b/.github/workflows/ci_insights.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - '**'
-    paths-ignore:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'CHANGES/**'
   push:
     branches:
       - '**'

--- a/.github/workflows/ci_standalone-community.yml
+++ b/.github/workflows/ci_standalone-community.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - '**'
-    paths-ignore:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'CHANGES/**'
   push:
     branches:
       - '**'

--- a/.github/workflows/ci_standalone-ldap.yml
+++ b/.github/workflows/ci_standalone-ldap.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - '**'
-    paths-ignore:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'CHANGES/**'
   push:
     branches:
       - '**'

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -1,13 +1,9 @@
 ---
 name: Standalone
-on: 
+on:
   pull_request:
     branches:
       - '**'
-    paths-ignore:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'CHANGES/**'
   push:
     branches:
       - '**'


### PR DESCRIPTION
In bf3503e we skipped required CI jobs for PRs that were docs-only, this results in the PR being unable to merge since those tests are required.

Per GitHub docs there may be no way to skip a required test: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs

No-Issue