### PR TITLE
use updated jedi dependency

### DIFF
--- a/CHANGES/2615.misc
+++ b/CHANGES/2615.misc
@@ -1,0 +1,1 @@
+Use updated jedi dependency.

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -11,6 +11,4 @@ orionutils
 fauxfactory
 
 # used by shell_plus
-jedi==0.17.2
-# jedi 0.18.x is buggy when used with ipython
-# ^ https://github.com/ipython/ipython/issues/12740#issuecomment-751273584
+jedi


### PR DESCRIPTION
Issue: AAH-2615

The jedi issues have been fixed, so we don't have to use the old version anymore.