### PR TITLE
Attempt to fix docker/urllib problem by using compose v2

### DIFF
--- a/.github/workflows/ci_insights.yml
+++ b/.github/workflows/ci_insights.yml
@@ -26,8 +26,12 @@ jobs:
       - name: Install LDAP requirements
         run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
-      - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+      - name: Install python requirements required to run integration tests
+        run: pip install requests pyyaml
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.17.3'
 
       - name: create the .compose.env file
         run: rm -f .compose.env; cp .compose.env.example .compose.env

--- a/.github/workflows/ci_standalone-certified-sync.yml
+++ b/.github/workflows/ci_standalone-certified-sync.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Install LDAP requirements
         run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
-      - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+      - name: Install python requirements required to run integration tests
+        run: pip install requests pyyaml
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.17.3'
 
       - name: setup oci-env
         run: |

--- a/.github/workflows/ci_standalone-community.yml
+++ b/.github/workflows/ci_standalone-community.yml
@@ -26,8 +26,12 @@ jobs:
       - name: Install LDAP requirements
         run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
-      - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+      - name: Install python requirements required to run integration tests
+        run: pip install requests pyyaml
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.17.3'
 
       - name: create the .compose.env file
         run: rm -f .compose.env; cp .compose.env.example .compose.env

--- a/.github/workflows/ci_standalone-iqe-rbac-tests.yml
+++ b/.github/workflows/ci_standalone-iqe-rbac-tests.yml
@@ -30,8 +30,12 @@ jobs:
       - name: Install LDAP requirements
         run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
-      - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+      - name: Install python requirements required to run integration tests
+        run: pip install requests pyyaml
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.17.3'
 
       - name: create the .compose.env file
         run: rm -f .compose.env; cp .compose.env.example .compose.env

--- a/.github/workflows/ci_standalone-ldap.yml
+++ b/.github/workflows/ci_standalone-ldap.yml
@@ -26,8 +26,12 @@ jobs:
       - name: Install LDAP requirements
         run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
-      - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+      - name: Install python requirements required to run integration tests
+        run: pip install requests pyyaml
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.17.3'
 
       - name: create the .compose.env file
         run: rm -f .compose.env; cp .compose.env.example .compose.env

--- a/.github/workflows/ci_standalone-rbac-on-repos.yml
+++ b/.github/workflows/ci_standalone-rbac-on-repos.yml
@@ -30,8 +30,12 @@ jobs:
       - name: Install LDAP requirements
         run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
-      - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+      - name: Install python requirements required to run integration tests
+        run: pip install requests pyyaml
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.17.3'
 
       - name: create the .compose.env file
         run: rm -f .compose.env; cp .compose.env.example .compose.env

--- a/.github/workflows/ci_standalone-rbac-roles.yml
+++ b/.github/workflows/ci_standalone-rbac-roles.yml
@@ -30,8 +30,12 @@ jobs:
       - name: Install LDAP requirements
         run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
-      - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+      - name: Install python requirements required to run integration tests
+        run: pip install requests pyyaml
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.17.3'
 
       - name: create the .compose.env file
         run: rm -f .compose.env; cp .compose.env.example .compose.env

--- a/.github/workflows/ci_standalone-x-repo-search.yml
+++ b/.github/workflows/ci_standalone-x-repo-search.yml
@@ -30,8 +30,12 @@ jobs:
       - name: Install LDAP requirements
         run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
-      - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+      - name: Install python requirements required to run integration tests
+        run: pip install requests pyyaml
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.17.3'
 
       - name: create the .compose.env file
         run: rm -f .compose.env; cp .compose.env.example .compose.env

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -26,8 +26,12 @@ jobs:
       - name: Install LDAP requirements
         run: sudo apt-get install -y libsasl2-dev python3 libldap2-dev libssl-dev build-essential
 
-      - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+      - name: Install python requirements required to run integration tests
+        run: pip install requests pyyaml
+
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.17.3'
 
       - name: create the .compose.env file
         run: rm -f .compose.env; cp .compose.env.example .compose.env

--- a/dev/common/RUN_INTEGRATION.sh
+++ b/dev/common/RUN_INTEGRATION.sh
@@ -29,11 +29,14 @@ if [[ ! -d $VENVPATH ]]; then
     python3.10 -m venv $VENVPATH
     # $PIP install --retries=0 --verbose --upgrade pip wheel
 fi
