### PR TITLE
Remove lru caching on get_access_policy for memory performance concerns.

### DIFF
--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from functools import lru_cache
 
 from django.conf import settings
 from django.contrib.auth.models import Permission
@@ -122,7 +121,6 @@ class AccessPolicyBase(AccessPolicyFromDB):
     NAME = None
 
     @classmethod
-    @lru_cache
     def get_access_policy(cls, view):
         statements = GALAXY_STATEMENTS
 


### PR DESCRIPTION
https://github.com/pulp/pulpcore/pull/4090

We subclass and override the get_access_policy function, so pulp's upstream change probably won't directly help us.