### PR TITLE
fix jinja templating call from ah collection workflow

### DIFF
--- a/.github/workflows/ci_automation_hub_collection.yml
+++ b/.github/workflows/ci_automation_hub_collection.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           # The ansible.cfg defined in the collection repository might break the test. We want the same variables for installation and running.
           rm -f ansible.cfg
+          rm -f galaxy.yml
+          mv .github/files/galaxy.yml.j2 .
           ansible all -i localhost, -c local -m template -a "src=galaxy.yml.j2 dest=galaxy.yml" -e collection_namespace=ansible -e collection_name=automation_hub -e collection_version=1.0.0 -e collection_repo=https://github.com/ansible/automation_hub_collection
           ansible-galaxy collection build -vvv
           ansible-galaxy collection install ansible-automation_hub-1.0.0.tar.gz -vvv

--- a/dev/ah_collection_plays/content.yml
+++ b/dev/ah_collection_plays/content.yml
@@ -13,14 +13,14 @@
   
   tasks:
     - name: Authenticate and retrieve API token
-      ansible.automation_hub.ah_token:
+      ah_token:
         ah_host: "{{ ah_host }}"
         ah_username: "{{ ah_username }}"
         ah_password: "{{ ah_password }}"
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Create the automate namespace
-      ansible.automation_hub.ah_namespace:
+      ah_namespace:
         name: automate
         company: Automator Inc.
         email: automator@redhat.com
@@ -30,7 +30,7 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Rename automate namespace to automator
-      ansible.automation_hub.ah_namespace:
+      ah_namespace:
         name: automate
         new_name: automator
         ah_host: "{{ ah_host }}"
@@ -38,7 +38,7 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Delete the automator namespace
-      ansible.automation_hub.ah_namespace:
+      ah_namespace:
         state: absent
         name: automator
         ah_host: "{{ ah_host }}"
@@ -46,14 +46,14 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Ensure there is an ansible namespace
-      ansible.automation_hub.ah_namespace:
+      ah_namespace:
         name: ansible
         ah_host: "{{ ah_host }}"
         ah_token: "{{ ah_token }}"
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Upload the automation hub collection to the ansible namespace
-      ansible.automation_hub.ah_collection:
+      ah_collection:
         namespace: ansible
         name: automation_hub
         path: "{{ ah_artifact_runner_absolute_path }}"
@@ -63,7 +63,7 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Approve the automation hub collection
-      ansible.automation_hub.ah_approval:
+      ah_approval:
         namespace: ansible
         name: automation_hub
         version: "1.0.0"
@@ -72,7 +72,7 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Delete the automation hub collection
-      ansible.automation_hub.ah_collection:
+      ah_collection:
         state: absent
         namespace: ansible
         name: automation_hub
@@ -82,7 +82,7 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Deauthenticate
-      ansible.automation_hub.ah_token:
+      ah_token:
         state: absent
         ah_host: "{{ ah_host }}"
         ah_token: "{{ ah_token }}"

--- a/dev/ah_collection_plays/ee.yml
+++ b/dev/ah_collection_plays/ee.yml
@@ -13,7 +13,7 @@
   
   tasks:
     - name: Add redhat.io registry
-      ansible.automation_hub.ah_ee_registry:
+      ah_ee_registry:
         name: redhat
         url: registry.redhat.io
         ah_host: "{{ ah_host }}"
@@ -24,7 +24,7 @@
         # Can be uncommented after AAH-2607 is resolved.
         #
         #    - name: Index redhat.io registry
-        #      ansible.automation_hub.ah_ee_registry_index:
+        #      ah_ee_registry_index:
         #        name: redhat
         #        ah_host: "{{ ah_host }}"
         #        ah_username: "{{ ah_username }}"
@@ -32,7 +32,7 @@
         #        ah_path_prefix: "{{ ah_path_prefix }}"
         #
         #    - name: Update aap22ee29rhel8 ee repository
-        #      ansible.automation_hub.ah_ee_repository:
+        #      ah_ee_repository:
         #        name: ansible-automation-platform-22/ee-29-rhel8
         #        description: AAP RHEL execution environment
         #        readme: |
