### PR TITLE
Fix permission set for updating a container push repo

### DIFF
--- a/CHANGES/2327.bugfix
+++ b/CHANGES/2327.bugfix
@@ -1,0 +1,1 @@
+Fix container push update permission

--- a/galaxy_ng/app/access_control/statements/pulp.py
+++ b/galaxy_ng/app/access_control/statements/pulp.py
@@ -181,6 +181,15 @@ PULP_CONTAINER_VIEWSETS = {
                     "has_namespace_or_obj_perms:container.modify_content_containerpushrepository",
                 ],
             },
+            {
+                "action": ["update", "partial_update"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition_expression": [
+                    "has_namespace_obj_perms:container.namespace_change_containerpushrepository or "
+                    "has_distribution_perms:container.change_containerdistribution",
+                ],
+            },
         ],
         # Remove permission assignment since it's trying to add permissions to groups
         # that don't exist

--- a/galaxy_ng/tests/integration/api/test_container_push_update.py
+++ b/galaxy_ng/tests/integration/api/test_container_push_update.py
@@ -1,0 +1,55 @@
+
+"""Tests related to container push update.
+
+See: https://issues.redhat.com/browse/AAH-2327
+"""
+import subprocess
+import time
+
+import pytest
+
+from galaxy_ng.tests.integration.utils import get_client
+
+
+@pytest.mark.parametrize(
+    "require_auth",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.standalone_only
+def test_can_update_container_push(ansible_config, require_auth):
+    # Pull alpine image
+    subprocess.check_call(["docker", "pull", "alpine"])
+    # Tag the image
+    subprocess.check_call(["docker", "tag", "alpine", "localhost:5001/alpine:latest"])
+
+    # Login to local registy with tls verify disabled
+    subprocess.check_call(["docker", "login", "-u", "admin", "-p", "admin", "localhost:5001"])
+    # Push image to local registry
+    subprocess.check_call(["docker", "push", "localhost:5001/alpine:latest"])
+
+    # Get an API client running with admin user credentials
+    client = get_client(
+        config=ansible_config("admin"),
+        request_token=True,
+        require_auth=require_auth
+    )
+    api_prefix = client.config.get("api_prefix").rstrip("/")
+
+    # Get the pulp_href for the pushed repo
+    image = client(
+        f"{api_prefix}/pulp/api/v3/repositories/container/container-push/?name=alpine"
+    )
+    container_href = image["results"][0]["pulp_href"]
+
+    for value in (42, 1):
+        # Make a Patch request changing the retain_repo_versions attribute to value
+        client(container_href, method="PATCH", args={"retain_repo_versions": value})
+
+        # sleep 2 seconds waiting task to finish
+        time.sleep(2)
+        # assert the change was persisted
+        repo = client(container_href)
+        assert repo["retain_repo_versions"] == value


### PR DESCRIPTION
Issue: AAH-2327

As a superuser I cannot modify a container-push repository via API

```bash
❯ curl -kX 'PATCH' \
  'https://FQDN/pulp/api/v3/repositories/container/container-push/6e2fd4fb-cc04-43e6-84c5-6880cbdbea52'/ \
  -H 'accept: application/json' \                     
  -H 'Authorization: Basic BASE64CREDSFORADMIN' \
  -H 'Content-Type: application/json' \
  -d '{
  "retain_repo_versions": 1
}'
```

Result: 403 `{"detail":"You do not have permission to perform this action."}`

Expected: 200 `{"task": "id"}`


