### PR TITLE
AAP2.2 compatibility

### DIFF
--- a/CHANGES/2362.misc
+++ b/CHANGES/2362.misc
@@ -1,0 +1,1 @@
+Adapt integration tests to be run against an AH from a pre-RBAC AAP installation (AAP 2.2)

--- a/galaxy_ng/tests/integration/api/test_api_base.py
+++ b/galaxy_ng/tests/integration/api/test_api_base.py
@@ -1,6 +1,9 @@
+import pytest
+
 from ..utils import get_client
 
 
+@pytest.mark.min_hub_version("4.6dev")
 def test_galaxy_api_root(ansible_config, artifact):
     """Test galaxy API root."""
 
@@ -25,3 +28,26 @@ def test_galaxy_api_root(ansible_config, artifact):
 
     pulp_root = api_client(api_prefix + '/' + response['available_versions']['pulp-v3'])
     assert "tasks" in pulp_root
+
+
+@pytest.mark.max_hub_version("4.5.5")
+def test_galaxy_api_root_v_4_5(ansible_config, artifact):
+    """Test galaxy API root."""
+
+    # TODO: change to `basic_user` profile when can access pulp-v3 api root
+    config = ansible_config("admin")
+    api_prefix = config.get("api_prefix")
+    api_prefix = api_prefix.rstrip("/")
+
+    api_client = get_client(
+        config=config,
+        request_token=True,
+        require_auth=True
+    )
+
+    # verify api root works
+    response = api_client(api_prefix + '/')
+    assert "v3" in response["available_versions"]
+
+    v3_root = api_client(api_prefix + '/' + response['available_versions']['v3'])
+    assert "published" in v3_root

--- a/galaxy_ng/tests/integration/api/test_artifact_download.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_download.py
@@ -5,9 +5,8 @@ from unittest.mock import patch
 
 import pytest
 from orionutils.generator import build_collection, randstr
-from pkg_resources import parse_version
 
