### PR TITLE
skip content signing tests in container verification pipelines

### DIFF
--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -17,6 +17,7 @@ from ..utils import (
     wait_for_task,
     wait_for_url,
 )
+from ..utils.iqe_utils import is_ocp_env
 
 pytestmark = pytest.mark.qa  # noqa: F821
 
@@ -192,6 +193,7 @@ def test_copy_collection_version(ansible_config, galaxy_client):
 
 @pytest.mark.standalone_only
 @pytest.mark.min_hub_version("4.7dev")
+@pytest.mark.skipif(is_ocp_env(), reason="Content signing not enabled in AAP Operator")
 def test_copy_associated_content(ansible_config, galaxy_client):
     """Tests whether a collection and associated content is copied from repo to repo"""
 

--- a/galaxy_ng/tests/integration/api/test_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_repositories.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from galaxy_ng.tests.integration.utils.iqe_utils import is_ocp_env
 from galaxy_ng.tests.integration.utils.rbac_utils import upload_test_artifact
 
 from galaxy_ng.tests.integration.utils.repo_management_utils import (
@@ -125,6 +126,7 @@ class TestRepositories:
 
     @pytest.mark.repositories
     @pytest.mark.standalone_only
+    @pytest.mark.skipif(is_ocp_env(), reason="Content signing not enabled in AAP Operator")
     def test_copy_signed_cv_endpoint(self, galaxy_client):
         """
         Verifies a signed cv can be copied to a different repo
@@ -165,6 +167,7 @@ class TestRepositories:
 
     @pytest.mark.repositories
     @pytest.mark.standalone_only
+    @pytest.mark.skipif(is_ocp_env(), reason="Content signing not enabled in AAP Operator")
     def test_move_signed_cv_endpoint(self, galaxy_client):
         """
         Verifies a signed cv can be moved to a different repo

--- a/galaxy_ng/tests/integration/api/test_x_repo_search.py
+++ b/galaxy_ng/tests/integration/api/test_x_repo_search.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from galaxy_ng.tests.integration.utils.iqe_utils import is_ocp_env
 from galaxy_ng.tests.integration.utils.rbac_utils import add_new_user_to_new_group
 
 from galaxy_ng.tests.integration.utils.repo_management_utils import (
@@ -554,6 +555,7 @@ class TestXRepoSearch:
 
     @pytest.mark.parametrize("is_signed", [True, False])
     @pytest.mark.x_repo_search
+    @pytest.mark.skipif(is_ocp_env(), reason="Content signing not enabled in AAP Operator")
     def test_search_by_is_signed_true_false(self, galaxy_client, is_signed):
         """
         Verifies that search endpoint can search by is_signed

--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -215,6 +215,13 @@ def is_ephemeral_env():
     )
 
 
+def is_ocp_env():
+    # this check will not be necessary when content signing is enabled in operator
+    return "ocp4.testing.ansible.com" in os.getenv(
+        "HUB_API_ROOT", "http://localhost:5001/api/automation-hub/"
+    )
+
+
 def is_stage_environment():
     return os.getenv("TESTS_AGAINST_STAGE", False)
 


### PR DESCRIPTION
Skipping tests that sign content in CVP pipelines because content signing is not configured in Operator. This issue will be addressed soon and this change will be reverted.

No-Issue