### PR TITLE
Bool or str

### DIFF
--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -332,7 +332,7 @@ def test_api_ui_v1_feature_flags(ansible_config):
         validate_json(instance=ds, schema=schema_featureflags)
 
         # assert ds['ai_deny_index'] is False
-        assert ds['execution_environments'] in [True or 'True']
+        assert ds['execution_environments'] in [True, 'True']
         assert ds['legacy_roles'] is False
 
 

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -332,7 +332,7 @@ def test_api_ui_v1_feature_flags(ansible_config):
         validate_json(instance=ds, schema=schema_featureflags)
 
         # assert ds['ai_deny_index'] is False
-        assert ds['execution_environments'] is True
+        assert ds['execution_environments'] in [True or 'True']
         assert ds['legacy_roles'] is False
 
 

--- a/galaxy_ng/tests/integration/schemas.py
+++ b/galaxy_ng/tests/integration/schemas.py
@@ -158,7 +158,12 @@ schema_featureflags = {
         'can_upload_signatures': {'type': 'boolean'},
         'collection_auto_sign': {'type': 'boolean'},
         'display_signatures': {'type': 'boolean'},
-        'execution_environments': {'type': 'boolean'},
+        'execution_environments': {
+            'anyOf': [
+                {'type': 'string'},
+                {'type': 'boolean'}
+            ]
+        },
         'container_signing': {'type': 'boolean'},
         'ai_deny_index': {'type': 'boolean'},
         '_messages': {'type': 'array'},


### PR DESCRIPTION
the feature-flags endpoint return true or 'True' for execution_environments depending on the AAP operator on openshift

```
AAP 2.3, galaxy_ng 4.6.5
GET /api/galaxy/_ui/v1/feature-flags/
{
    "legacy_roles": false,
    "execution_environments": "True",
    ...
}
AAP 2.4 galaxy_ng 4.7.1
GET /api/galaxy/_ui/v1/feature-flags/

{
    "legacy_roles": false,
    "execution_environments": true,
    ...
}
```

with this change, we cover both cases and make the tests pass