### PR TITLE
[i18n] Remove stable-4.4 from matrix

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         branch:
         - 'master'
-        - 'stable-4.4'
         - 'stable-4.5'
         - 'stable-4.6'
         - 'stable-4.7'


### PR DESCRIPTION
No-Issue

Fix https://github.com/ansible/galaxy_ng/pull/1758 wasn't backported to `stable-4.4`, so removing it from translation matrix.   
