### PR TITLE
[stable-4.5] Add UIClient class

### DIFF
--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -55,7 +55,7 @@ jobs:
         run: sleep 120
 
       - name: run the integration tests
-        continue-on-error: true
+        continue-on-error: false
         run: HUB_LOCAL=1 ./dev/common/RUN_INTEGRATION.sh
 
       - name: dump the api logs

--- a/galaxy_ng/tests/integration/api/test_artifact_upload.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_upload.py
@@ -254,17 +254,27 @@ def test_long_field_values(ansible_config, upload_artifact, field):
 @pytest.mark.parametrize(
     "spec",
     [
-        # ("2eq", "==2.10", "completed"),
+        # TODO: move most these to galaxy-importer unit tests
+        ("2eq", "==2.10", "completed"),
+        # ("gt", ">2.10.0", "completed"),
+        # ("gteq", ">=2.10", "completed"),
+        # ("beta", ">=2.12b1", "completed"),
+        ("beta2", ">=2.12.0b1", "completed"),
+        # ("lt", "<2.11", "completed"),
         # ("range1", ">=2.10,<2.11", "completed"),
-        ("range2", ">=2.10,<<2.11", "failed"),
-        ("2comma", ">=2.10,,", "failed"),
-        # ("star", "2.10.*", "completed"),
+        # ("it_strips_commas", ">=2.10,,", "completed"),
+        # ("gtstar", ">2.10.*", "completed"),
         # ("exc", ">=2.1,!=2.1.2", "completed"),
-        # Known limitations
-        # ("label", "2.10.post1", "completed"),
-        # ("pre", "2.11b4", "completed"),
+        ("norange", "2.10", "failed"),
+        # ("norange2", "2.10.0", "failed"),
+        # ("norange3", "2.10.0b1", "failed"),
+        # ("norange4", "2.10.*", "failed"),
         # ("1eq", "=2.10", "failed"),
-        # ("contradiction", ">2.0,<1.0", "failed"),
+        # Potentially unexpected
+        # ("gt_dup", ">>>>>2.11", "completed"),
+        # ("lt_dup", ">=2.10,<<2.11", "completed"),
+        # ("contradiction", ">2.0,<1.0", "completed"),
+        # ("text", ">nonumbers", "completed"),
     ],
     ids=lambda _: _[0],
 )

--- a/galaxy_ng/tests/integration/api/test_container_push_update.py
+++ b/galaxy_ng/tests/integration/api/test_container_push_update.py
@@ -35,11 +35,10 @@ def test_can_update_container_push(ansible_config, require_auth):
         request_token=True,
         require_auth=require_auth
     )
-    api_prefix = "/api/automation-hub"
 
     # Get the pulp_href for the pushed repo
     image = client(
-        f"{api_prefix}/pulp/api/v3/repositories/container/container-push/?name=alpine"
+        "/pulp/api/v3/repositories/container/container-push/?name=alpine"
     )
     container_href = image["results"][0]["pulp_href"]
 

--- a/galaxy_ng/tests/integration/api/test_openapi.py
+++ b/galaxy_ng/tests/integration/api/test_openapi.py
@@ -49,6 +49,10 @@ def test_galaxy_openapi_no_pulp_variables(ansible_config):
 
 
 @pytest.mark.openapi
+@pytest.mark.skip(
+    reason="uncomment after https://github.com/pulp/pulpcore/pull/3564 is merged"
+           " and pulpcore version is upgraded"
+)
 def test_galaxy_openapi_validation(ansible_config):
     """Tests whether openapi.json passes openapi linter"""
 

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -3,7 +3,6 @@ from ..utils import UIClient
 
 
 @pytest.mark.standalone_only
-@pytest.mark.api_ui
 def test_api_ui_v1_collection_versions_version_range(ansible_config, uncertifiedv2):
     """Test the ?version_range query parameter."""
     c1, c2 = uncertifiedv2

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -60,6 +60,14 @@ class AnsibleConfigFixture(dict):
     def __init__(self, namespace1, namespace=None):
         self.namespace = namespace
 
+        # workaround for a weird error with the galaxy cli lib ...
+        galaxy_token_fn = os.path.expanduser('~/.ansible/galaxy_token')
+        if not os.path.exists(os.path.dirname(galaxy_token_fn)):
+            os.makedirs(os.path.dirname(galaxy_token_fn))
+        if not os.path.exists(galaxy_token_fn):
+            with open(galaxy_token_fn, 'w') as f:
+                f.write('')
+
     def __repr__(self):
         return f'<AnsibleConfigFixture: {self.namespace}>'
 

