### PR TITLE
Bump to pulp_ansible 0.19.0

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -315,7 +315,7 @@ psycopg[binary]==3.1.9
     # via pulpcore
 psycopg-binary==3.1.9
     # via psycopg
-pulp-ansible==0.18.0
+pulp-ansible==0.19.0
     # via galaxy-ng (setup.py)
 pulp-container==2.15.1
     # via galaxy-ng (setup.py)

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -326,7 +326,7 @@ psycopg[binary]==3.1.9
     # via pulpcore
 psycopg-binary==3.1.9
     # via psycopg
-pulp-ansible==0.18.0
+pulp-ansible==0.19.0
     # via galaxy-ng (setup.py)
 pulp-container==2.15.1
     # via galaxy-ng (setup.py)

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -315,7 +315,7 @@ psycopg[binary]==3.1.9
     # via pulpcore
 psycopg-binary==3.1.9
     # via psycopg
-pulp-ansible==0.18.0
+pulp-ansible==0.19.0
     # via galaxy-ng (setup.py)
 pulp-container==2.15.1
     # via galaxy-ng (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ def _format_pulp_requirement(plugin, specifier=None, ref=None, gh_namespace="pul
 requirements = [
     "galaxy-importer>=0.4.11,<0.5.0",
     "pulpcore>=3.28.1,<3.40.0",
-    "pulp_ansible>=0.18.0,<0.19.0",
+    "pulp_ansible>=0.19.0,<0.20.0",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
     "pulp-container>=2.15.0,<2.17.0",


### PR DESCRIPTION
Brings in the download counter and the optimizations for namespace metadata.