### PR TITLE
add LegacyRoleImport model to store galaxy-importer logs for legacy imports

### DIFF
--- a/docker/etc/settings.py
+++ b/docker/etc/settings.py
@@ -159,6 +159,11 @@ LOGGING = {
             "class": "pulp_ansible.app.logutils.CollectionImportHandler",
             "formatter": "simple",
         },
+        "legacy_role_import": {
+            "level": "DEBUG",
+            "class": "galaxy_ng.app.api.v1.log.LegacyRoleImportHandler",
+            "formatter": "simple"
+        }
 
     },
     'root': {
@@ -191,6 +196,11 @@ LOGGING = {
             "handlers": ["collection_import"],
             "propagate": False,
         },
+        "galaxy_ng.app.api.v1.tasks.legacy_role_import": {
+            "level": "DEBUG",
+            "handlers": ["legacy_role_import"],
+            "propagate": False
+        }
     }
 }
 LOGGING["handlers"].update(_extra_handlers)

--- a/galaxy_ng/app/api/v1/log.py
+++ b/galaxy_ng/app/api/v1/log.py
@@ -1,0 +1,16 @@
+import logging
+
+
+class LegacyRoleImportHandler(logging.Handler):
+    """Logging handler for legacy role imports using galaxy-importer."""
+
+    def emit(self, record: logging.LogRecord):
+        """
+        Store the log record into the `LegacyRoleImport.logs` field of the current task.
+        """
+        from .models import LegacyRoleImport
+        from pulpcore.plugin.models import Task
+
+        legacy_role_import = LegacyRoleImport.objects.get(task=Task.current().pulp_id)
+        legacy_role_import.add_log_record(record)
+        legacy_role_import.save()

--- a/galaxy_ng/app/api/v1/models.py
+++ b/galaxy_ng/app/api/v1/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from pulpcore.plugin.models import Task
 
 from galaxy_ng.app.models import Namespace
 from galaxy_ng.app.models.auth import User
@@ -157,3 +158,22 @@ class LegacyRoleDownloadCount(models.Model):
     )
 
     count = models.IntegerField(default=0)
+
+
+class LegacyRoleImport(models.Model):
+    """The legacy role import task with galaxy-importer/ansible-lint messages."""
+
+    task = models.OneToOneField(
+        Task,
+        on_delete=models.CASCADE,
+        editable=False,
+        related_name="+",
+        primary_key=True
+    )
+
+    logs = models.JSONField(default=list, editable=False)
+
+    def add_log_record(self, log_record):
+        self.logs.append(
+            {"message": log_record.msg, "level": log_record.levelname, "time": log_record.created}
+        )


### PR DESCRIPTION
When a legacy role is imported, galaxy-importer calls ansible-lint on the role. Currently, those logs remain unused by galaxy_ng, but ideally, they will be accessible and shown to users when they import a legacy role.

This PR largely mirrors how collection import logs are handled by pulp_ansible. A new `LegacyRoleImport` model is created for each legacy role import task. A `LegacyRoleImportHandler` which inherits from `logging.Handler` will emit all log records into the corresponding `LegacyRoleImport` model.