--- a/galaxy_ng/tests/integration/constants.py
+++ b/galaxy_ng/tests/integration/constants.py
@@ -3,3 +3,6 @@
 USERNAME_ADMIN = "ansible-insights"
 USERNAME_CONSUMER = "autohubtest3"
 USERNAME_PUBLISHER = "autohubtest2"
+
+# time.sleep() seconds for checks that wait once
+SLEEP_SECONDS_ONETIME = 3

--- a/galaxy_ng/tests/integration/utils.py
+++ b/galaxy_ng/tests/integration/utils.py
@@ -15,6 +15,8 @@ from subprocess import run
 from urllib.parse import urljoin
 import shutil
 import subprocess
+import requests
+from urllib.parse import urlparse
 
 from ansible import context
 from ansible.galaxy.api import GalaxyAPI
@@ -580,3 +582,191 @@ def build_collection(
         pre_build=pre_build,
         extra_files=extra_files
     )
+
+
+class UIClient:
+
+    """ An HTTP client to mimic the UI """
+
+    _rs = None
+
+    def __init__(self, username=None, password=None, baseurl=None, authurl=None, config=None):
+        self.username = username
+        self.password = password
+        self.baseurl = baseurl
+        self.authurl = authurl
+        self.config = config
+
+        # default to config settings ...
+        if self.config is not None and not self.username:
+            self.username = self.config.get('username')
+        if self.config is not None and not self.password:
+            self.password = self.config.get('password')
+        if self.config is not None and not self.baseurl:
+            self.baseurl = self.config.get('url')
+        if self.config is not None and not self.authurl:
+            self.authurl = self.config.get('auth_url')
+
+        self.login_url = self.baseurl + '_ui/v1/auth/login/'
+        self.logout_url = self.baseurl + '_ui/v1/auth/logout/'
+
+    @property
+    def cookies(self):
+        return dict(self._rs.cookies)
+
+    def __enter__(self):
+        self.login()
+        return self
+
+    def __exit__(self, a, b, c):
+        self.logout()
+
+    def login(self):
+        self._rs = requests.Session()
+
+        # GET the page to acquire the csrftoken
+        self._rs.get(self.login_url)
+
+        # parse the cookies
+        cookies = self.cookies
+
+        # now POST the credentials
+        pheaders = {
+            'Cookie': f"csrftoken={cookies['csrftoken']}",
+            'X-CSRFToken': cookies['csrftoken']
+        }
+        self._rs.post(
+            self.login_url,
+            headers=pheaders,
+            json={'username': self.username, 'password': self.password}
+        )
+
+    def logout(self, expected_code=None):
+
+        if self._rs is None:
+            raise Exception('client is not authenticated')
+
+        # POST to the logout url with the cookie and sesionid
+        cookies = self.cookies
+        pheaders = {
+            'Content-Type': 'application/json',
+            'Cookie': f"csrftoken={cookies['csrftoken']}; sessionid={cookies['sessionid']}",
+            'X-CSRFToken': cookies['csrftoken']
+        }
+        res = self._rs.post(self.logout_url, json={}, headers=pheaders)
+
+        if expected_code is not None:
+            if res.status_code != expected_code:
+                raise Exception(f'logout status code was not {expected_code}')
+
+    def get(self, relative_url: str = None, absolute_url: str = None) -> requests.models.Response:
+
+        pheaders = {
+            'Accept': 'application/json',
+        }
+
+        # send cookies whenever possible ...
+        if self.cookies is not None:
+            cookie = []
+            if self.cookies.get('csrftoken'):
+                cookie.append(f"csrftoken={self.cookies['csrftoken']}")
+            if self.cookies.get('sessionid'):
+                cookie.append(f"sessionid={self.cookies['sessionid']}")
+            pheaders['Cookie'] = '; '.join(cookie)
+
+        this_url = None
+        if absolute_url:
+            uri = urlparse(self.baseurl)
+            this_url = f"{uri.scheme}://{uri.netloc}{absolute_url}"
+        else:
+            this_url = self.baseurl + relative_url
+
+        # get the response
+        resp = self._rs.get(this_url, headers=pheaders)
+        return resp
+
+    def get_paginated(self, relative_url: str = None, absolute_url: str = None) -> list:
+        """Iterate through all results in a paginated queryset"""
+        if absolute_url:
+            resp = self.get(absolute_url=absolute_url)
+        else:
+            resp = self.get(relative_url)
+
+        ds = resp.json()
+        key = 'results'
+        if 'data' in ds:
+            key = 'data'
+            results = ds['data']
+        else:
+            results = ds['results']
+
+        next_url = ds['links']['next']
+        while next_url:
+            if next_url.startswith(urlparse(self.baseurl).path):
+                next_resp = self.get(absolute_url=next_url)
+            else:
+                next_resp = self.get(next_url)
+            _ds = next_resp.json()
+            results.extend(_ds[key])
+            next_url = _ds['links']['next']
+
+        return results
+
+    def post(self, relative_url: str, payload: dict) -> requests.models.Response:
+        pheaders = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+
+        # send cookies whenever possible ...
+        if self.cookies is not None:
+            cookie = []
+            if self.cookies.get('csrftoken'):
+                pheaders['X-CSRFToken'] = self.cookies['csrftoken']
+                cookie.append(f"csrftoken={self.cookies['csrftoken']}")
+            if self.cookies.get('sessionid'):
+                cookie.append(f"sessionid={self.cookies['sessionid']}")
+            pheaders['Cookie'] = '; '.join(cookie)
+
+        # get the response
+        resp = self._rs.post(self.baseurl + relative_url, json=payload, headers=pheaders)
+        return resp
+
+    def put(self, relative_url: str, payload: dict) -> requests.models.Response:
+        pheaders = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+
+        # send cookies whenever possible ...
+        if self.cookies is not None:
+            cookie = []
+            if self.cookies.get('csrftoken'):
+                pheaders['X-CSRFToken'] = self.cookies['csrftoken']
+                cookie.append(f"csrftoken={self.cookies['csrftoken']}")
+            if self.cookies.get('sessionid'):
+                cookie.append(f"sessionid={self.cookies['sessionid']}")
+            pheaders['Cookie'] = '; '.join(cookie)
+
+        # get the response
+        resp = self._rs.put(self.baseurl + relative_url, json=payload, headers=pheaders)
+        return resp
+
+    def delete(self, relative_url: str) -> requests.models.Response:
+        pheaders = {
+            'Accept': 'application/json',
+        }
+
+        # send cookies whenever possible ...
+        if self.cookies is not None:
+            cookie = []
+            if self.cookies.get('csrftoken'):
+                pheaders['X-CSRFToken'] = self.cookies['csrftoken']
+                cookie.append(f"csrftoken={self.cookies['csrftoken']}")
+            if self.cookies.get('sessionid'):
+                cookie.append(f"sessionid={self.cookies['sessionid']}")
+            pheaders['Cookie'] = '; '.join(cookie)
+
+        # get the response
+        resp = self._rs.delete(self.baseurl + relative_url, headers=pheaders)
+        return resp