@@ -44,7 +44,7 @@
         #        ah_path_prefix: "{{ ah_path_prefix }}"
         #
         #    - name: Delete the aap22ee29rhel8 repository
-        #      ansible.automation_hub.ah_ee_repository:
+        #      ah_ee_repository:
         #        name: ansible-automation-platform-22/ee-29-rhel8
         #        state: absent
         #        ah_host: "{{ ah_host }}"
@@ -53,7 +53,7 @@
         #        ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Delete the redhat.io registry
-      ansible.automation_hub.ah_ee_registry:
+      ah_ee_registry:
         name: redhat
         state: absent
         ah_host: "{{ ah_host }}"

--- a/dev/ah_collection_plays/repo.yml
+++ b/dev/ah_collection_plays/repo.yml
@@ -13,14 +13,14 @@
   
   tasks:
     - name: Authenticate and retrieve API token
-      ansible.automation_hub.ah_token:
+      ah_token:
         ah_host: "{{ ah_host }}"
         ah_username: "{{ ah_username }}"
         ah_password: "{{ ah_password }}"
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Configure community repository
-      ansible.automation_hub.ah_repository:
+      ah_repository:
         name: community
         url: https://galaxy.ansible.com/api/
         requirements:
@@ -31,14 +31,14 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Sync community repository
-      ansible.automation_hub.ah_repository_sync:
+      ah_repository_sync:
         name: community
         ah_host: "{{ ah_host }}"
         ah_token: "{{ ah_token }}"
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Deauthenticate
-      ansible.automation_hub.ah_token:
+      ah_token:
         ah_host: "{{ ah_host }}"
         ah_token: "{{ ah_token }}"
         ah_path_prefix: "{{ ah_path_prefix }}"

--- a/dev/ah_collection_plays/user.yml
+++ b/dev/ah_collection_plays/user.yml
@@ -13,7 +13,7 @@
   
   tasks:
     - name: Create a developers group
-      ansible.automation_hub.ah_group:
+      ah_group:
         name: developers
         ah_host: "{{ ah_host }}"
         ah_username: "{{ ah_username }}"
@@ -21,7 +21,7 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Add 3 new users who are developers
-      ansible.automation_hub.ah_user:
+      ah_user:
         username: "dev_{{ item }}"
         password: password!@3w6$%
         first_name: Developer
@@ -38,7 +38,7 @@
         - blue
 
     - name: Create an executives group
-      ansible.automation_hub.ah_group:
+      ah_group:
         name: executives
         ah_host: "{{ ah_host }}"
         ah_username: "{{ ah_username }}"
@@ -46,7 +46,7 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Create an omnipotent role with all permissions
-      ansible.automation_hub.ah_role:
+      ah_role:
         name: galaxy.omnipotent
         description: Manage anything and everything
         perms: all
@@ -59,7 +59,7 @@
 # https://github.com/ansible/automation_hub_collection/issues/179 is resolved.
 
     - name: Create new executive users
-      ansible.automation_hub.ah_user:
+      ah_user:
         username: "{{ item }}"
         password: executive!@3w6$%
         is_superuser: true
@@ -77,7 +77,7 @@
         - cto
 
     - name: Delete the red developer
-      ansible.automation_hub.ah_user:
+      ah_user:
         state: absent
         username: dev_red
         ah_host: "{{ ah_host }}"
@@ -86,7 +86,7 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
 
     - name: Delete the developers and executives groups
-      ansible.automation_hub.ah_group:
+      ah_group:
         state: absent
         name: "{{ item }}"
         ah_host: "{{ ah_host }}"
@@ -98,7 +98,7 @@
         - executives
 
     - name: Delete the omnipotent role
-      ansible.automation_hub.ah_role:
+      ah_role:
         state: absent
         name: galaxy.omnipotent
         ah_host: "{{ ah_host }}"


### PR DESCRIPTION
~~The automation hub collection now has a true `galaxy.yml` file in the repository, so the workflow no longer must create the `galaxy.yml`~~