### PR TITLE
Redirect docs from netlify to RTD

### DIFF
--- a/CHANGES/2409.misc
+++ b/CHANGES/2409.misc
@@ -1,0 +1,1 @@
+Move documentation from netlify to RTD

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To learn more about Pulp, [view the Pulp project page](https://pulpproject.org/)
 
 ## Documentation
 
-Project documentation is hosted on [netlify](https://galaxyng.netlify.app/).
+Project documentation is hosted on [Read The Docs](http://galaxy-ng.readthedocs.io/).
 
 ## OpenAPI Spec
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,9 @@ PYTHON_VERSION = "3.8"
 
 [context.deploy-preview]
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF"
+
+[[redirects]]
+  from = "/*"
+  to = "https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
Docs are now hosted on http://galaxy-ng.readthedocs.io/ this PR sets redirects from old site to the new location

Issue: AAH-2409