-source $VENVPATH/bin/activate
+source "$VENVPATH/bin/activate"
 echo "PYTHON: $(which python)"
 
 $VENVPATH/bin/pip install -r integration_requirements.txt
 $VENVPATH/bin/pip show epdb || pip install epdb
+
+CONTAINER_API=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F api)
+CONTAINER_WORKER=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F worker)
 
 # when running user can specify extra pytest arguments such as
 # export HUB_LOCAL=1
@@ -47,10 +50,10 @@ else
 
     if [[ $RC != 0 ]]; then
         # dump the api logs
-        docker logs galaxy_ng_api_1
+        docker logs "${CONTAINER_API}"
 
         # dump the worker logs
-        docker logs galaxy_ng_worker_1
+        docker logs "${CONTAINER_WORKER}"
     fi
 
 fi

--- a/dev/standalone-certified-sync/RUN_INTEGRATION.sh
+++ b/dev/standalone-certified-sync/RUN_INTEGRATION.sh
@@ -25,15 +25,17 @@ $VENVPATH/bin/pip show epdb || pip install epdb
 # when running user can specify extra pytest arguments such as
 # export HUB_LOCAL=1
 # dev/common/RUN_INTEGRATION.sh --pdb -sv --log-cli-level=DEBUG "-m standalone_only" -k mytest
-$VENVPATH/bin/pytest --capture=no -m "certified_sync or rm_sync" -v $@ galaxy_ng/tests/integration
+$VENVPATH/bin/pytest --capture=no -m "certified_sync or rm_sync" -v "$@" galaxy_ng/tests/integration
 RC=$?
 
 if [[ $RC != 0 ]]; then
+    CONTAINER_API=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F api)
+    CONTAINER_WORKER=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F worker)
     # dump the api logs
-    docker logs galaxy_ng_api_1
+    docker logs "$CONTAINER_API"
 
     # dump the worker logs
-    docker logs galaxy_ng_worker_1
+    docker logs "$CONTAINER_WORKER"
 fi
 
 exit $RC

--- a/dev/standalone-community/RUN_INTEGRATION.sh
+++ b/dev/standalone-community/RUN_INTEGRATION.sh
@@ -19,24 +19,26 @@ echo "PYTHON: $(which python)"
 pip install -r integration_requirements.txt
 pip show epdb || pip install epdb
 
+CONTAINER=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F api)
+
 echo "Setting up test data"
-docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
+docker exec -i "$CONTAINER" /entrypoint.sh manage shell < dev/common/setup_test_data.py
 
 # social logins will happen against the github mock
 export SOCIAL_AUTH_GITHUB_BASE_URL='http://localhost:8082'
 export SOCIAL_AUTH_GITHUB_API_URL='http://localhost:8082'
 
 export HUB_API_ROOT='http://localhost:5001/api/'
-pytest --capture=no -m "community_only" $@ -v galaxy_ng/tests/integration
+pytest --capture=no -m "community_only" "$@" -v galaxy_ng/tests/integration
 RC=$?
 
-if [[ $RC != 0 && ! -z $DUMP_LOGS ]]; then
+if [[ $RC != 0 && -n "$DUMP_LOGS" ]]; then
     echo "DUMPING LOGS!"
     for CNAME in $(docker ps --format '{{ .Names }}'); do
         echo "----------------------------------------"
-        echo $CNAME
+        echo "$CNAME"
         echo "----------------------------------------"
-        docker logs $CNAME
+        docker logs "$CNAME"
     done
 fi
 

--- a/dev/standalone-iqe-tests/RUN_RBAC_REPOS_INTEGRATION.sh
+++ b/dev/standalone-iqe-tests/RUN_RBAC_REPOS_INTEGRATION.sh
@@ -19,18 +19,20 @@ echo "PYTHON: $(which python)"
 $VENVPATH/bin/pip install -r integration_requirements.txt
 $VENVPATH/bin/pip show epdb || pip install epdb
 
+CONTAINER_API=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F api)
+CONTAINER_WORKER=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F worker)
 echo "Setting up test data"
-docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
+docker exec -i "$CONTAINER_API" /entrypoint.sh manage shell < dev/common/setup_test_data.py
 
 $VENVPATH/bin/pytest --capture=no -m "rbac_repos" -v $@ galaxy_ng/tests/integration
 RC=$?
 
 if [[ $RC != 0 ]]; then
     # dump the api logs
-    docker logs galaxy_ng_api_1
+    docker logs "$CONTAINER_API"
 
     # dump the worker logs
-    docker logs galaxy_ng_worker_1
+    docker logs "$CONTAINER_WORKER"
 fi
 
 exit $RC

--- a/dev/standalone-iqe-tests/RUN_X_REPO_SEARCH_INTEGRATION.sh
+++ b/dev/standalone-iqe-tests/RUN_X_REPO_SEARCH_INTEGRATION.sh
@@ -19,18 +19,20 @@ echo "PYTHON: $(which python)"
 $VENVPATH/bin/pip install -r integration_requirements.txt
 $VENVPATH/bin/pip show epdb || pip install epdb
 
+CONTAINER_API=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F api)
+CONTAINER_WORKER=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F worker)
 echo "Setting up test data"
-docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
+docker exec -i "$CONTAINER_API" /entrypoint.sh manage shell < dev/common/setup_test_data.py
 
 $VENVPATH/bin/pytest --capture=no -m "x_repo_search" -v $@ galaxy_ng/tests/integration
 RC=$?
 
 if [[ $RC != 0 ]]; then
     # dump the api logs
-    docker logs galaxy_ng_api_1
+    docker logs "$CONTAINER_API"
 
     # dump the worker logs
-    docker logs galaxy_ng_worker_1
+    docker logs "$CONTAINER_WORKER"
 fi
 
 exit $RC

--- a/dev/standalone-ldap/RUN_INTEGRATION.sh
+++ b/dev/standalone-ldap/RUN_INTEGRATION.sh
@@ -23,13 +23,12 @@ pip install -r integration_requirements.txt
 pip show epdb || pip install epdb
 
 echo "Setting up test data"
-# If using a custom DEV_IMAGE_SUFFIX the container name will be different.
-CONTAINER_ID=${GALAXY_API_CONTAINER_NAME:-galaxy_ng_api_1}
-docker exec -i $CONTAINER_ID /entrypoint.sh manage shell < dev/common/setup_test_data.py
+CONTAINER=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F api)
+docker exec -i "$CONTAINER" /entrypoint.sh manage shell < dev/common/setup_test_data.py
 
 
 #export HUB_API_ROOT='http://localhost:5001/api/'
-pytest --capture=no --tb=short -m "standalone_only and ldap" $@ -v galaxy_ng/tests/integration
+pytest --capture=no --tb=short -m "standalone_only and ldap" "$@" -v galaxy_ng/tests/integration
 RC=$?
 
 exit $RC

--- a/dev/standalone-rbac-roles/RUN_INTEGRATION.sh
+++ b/dev/standalone-rbac-roles/RUN_INTEGRATION.sh
@@ -25,12 +25,13 @@ echo "PYTHON: $(which python)"
 pip install -r integration_requirements.txt
 pip show epdb || pip install epdb
 
+CONTAINER=$(docker ps --filter="name=galaxy_ng" --format="table {{.Names}}" | grep -F api)
 echo "Setting up test data"
-docker exec -i galaxy_ng_api_1 /entrypoint.sh manage shell < dev/common/setup_test_data.py
+docker exec -i "$CONTAINER" /entrypoint.sh manage shell < dev/common/setup_test_data.py
 
 
 #export HUB_API_ROOT='http://localhost:5001/api/'
-pytest --capture=no --tb=short -m "rbac_roles" $@ -v galaxy_ng/tests/integration
+pytest --capture=no --tb=short -m "rbac_roles" "$@" -v galaxy_ng/tests/integration
 RC=$?
 
 exit $RC


### PR DESCRIPTION
No-Issue

We where seeing CI errors due to https://github.com/docker/docker-py/issues/3113

Problem:

When we do "pip install docker-compose" we are installing unsopported version of docker-compose, which comes with docker-py, which depends on request, which depends on a broken version of urllib3.

Solution:

Start using docker compose v2

New problem, container names are different in compose v2

This PR fixes both problems