### PR TITLE
Undo set_certification test skips

### DIFF
--- a/dev/insights/RUN_INTEGRATION.sh
+++ b/dev/insights/RUN_INTEGRATION.sh
@@ -10,6 +10,7 @@ set -e
 export HUB_API_ROOT="http://localhost:8080/api/automation-hub/"
 export HUB_AUTH_URL="http://localhost:8080/auth/realms/redhat-external/protocol/openid-connect/token"
 export HUB_USE_MOVE_ENDPOINT="true"
+export HUB_UPLOAD_SIGNATURES="true"
 unset HUB_TOKEN
 
 which virtualenv || pip install --user virtualenv

--- a/galaxy_ng/tests/integration/utils/collections.py
+++ b/galaxy_ng/tests/integration/utils/collections.py
@@ -17,8 +17,6 @@ from urllib.parse import urljoin
 from urllib.parse import urlparse
 from contextlib import contextmanager
 
-import pytest
-
 from ansible.galaxy.api import GalaxyError
 from orionutils.generator import build_collection as _build_collection
 from orionutils.generator import randstr
@@ -349,14 +347,6 @@ def set_certification(client, collection, level="published", hub_4_5=False):
     For use in instances that use repository-based certification and that
     do not have auto-certification enabled.
     """
-
-    # are signatures required?
-    settings = client("_ui/v1/settings/")
-    if settings.get("GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL"):
-        pytest.skip(
-            "FIXME: set_certification function incompatible with"
-            + " GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL."
-        )
 
     if hub_4_5:
         if client.config["use_move_endpoint"]:


### PR DESCRIPTION
The real issue was that the insights docker profile needed to have HUB_UPLOAD_SIGNATURES set to true.