-from ..conftest import get_hub_version
+from ..conftest import is_hub_4_5
 from ..constants import USERNAME_PUBLISHER
 from ..utils import (
     CapturingGalaxyError,
@@ -47,11 +46,8 @@ def test_download_artifact(ansible_config, upload_artifact):
             resp = wait_for_task(api_client, resp)
             assert resp["state"] == "completed"
 
-    hub_version = get_hub_version(ansible_config)
-    very_old = False
-    if parse_version(hub_version) < parse_version('4.6'):
-        very_old = True
-    set_certification(api_client, artifact, very_old=very_old)
+    hub_4_5 = is_hub_4_5(ansible_config)
+    set_certification(api_client, artifact, hub_4_5=hub_4_5)
 
     # download collection
     config = ansible_config("basic_user")

--- a/galaxy_ng/tests/integration/api/test_artifact_upload.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_upload.py
@@ -9,7 +9,7 @@ from orionutils.generator import build_collection, randstr
 from pkg_resources import parse_version
 
 from galaxy_ng.tests.integration.constants import USERNAME_PUBLISHER
-from ..conftest import get_hub_version
+from ..conftest import get_hub_version, is_hub_4_5
 
 from ..utils import (
     CapturingGalaxyError,
@@ -65,9 +65,8 @@ def test_api_publish(ansible_config, artifact, upload_artifact, use_distribution
     # inbound repos aren't created anymore. This will create one to verify that they still
     # work on legacy clients
     if use_distribution:
-        hub_version = get_hub_version(ansible_config)
-        if parse_version(hub_version) < parse_version('4.6'):
-            pytest.skip(f"Hub version is {hub_version}")
+        if is_hub_4_5(ansible_config):
+            pytest.skip("Hub version is 4.5")
         admin_client = get_client(ansible_config(profile="admin"))
         distros = admin_client("pulp/api/v3/distributions/ansible/"
                                f"ansible/?name=inbound-{artifact.namespace}")

--- a/galaxy_ng/tests/integration/api/test_artifact_upload.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_upload.py
@@ -6,10 +6,9 @@ from unittest.mock import patch
 
 import pytest
 from orionutils.generator import build_collection, randstr
-from pkg_resources import parse_version
 
 from galaxy_ng.tests.integration.constants import USERNAME_PUBLISHER
-from ..conftest import get_hub_version, is_hub_4_5
+from ..conftest import is_hub_4_5
 
 from ..utils import (
     CapturingGalaxyError,

--- a/galaxy_ng/tests/integration/api/test_collection_signing.py
+++ b/galaxy_ng/tests/integration/api/test_collection_signing.py
@@ -445,9 +445,12 @@ def test_upload_signature(config, require_auth, settings, upload_artifact):
     staging_has_gpgkey = False
     for distribution in distributions["data"]:
         if distribution["name"] == "staging":
-            if distribution["repository"]["gpgkey"]:
-                staging_has_gpgkey = True
-                break
+            try:
+                if distribution["repository"]["gpgkey"]:
+                    staging_has_gpgkey = True
+                    break
+            except KeyError:
+                pass
 
     if not staging_has_gpgkey:
         pytest.skip("Staging repository doesn't have a gpgkey")

--- a/galaxy_ng/tests/integration/api/test_groups.py
+++ b/galaxy_ng/tests/integration/api/test_groups.py
@@ -32,6 +32,7 @@ API_PREFIX = CLIENT_CONFIG.get("api_prefix").rstrip("/")
 @pytest.mark.role
 @pytest.mark.pulp_api
 @pytest.mark.standalone_only
+@pytest.mark.min_hub_version("4.6dev")
 def test_group_role_listing(ansible_config, test_data):
     """Tests ability to list roles assigned to a namespace."""
 

--- a/galaxy_ng/tests/integration/api/test_locked_roles.py
+++ b/galaxy_ng/tests/integration/api/test_locked_roles.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.qa  # noqa: F821
 
 @pytest.mark.standalone_only
 @pytest.mark.role
+@pytest.mark.min_hub_version("4.6dev")
 def test_locked_roles_exist(ansible_config):
     config = ansible_config("admin")
     api_client = get_client(

--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -5,11 +5,10 @@ See: https://issues.redhat.com/browse/AAH-1268
 """
 import pytest
 from orionutils.generator import build_collection
-from pkg_resources import parse_version
 
 from galaxykit.collections import upload_artifact
 from galaxykit.utils import wait_for_task as gk_wait_for_task
-from ..conftest import get_hub_version
+from ..conftest import is_hub_4_5
 from ..constants import USERNAME_PUBLISHER
 from ..utils import (
     copy_collection_version,
@@ -80,11 +79,8 @@ def test_move_collection_version(ansible_config, galaxy_client):
     assert ckey not in before['published']
 
     # Certify and check the response...
-    hub_version = get_hub_version(ansible_config)
-    very_old = False
-    if parse_version(hub_version) < parse_version('4.6'):
-        very_old = True
-    cert_result = set_certification(api_client, artifact, very_old=very_old)
+    hub_4_5 = is_hub_4_5(ansible_config)
+    cert_result = set_certification(api_client, artifact, hub_4_5=hub_4_5)
 
     assert cert_result['namespace']['name'] == artifact.namespace
     assert cert_result['name'] == artifact.name

--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -5,9 +5,11 @@ See: https://issues.redhat.com/browse/AAH-1268
 """
 import pytest
 from orionutils.generator import build_collection
+from pkg_resources import parse_version
 
 from galaxykit.collections import upload_artifact
 from galaxykit.utils import wait_for_task as gk_wait_for_task
+from ..conftest import get_hub_version
 from ..constants import USERNAME_PUBLISHER
 from ..utils import (
     copy_collection_version,
@@ -78,7 +80,12 @@ def test_move_collection_version(ansible_config, galaxy_client):
     assert ckey not in before['published']
 
     # Certify and check the response...
-    cert_result = set_certification(api_client, artifact)
+    hub_version = get_hub_version(ansible_config)
+    very_old = False
+    if parse_version(hub_version) < parse_version('4.6'):
+        very_old = True
+    cert_result = set_certification(api_client, artifact, very_old=very_old)
+
     assert cert_result['namespace']['name'] == artifact.namespace
     assert cert_result['name'] == artifact.name
     assert cert_result['version'] == artifact.version

--- a/galaxy_ng/tests/integration/api/test_openapi.py
+++ b/galaxy_ng/tests/integration/api/test_openapi.py
@@ -70,6 +70,7 @@ def test_galaxy_openapi_validation(ansible_config):
 
 
 @pytest.mark.openapi
+@pytest.mark.min_hub_version("4.6dev")
 def test_pulp_openapi_has_variables(ansible_config):
     """Tests whether openapi.json has valid path names for pulp"""
 

--- a/galaxy_ng/tests/integration/api/test_pulp_api.py
+++ b/galaxy_ng/tests/integration/api/test_pulp_api.py
@@ -14,6 +14,7 @@ REGEX_40X = r"HTTP Code: 40\d"
 
 @pytest.mark.standalone_only
 @pytest.mark.pulp_api
+@pytest.mark.min_hub_version("4.6dev")
 def test_pulp_api_redirect(ansible_config, artifact):
     """Test that /pulp/ is redirecting to /api/galaxy/pulp/"""
 
@@ -48,6 +49,7 @@ def test_pulp_api_redirect(ansible_config, artifact):
     ],
 )
 @pytest.mark.pulp_api
+@pytest.mark.min_hub_version("4.6dev")
 def test_pulp_endpoint_readonly(ansible_config, artifact, url):
     """Ensure authenticated user has readonly access to view"""
 
@@ -82,6 +84,7 @@ TEST_ROLE_NAME = "test_role_".join(random.choices(string.ascii_lowercase, k=10))
 )
 @pytest.mark.pulp_api
 @pytest.mark.standalone_only
+@pytest.mark.min_hub_version("4.6dev")
 def test_pulp_roles_endpoint(ansible_config, require_auth):
     config = ansible_config("admin")
     api_prefix = config.get("api_prefix").rstrip("/")

--- a/galaxy_ng/tests/integration/api/test_remote_sync.py
+++ b/galaxy_ng/tests/integration/api/test_remote_sync.py
@@ -17,6 +17,7 @@ REQUIREMENTS_FILE = "collections:\n  - name: newswangerd.collection_demo\n    ve
 # /api/automation-hub/content/community/v3/sync/config/
 # /api/automation-hub/content/community/v3/sync/
 @pytest.mark.standalone_only
+@pytest.mark.min_hub_version("4.6dev")
 def test_api_ui_v1_remote_sync(ansible_config):
 
     cfg = ansible_config("admin")

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -161,6 +161,7 @@ def test_api_ui_v1_collection_versions_version_range(ansible_config, uncertified
 # /api/automation-hub/_ui/v1/distributions/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
+@pytest.mark.min_hub_version("4.6dev")
 def test_api_ui_v1_distributions(ansible_config):
     cfg = ansible_config('basic_user')
     with UIClient(config=cfg) as uclient:
@@ -192,6 +193,7 @@ def test_api_ui_v1_distributions(ansible_config):
 # /api/automation-hub/_ui/v1/distributions/{pulp_id}/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
+@pytest.mark.min_hub_version("4.6dev")
 def test_api_ui_v1_distributions_by_id(ansible_config):
 
     cfg = ansible_config('basic_user')
@@ -222,6 +224,7 @@ def test_api_ui_v1_distributions_by_id(ansible_config):
 # /api/automation-hub/_ui/v1/execution-environments/registries/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
+@pytest.mark.this
 def test_api_ui_v1_execution_environments_registries(ansible_config):
 
     cfg = ansible_config('ee_admin')
@@ -316,6 +319,7 @@ def local_container():
 # /api/automation-hub/_ui/v1/feature-flags/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
+@pytest.mark.min_hub_version("4.6dev")
 def test_api_ui_v1_feature_flags(ansible_config):
 
     cfg = ansible_config('basic_user')
@@ -536,6 +540,7 @@ def test_api_ui_v1_me(ansible_config):
 # /api/automation-hub/_ui/v1/my-namespaces/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
+@pytest.mark.min_hub_version("4.6dev")
 def test_api_ui_v1_my_namespaces(ansible_config):
     config = ansible_config("partner_engineer")
     api_client = get_client(config, request_token=True, require_auth=True)
@@ -593,6 +598,7 @@ def test_api_ui_v1_my_namespaces(ansible_config):
 # /api/automation-hub/_ui/v1/my-namespaces/{name}/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
+@pytest.mark.min_hub_version("4.6dev")
 def test_api_ui_v1_my_namespaces_name(ansible_config):
     cfg = ansible_config('partner_engineer')
     with UIClient(config=cfg) as uclient:
@@ -706,6 +712,7 @@ def test_api_ui_v1_collection_detail_view(ansible_config, published):
 # /api/automation-hub/_ui/v1/settings/
 @pytest.mark.standalone_only
 @pytest.mark.api_ui
+@pytest.mark.min_hub_version("4.6dev")
 def test_api_ui_v1_settings(ansible_config):
 
     cfg = ansible_config('basic_user')

--- a/galaxy_ng/tests/integration/cli/test_dependencies.py
+++ b/galaxy_ng/tests/integration/cli/test_dependencies.py
@@ -3,9 +3,8 @@ import logging
 
 import attr
 import pytest
-from pkg_resources import parse_version
 
-from ..conftest import get_hub_version
+from ..conftest import is_hub_4_5
 from ..utils import ansible_galaxy, build_collection, get_client, set_certification
 
 pytestmark = pytest.mark.qa  # noqa: F821
@@ -70,11 +69,8 @@ def test_collection_dependency_install(ansible_config, published, cleanup_collec
     if retcode == 0:
         config = ansible_config("partner_engineer")
         client = get_client(config)
-        hub_version = get_hub_version(ansible_config)
-        very_old = False
-        if parse_version(hub_version) < parse_version('4.6'):
-            very_old = True
-        set_certification(client, artifact2, very_old=very_old)
+        hub_4_5 = is_hub_4_5(ansible_config)
+        set_certification(client, artifact2, hub_4_5=hub_4_5)
 
         pid = ansible_galaxy(
             f"collection install -vvv --ignore-cert \

--- a/galaxy_ng/tests/integration/cli/test_dependencies.py
+++ b/galaxy_ng/tests/integration/cli/test_dependencies.py
@@ -3,7 +3,9 @@ import logging
 
 import attr
 import pytest
+from pkg_resources import parse_version
 
+from ..conftest import get_hub_version
 from ..utils import ansible_galaxy, build_collection, get_client, set_certification
 
 pytestmark = pytest.mark.qa  # noqa: F821
@@ -20,6 +22,7 @@ class DependencySpec:
 
 
 @pytest.mark.cli
+# @pytest.mark.min_hub_version("4.6dev")
 @pytest.mark.parametrize(
     "params",
     (
@@ -67,7 +70,11 @@ def test_collection_dependency_install(ansible_config, published, cleanup_collec
     if retcode == 0:
         config = ansible_config("partner_engineer")
         client = get_client(config)
-        set_certification(client, artifact2)
+        hub_version = get_hub_version(ansible_config)
+        very_old = False
+        if parse_version(hub_version) < parse_version('4.6'):
+            very_old = True
+        set_certification(client, artifact2, very_old=very_old)
 
         pid = ansible_galaxy(
             f"collection install -vvv --ignore-cert \

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -370,12 +370,8 @@ def published(ansible_config, artifact):
     )
 
     # certify
-    hub_version = get_hub_version(ansible_config)
-    very_old = False
-    if parse_version(hub_version) < parse_version('4.6'):
-        very_old = True
-
-    set_certification(api_client, artifact, very_old=very_old)
+    hub_4_5 = is_hub_4_5(ansible_config)
+    set_certification(api_client, artifact, hub_4_5=hub_4_5)
 
     return artifact
 
@@ -401,11 +397,8 @@ def certifiedv2(ansible_config, artifact):
     )
 
     # certify v1
-    hub_version = get_hub_version(ansible_config)
-    very_old = False
-    if parse_version(hub_version) < parse_version('4.6'):
-        very_old = True
-    set_certification(api_client, artifact, very_old=very_old)
+    hub_4_5 = is_hub_4_5(ansible_config)
+    set_certification(api_client, artifact, hub_4_5=hub_4_5)
 
     # Increase collection version
     new_version = increment_version(artifact.version)
@@ -423,11 +416,7 @@ def certifiedv2(ansible_config, artifact):
     )
 
     # certify newer version
-    hub_version = get_hub_version(ansible_config)
-    very_old = False
-    if parse_version(hub_version) < parse_version('4.6'):
-        very_old = True
-    set_certification(api_client, artifact2, very_old=very_old)
+    set_certification(api_client, artifact2, hub_4_5=hub_4_5)
 
     return (artifact, artifact2)
 
@@ -453,11 +442,8 @@ def uncertifiedv2(ansible_config, artifact):
     )
 
     # certify v1
-    hub_version = get_hub_version(ansible_config)
-    very_old = False
-    if parse_version(hub_version) < parse_version('4.6'):
-        very_old = True
-    set_certification(api_client, artifact, very_old=very_old)
+    hub_4_5 = is_hub_4_5(ansible_config)
+    set_certification(api_client, artifact, hub_4_5=hub_4_5)
 
     # Increase collection version
     new_version = increment_version(artifact.version)
@@ -822,3 +808,8 @@ def min_hub_version(ansible_config, spec):
 def max_hub_version(ansible_config, spec):
     version = get_hub_version(ansible_config)
     return Requirement.parse(f"galaxy_ng>{spec}").specifier.contains(version)
+
+
+def is_hub_4_5(ansible_config):
+    hub_version = get_hub_version(ansible_config)
+    return parse_version(hub_version) < parse_version('4.6')

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -74,7 +74,6 @@ x_repo_search: tests verifying cross-repo search endpoint
 repositories: tests verifying custom repositories
 """
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -219,7 +218,8 @@ class AnsibleConfigFixture(dict):
     def _set_profile_from_vault(self, loader, profile, param):
         param_vault_path = self.PROFILES[profile][param]["vault_path"]
         param_vault_key = self.PROFILES[profile][param]["vault_key"]
-        param_from_vault = loader.get_value_from_vault(path=param_vault_path, key=param_vault_key)
+        param_from_vault = loader.get_value_from_vault(path=param_vault_path,
+                                                       key=param_vault_key)
         self.PROFILES[profile][param] = param_from_vault
 
     def __repr__(self):
@@ -353,7 +353,6 @@ def get_ansible_config_sync():
 
 @pytest.fixture(scope="function")
 def published(ansible_config, artifact):
-
     # make sure the expected namespace exists ...
     config = ansible_config("partner_engineer")
     api_prefix = config.get("api_prefix")
@@ -371,7 +370,12 @@ def published(ansible_config, artifact):
     )
 
     # certify
-    set_certification(api_client, artifact)
+    hub_version = get_hub_version(ansible_config)
+    very_old = False
+    if parse_version(hub_version) < parse_version('4.6'):
+        very_old = True
+
+    set_certification(api_client, artifact, very_old=very_old)
 
     return artifact
 
@@ -397,7 +401,11 @@ def certifiedv2(ansible_config, artifact):
     )
 
     # certify v1
-    set_certification(api_client, artifact)
+    hub_version = get_hub_version(ansible_config)
+    very_old = False
+    if parse_version(hub_version) < parse_version('4.6'):
+        very_old = True
+    set_certification(api_client, artifact, very_old=very_old)
 
     # Increase collection version
     new_version = increment_version(artifact.version)
@@ -415,7 +423,11 @@ def certifiedv2(ansible_config, artifact):
     )
 
     # certify newer version
-    set_certification(api_client, artifact2)
+    hub_version = get_hub_version(ansible_config)
+    very_old = False
+    if parse_version(hub_version) < parse_version('4.6'):
+        very_old = True
+    set_certification(api_client, artifact2, very_old=very_old)
 
     return (artifact, artifact2)
 
@@ -441,7 +453,11 @@ def uncertifiedv2(ansible_config, artifact):
     )
 
     # certify v1
-    set_certification(api_client, artifact)
+    hub_version = get_hub_version(ansible_config)
+    very_old = False
+    if parse_version(hub_version) < parse_version('4.6'):
+        very_old = True
+    set_certification(api_client, artifact, very_old=very_old)
 
     # Increase collection version
     new_version = increment_version(artifact.version)
@@ -573,7 +589,10 @@ def get_galaxy_client(ansible_config):
 
 
 def pytest_sessionstart(session):
-    hub_version = get_hub_version(get_ansible_config())
+    ansible_config = get_ansible_config()
+    hub_version = get_hub_version(ansible_config)
+    if not is_standalone() and not is_ephemeral_env() and not is_dev_env_standalone():
+        set_test_data(ansible_config, hub_version)
     logger.debug(f"Running tests against hub version {hub_version}")
 
 
@@ -696,6 +715,78 @@ def set_credentials_when_not_docker_pah(url):
     AnsibleConfigFixture.PROFILES["admin"]["token"] = token
 
 
+def set_test_data(ansible_config, hub_version):
+    role = "admin"
+    gc = GalaxyKitClient(ansible_config).gen_authorized_client(role)
+    gc.create_group("ns_group_for_tests")
+    gc.create_group("system:partner-engineers")
+    gc.create_group("ee_group_for_tests")
+    pe_roles = [
+        "galaxy.group_admin",
+        "galaxy.user_admin",
+        "galaxy.collection_admin",
+    ]
+    gc.get_or_create_user(username="iqe_normal_user", password="Th1sP4ssd", group=None)
+    gc.get_or_create_user(username="org-admin", password="Th1sP4ssd", group=None)
+    gc.get_or_create_user(username="jdoe", password="Th1sP4ssd", group=None)
+    gc.get_or_create_user(username="ee_admin", password="Th1sP4ssd", group=None)
+    ns_group_id = get_group_id(gc, group_name="ns_group_for_tests")
+    gc.add_user_to_group(username="iqe_normal_user", group_id=ns_group_id)
+    gc.add_user_to_group(username="org-admin", group_id=ns_group_id)
+    gc.add_user_to_group(username="jdoe", group_id=ns_group_id)
+    pe_group_id = get_group_id(gc, group_name="system:partner-engineers")
+    if parse_version(hub_version) < parse_version('4.6'):
+        pe_permissions = ["galaxy.view_group",
+                          "galaxy.delete_group",
+                          "galaxy.add_group",
+                          "galaxy.change_group",
+                          "galaxy.view_user",
+                          "galaxy.delete_user",
+                          "galaxy.add_user",
+                          "galaxy.change_user",
+                          "ansible.delete_collection",
+                          "galaxy.delete_namespace",
+                          "galaxy.add_namespace",
+                          "ansible.modify_ansible_repo_content",
+                          "ansible.view_ansiblerepository",
+                          "ansible.add_ansiblerepository",
+                          "ansible.change_ansiblerepository",
+                          "ansible.delete_ansiblerepository",
+                          "galaxy.change_namespace",
+                          "galaxy.upload_to_namespace",
+                          ]
+        gc.set_permissions("system:partner-engineers", pe_permissions)
+    else:
+        for rbac_role in pe_roles:
+            try:
+                gc.add_role_to_group(rbac_role, pe_group_id)
+            except GalaxyClientError:
+                # role already assigned to group. It's ok.
+                pass
+
+    gc.add_user_to_group(username="jdoe", group_id=pe_group_id)
+    gc.create_namespace(name="autohubtest2", group="ns_group_for_tests",
+                        object_roles=["galaxy.collection_namespace_owner"])
+    gc.create_namespace(name="autohubtest3", group="ns_group_for_tests",
+                        object_roles=["galaxy.collection_namespace_owner"])
+
+    ee_group_id = get_group_id(gc, group_name="ee_group_for_tests")
+    ee_role = 'galaxy.execution_environment_admin'
+    if parse_version(hub_version) < parse_version('4.6'):
+        ee_permissions = ["container.delete_containerrepository",
+                          "galaxy.add_containerregistryremote",
+                          "galaxy.change_containerregistryremote",
+                          "galaxy.delete_containerregistryremote"]
+        gc.set_permissions("ee_group_for_tests", ee_permissions)
+    else:
+        try:
+            gc.add_role_to_group(ee_role, ee_group_id)
+        except GalaxyClientError:
+            # role already assigned to group. It's ok.
+            pass
+    gc.add_user_to_group(username="ee_admin", group_id=ee_group_id)
+
+
 @lru_cache()
 def get_hub_version(ansible_config):
     if is_standalone():
@@ -715,49 +806,8 @@ def get_hub_version(ansible_config):
         AnsibleConfigFixture.PROFILES["partner_engineer"]["token"] = pe_token_bck
         return galaxy_ng_version
     elif not is_dev_env_standalone():
-        # if we are here, we need to create some test data
-        # (same as dev/common/setup_test_data.py)
         role = "admin"
         set_credentials_when_not_docker_pah(ansible_config().get("url"))
-        gc = GalaxyKitClient(ansible_config).gen_authorized_client(role)
-        gc.create_group("ns_group_for_tests")
-        gc.create_group("system:partner-engineers")
-        gc.create_group("ee_group_for_tests")
-        pe_roles = [
-            "galaxy.group_admin",
-            "galaxy.user_admin",
-            "galaxy.collection_admin",
-        ]
-        gc.get_or_create_user(username="iqe_normal_user", password="Th1sP4ssd", group=None)
-        gc.get_or_create_user(username="org-admin", password="Th1sP4ssd", group=None)
-        gc.get_or_create_user(username="jdoe", password="Th1sP4ssd", group=None)
-        gc.get_or_create_user(username="ee_admin", password="Th1sP4ssd", group=None)
-        ns_group_id = get_group_id(gc, group_name="ns_group_for_tests")
-        gc.add_user_to_group(username="iqe_normal_user", group_id=ns_group_id)
-        gc.add_user_to_group(username="org-admin", group_id=ns_group_id)
-        gc.add_user_to_group(username="jdoe", group_id=ns_group_id)
-        pe_group_id = get_group_id(gc, group_name="system:partner-engineers")
-        for rbac_role in pe_roles:
-            try:
-                gc.add_role_to_group(rbac_role, pe_group_id)
-            except GalaxyClientError:
-                # role already assigned to group. It's ok.
-                pass
-
-        gc.add_user_to_group(username="jdoe", group_id=pe_group_id)
-        gc.create_namespace(name="autohubtest2", group="ns_group_for_tests",
-                            object_roles=["galaxy.collection_namespace_owner"])
-        gc.create_namespace(name="autohubtest3", group="ns_group_for_tests",
-                            object_roles=["galaxy.collection_namespace_owner"])
-
-        ee_group_id = get_group_id(gc, group_name="ee_group_for_tests")
-        ee_role = 'galaxy.execution_environment_admin'
-        try:
-            gc.add_role_to_group(ee_role, ee_group_id)
-        except GalaxyClientError:
-            # role already assigned to group. It's ok.
-            pass
-        gc.add_user_to_group(username="ee_admin", group_id=ee_group_id)
     else:
         role = "admin"
     gc = GalaxyKitClient(ansible_config).gen_authorized_client(role)

--- a/galaxy_ng/tests/integration/utils/collections.py
+++ b/galaxy_ng/tests/integration/utils/collections.py
@@ -343,12 +343,29 @@ def get_collection_full_path(namespace, collection_name):
     return os.path.join(get_collections_namespace_path(namespace), collection_name)
 
 
-def set_certification(client, collection, level="published"):
+def set_certification(client, collection, level="published", very_old=False):
     """Moves a collection from the `staging` to the `published` repository.
 
     For use in instances that use repository-based certification and that
     do not have auto-certification enabled.
     """
+
+    if very_old:
+        if client.config["use_move_endpoint"]:
+            url = (
+                f"v3/collections/{collection.namespace}/{collection.name}/versions/"
+                f"{collection.version}/move/staging/published/"
+            )
+
+            client(url, method="POST", args=b"{}")
+
+            # no task url in response from above request, so can't intelligently wait.
+            # so we'll just sleep for 1 second and hope the certification is done by then.
+            dest_url = (
+                f"v3/collections/{collection.namespace}/"
+                f"{collection.name}/versions/{collection.version}/"
+            )
+            return wait_for_url(client, dest_url)
 
     # exit early if config is set to auto approve
     if not client.config["use_move_endpoint"]:

--- a/galaxy_ng/tests/integration/utils/collections.py
+++ b/galaxy_ng/tests/integration/utils/collections.py
@@ -343,24 +343,20 @@ def get_collection_full_path(namespace, collection_name):
     return os.path.join(get_collections_namespace_path(namespace), collection_name)
 
 
-def set_certification(client, collection, level="published", very_old=False):
+def set_certification(client, collection, level="published", hub_4_5=False):
     """Moves a collection from the `staging` to the `published` repository.
 
     For use in instances that use repository-based certification and that
     do not have auto-certification enabled.
     """
 
-    if very_old:
+    if hub_4_5:
         if client.config["use_move_endpoint"]:
             url = (
                 f"v3/collections/{collection.namespace}/{collection.name}/versions/"
                 f"{collection.version}/move/staging/published/"
             )
-
             client(url, method="POST", args=b"{}")
-
-            # no task url in response from above request, so can't intelligently wait.
-            # so we'll just sleep for 1 second and hope the certification is done by then.
             dest_url = (
                 f"v3/collections/{collection.namespace}/"
                 f"{collection.name}/versions/{collection.version}/"


### PR DESCRIPTION
This is to make galaxy_ng tests comptatible with AAP 2.2 (hub 4.5):

* skip tests
* replace roles with permissions (pre-rbac hub)

Issue: AAH-2362
