### PR TITLE
Fix error where docker tries to pull base image from localhost on M1 macs

### DIFF
--- a/docs/dev/oci_env.md
+++ b/docs/dev/oci_env.md
@@ -31,6 +31,14 @@ This will launch galax_ng from source (see `DEV_SOURCE_PATH`) using the galaxy_n
 
 Other profiles are available under the `profiles/` directory.
 
+### M1 Macs
+
+If you are using ARM, you'll need to use the `galaxy_ng:m1` profile along with the base profile.
+
+```
+COMPOSE_PROFILE=galaxy_ng/base:galaxy_ng/m1
+```
+
 ## Develop using keycloak, insights mode and ldap
 
 Profiles for all of these modes are available from galaxy_ng. Simply add them to your `COMPOSE_PROFILE`:

--- a/profiles/m1/README.md
+++ b/profiles/m1/README.md
@@ -1,0 +1,10 @@
+# galaxy_ng/m1
+
+## Usage
+
+This profile fixes a bug when running on M1 Macs where docker compose builds the pulp base image for x86
+and then attempts to build any other images from the pulp base image for arm64, which is incompatible
+with x86 base images.
+
+This has to be a separate profile because the `platforms` arg in compose.yaml is not supported on older
+versions of docker-compose or podman, that are used on x86 machines.

--- a/profiles/m1/compose.yaml
+++ b/profiles/m1/compose.yaml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  _galaxy_base:
+    build:
+      context: "{SRC_DIR}/galaxy_ng/"
+      dockerfile: "profiles/base/Dockerfile"
+
+      # This is necesary for M1 Macs. The localhost/oci_env/pulp:base gets built
+      # as amd64 for some reason. This service builds off of that image and
+      # attempts to build it as arm64. By doing so, it tries to find a local
+      # localhost/oci_env/pulp:base arm64 image, fails and then tries to pull
+      # the image from the localhost registry.
+      platforms:
+        - "linux/amd64"
+

--- a/profiles/m1/profile_requirements.txt
+++ b/profiles/m1/profile_requirements.txt
@@ -1,0 +1,1 @@
+galaxy_ng/base


### PR DESCRIPTION
Since the base image is tagged with localhost, docker occasionally tries to pull the image from a non-existant registry running on localhost:80