### PR TITLE
Disable new insights mode tests using non-CRC client

### DIFF
--- a/dev/ephemeral/run_tests.sh
+++ b/dev/ephemeral/run_tests.sh
@@ -12,7 +12,7 @@ ${VENV_PATH}/bin/pip install -r integration_requirements.txt
 
 echo "Running pytest ..."
 ${VENV_PATH}/bin/pytest \
-    --capture=no -m "cloud_only or (not standalone_only and not community_only and not sync and not rm_sync and not x_repo_search and not rbac_repos)" \
+    --capture=no -m "cloud_only or (not standalone_only and not community_only and not sync and not rm_sync and not x_repo_search and not rbac_repos and not skip_crc_infra)" \
     -v \
     galaxy_ng/tests/integration $@
 RC=$?

--- a/galaxy_ng/tests/integration/api/test_iqe_rbac.py
+++ b/galaxy_ng/tests/integration/api/test_iqe_rbac.py
@@ -9,6 +9,7 @@ from galaxykit.container_images import get_container_images
 from galaxykit.containers import add_owner_to_ee
 from galaxykit.containers import create_container
 from galaxykit.containers import delete_container
+from galaxykit.groups import create_group
 from galaxykit.namespaces import delete_namespace
 from galaxykit.registries import create_registry
 from galaxykit.registries import delete_registry
@@ -155,9 +156,9 @@ class TestRBAC:
         """
         group_name = f"rbac_test_group_{uuid4()}"
         gc = galaxy_client("iqe_admin")
-        gc.create_group(group_name)
+        create_group(gc, group_name)
         with pytest.raises(GalaxyClientError) as ctx:
-            gc.create_group(group_name)
+            create_group(gc, group_name, exists_ok=False)
         assert ctx.value.args[0]["status"] == "409"
 
     @pytest.mark.iqe_rbac_test

--- a/galaxy_ng/tests/integration/api/test_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_repositories.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.min_hub_version("4.7dev")
 class TestRepositories:
     @pytest.mark.repositories
+    @pytest.mark.skip_crc_infra  # FIXME: client does not work in CRC infra
     def test_cant_upload_same_collection_same_repo(self, galaxy_client):
         """
         Verifies that the same collection / version cannot be uploaded to the same repo
@@ -38,6 +39,7 @@ class TestRepositories:
         assert ctx.value.response.status_code == 400
 
     @pytest.mark.repositories
+    @pytest.mark.skip_crc_infra  # FIXME: client does not work in CRC infra
     def test_copy_cv_endpoint(self, galaxy_client):
         """
         Verifies a cv can be copied to a different repo
@@ -70,6 +72,7 @@ class TestRepositories:
         assert verify_repo_data(expected, results)
 
     @pytest.mark.repositories
+    @pytest.mark.skip_crc_infra  # FIXME: client does not work in CRC infra
     def test_move_cv_endpoint(self, galaxy_client):
         """
         Verifies a cv can be moved to a different repo

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -68,6 +68,7 @@ rbac_repos: tests verifying rbac roles on custom repositories
 rm_sync: tests verifying syncing custom repositories
 x_repo_search: tests verifying cross-repo search endpoint
 repositories: tests verifying custom repositories
+skip_crc_infra: tests skipped in crc infrastructure, like pr_check.sh and crc stage pipeline
 """
 
 


### PR DESCRIPTION
Tests added in https://github.com/ansible/galaxy_ng/commit/274bd138891195b604c0e05862d3fa1db08c3be4#diff-e9eca897bbc521ced6d6fe94f1eceb38b05ab40eefc1c0590a32103d404e254eR25 (test_cant_upload_same_collection_same_repo, test_copy_cv_endpoint, test_move_cv_endpoint) use a galaxykit client that is not currently used for insights mode tests, and they fail in environments using CRC infrastructure: GH Action ci.int.devshift.net pr_check, and Jenkins CRC Stage Integration tests.

This PR allows for skipping those in CRC infrastructure to get CI green. Eventually tests should use existing client, or update galaxykit client to handle this case.

Also pulls fix from #1721 for failing test on HEAD

No-Issue