### PR TITLE
Add readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# RTD API version
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+   install:
+   - requirements: ./docs_requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,4 @@ exclude mkdocs.yml
 exclude netlify.toml
 exclude docs
 exclude docs_requirements.txt
+exclude .readthedocs.yaml


### PR DESCRIPTION
No-Issue

#### What is this PR doing:
This adds configuration to build Galaxy NG docs on Read The Docs.

#### Reviewers must know:

Test build from my fork: https://oranod-galaxy-ng.readthedocs.io/en/latest/
Build logs: https://readthedocs.org/api/v2/build/20986040.txt
