### PR TITLE
copy_expert is deprecated in django 4.x + psycopg

### DIFF
--- a/galaxy_ng/app/management/commands/analytics-export-local.py
+++ b/galaxy_ng/app/management/commands/analytics-export-local.py
@@ -1,0 +1,30 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from galaxy_ng.app.management.commands.analytics.collector import LocalCollector
+from galaxy_ng.app.management.commands.analytics import galaxy_collector
+from django.utils.timezone import now, timedelta
+
+logger = logging.getLogger("analytics")
+
+
+class Command(BaseCommand):
+    """Django management command to export collections data to local disk"""
+
+    def handle(self, *args, **options):
+        """Handle command"""
+
+        collector = LocalCollector(
+            collector_module=galaxy_collector,
+            collection_type="manual",
+            logger=logger,
+        )
+
+        collector.gather(since=now() - timedelta(days=8), until=now() - timedelta(days=1))
+
+        print("Completed ")
+
+
+if __name__ == "__main__":
+    cmd = Command()
+    cmd.handle()

--- a/galaxy_ng/app/management/commands/analytics/collector.py
+++ b/galaxy_ng/app/management/commands/analytics/collector.py
@@ -1,7 +1,8 @@
 from django.db import connection
 
 from insights_analytics_collector import Collector as BaseCollector
-from galaxy_ng.app.management.commands.analytics.package import Package
+from galaxy_ng.app.management.commands.analytics.package import S3Package
+from galaxy_ng.app.management.commands.analytics.package import LocalPackage
 
 
 class Collector(BaseCollector):
@@ -16,7 +17,7 @@ class Collector(BaseCollector):
 
     @staticmethod
     def _package_class():
-        return Package
+        return S3Package
 
     def get_last_gathering(self):
         return self._last_gathering()
@@ -44,3 +45,10 @@ class Collector(BaseCollector):
     def _save_last_gather(self):
         # doing a full scan database dump
         pass
+
+
+class LocalCollector(Collector):
+
+    @staticmethod
+    def _package_class():
+        return LocalPackage

--- a/galaxy_ng/app/management/commands/analytics/galaxy_collector.py
+++ b/galaxy_ng/app/management/commands/analytics/galaxy_collector.py
@@ -222,9 +222,28 @@ def _simple_csv(full_path, file_name, query, max_data_size=209715200):
     file_path = _get_file_path(full_path, file_name)
     tfile = _get_csv_splitter(file_path, max_data_size)
 
-    with Collector.db_connection().cursor() as cursor:
-        cursor.copy_expert(query, tfile)
+    # copy_expert nor copy_to nor COPY are supported by psycopg
+    query = query.replace('\n', ' ')
+    query = query.replace('    ', '')
+    query = query.replace('COPY (', '')
+    query = query.replace(') TO STDOUT WITH CSV HEADER', '')
+    query = query.strip()
 
+    # use a normal .execute to get the data as rows ...
+    with Collector.db_connection().cursor() as cursor:
+        cursor.execute(query)
+        column_names = [col[0] for col in cursor.description]
+        rows = cursor.fetchall()
+
+    # csv'ify the data ...
+    csv_data = ','.join(column_names) + '\n'
+    for row in rows:
+        csv_data += ','.join([str(x) for x in row]) + '\n'
+
+    # do what copy_expert would have done ...
+    tfile.write(csv_data)
+
+    # return the tmp file path as identified by the splitter
     return tfile.file_list()
 
 

--- a/galaxy_ng/tests/integration/management_commands/test_analytics_command.py
+++ b/galaxy_ng/tests/integration/management_commands/test_analytics_command.py
@@ -1,0 +1,41 @@
+import pytest
+
+import subprocess
+
+
+def run_api_container_command(cmd):
+    cmd = f'./compose exec api /bin/bash -c "{cmd}"'
+    pid = subprocess.run(
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT
+    )
+    return pid.returncode, pid.stdout.decode('utf-8')
+
+
+@pytest.mark.community_only
+def test_analytics_export_local_command(auto_approved_artifacts):
+    """
+    Validate the analytics export with the local version so that
+    we don't need real or mocked S3 to check it's basic function.
+    """
+
+    # run the export command ...
+    export_rc, export_log = run_api_container_command('pulpcore-manager analytics-export-local')
+    assert export_rc == 0
+
+    # extract tarball filepath from the output ...
+    lines = export_log.split('\n')
+    tarfile = [x for x in lines if 'data has been saved to:' in x][0]
+    tarfile = tarfile.split()[-1]
+
+    # verify it exists ...
+    exists_rc, exists_output = run_api_container_command(f'test -f {tarfile} && echo \"exists\"')
+    assert exists_rc == 0
+
+    # verify it has some content ...
+    listing_rc, listing_output = run_api_container_command(f'tar tzvf {tarfile}')
+    assert listing_rc == 0
+    content = listing_output.split('\n')
+    content = [x for x in content if x.startswith('-r')]


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-2408

We need a way to validate this code without having s3 in the mix, so there's a new command to just copy the generated tarball to a new folder in /tmp. We can later look at adding minio to the compose stack and have the s3 based command copy there, but we'll need to revise the Package code to allow for a different s3 host url ... but that's beyond the scope of this particular PR.