--- a/galaxy_ng/tests/integration/utils.py
+++ b/galaxy_ng/tests/integration/utils.py
@@ -623,6 +623,7 @@ class UIClient:
 
     def login(self):
         self._rs = requests.Session()
+        self._rs.verify = False
 
         # GET the page to acquire the csrftoken
         self._rs.get(self.login_url)
@@ -633,7 +634,8 @@ class UIClient:
         # now POST the credentials
         pheaders = {
             'Cookie': f"csrftoken={cookies['csrftoken']}",
-            'X-CSRFToken': cookies['csrftoken']
+            'X-CSRFToken': cookies['csrftoken'],
+            'Referer': self.login_url,
         }
         self._rs.post(
             self.login_url,
@@ -651,7 +653,8 @@ class UIClient:
         pheaders = {
             'Content-Type': 'application/json',
             'Cookie': f"csrftoken={cookies['csrftoken']}; sessionid={cookies['sessionid']}",
-            'X-CSRFToken': cookies['csrftoken']
+            'X-CSRFToken': cookies['csrftoken'],
+            'Referer': self.login_url,
         }
         res = self._rs.post(self.logout_url, json={}, headers=pheaders)
 
@@ -715,7 +718,8 @@ class UIClient:
     def post(self, relative_url: str, payload: dict) -> requests.models.Response:
         pheaders = {
             'Accept': 'application/json',
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'Referer': self.login_url
         }
 
         # send cookies whenever possible ...
@@ -755,6 +759,7 @@ class UIClient:
     def delete(self, relative_url: str) -> requests.models.Response:
         pheaders = {
             'Accept': 'application/json',
+            'Referer': self.login_url
         }
 
         # send cookies whenever possible ...


### PR DESCRIPTION
No-Issue

Fix `stable-4.5` CI issues and set `continue-on-error: false`

Issues:
- UIClient was missing (Started happening from https://github.com/ansible/galaxy_ng/pull/1604)
-  Skip `test_galaxy_openapi_validation` (https://github.com/ansible/galaxy_ng/pull/1616)