### PR TITLE
[stable-4.7] Backport missing `clear_fuzzy_entries.sh` script

### DIFF
--- a/.github/workflows/scripts/clear_fuzzy_entries.sh
+++ b/.github/workflows/scripts/clear_fuzzy_entries.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+for lang in galaxy_ng/locale/* ; do
+  msgattrib --clear-fuzzy --empty -o $lang/LC_MESSAGES/django.po $lang/LC_MESSAGES/django.po
+done


### PR DESCRIPTION
No-Issue

https://github.com/ansible/galaxy_ng/actions/runs/5140730182 

The script failed, because I forgot to add/backport `clear_fuzzy_entries.sh` script to older branches in https://github.com/ansible/galaxy_ng/pull/1683. 
