### PR TITLE
Add retries to move cv call in test.

### DIFF
--- a/galaxy_ng/tests/integration/api/test_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_repositories.py
@@ -110,7 +110,24 @@ class TestRepositories:
         add_content_units(gc_admin, content_units, repo_pulp_href_1)
 
         test_repo_name_2 = f"repo-test-{generate_random_string()}"
-        repo_pulp_href_2 = create_repo_and_dist(gc_admin, test_repo_name_2)
+
+        # FIXME - the POST call will often result in an error with the oci+insights profile ...
+        # root:client.py:216 Cannot parse expected JSON response
+        # (http://localhost:38080/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/):
+        # Post "http://pulp:55001/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/":
+        # read tcp 172.18.0.2:47338->172.18.0.3:55001: read: connection reset by peer
+        repo_pulp_href_2 = None
+        retries = 10
+        for x in range(0, retries):
+            try:
+                repo_pulp_href_2 = create_repo_and_dist(gc_admin, test_repo_name_2)
+                break
+            except Exception as e:
+                print(e)
+                time.sleep(5)
+
+        if repo_pulp_href_2 is None:
+            raise Exception("failed to create repo and dist")
 
         # FIXME - the POST call will often result in an error with the oci+insights profile ...
         # root:client.py:216 Cannot parse expected JSON response

--- a/galaxy_ng/tests/integration/api/test_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_repositories.py
@@ -112,6 +112,14 @@ class TestRepositories:
         test_repo_name_2 = f"repo-test-{generate_random_string()}"
         repo_pulp_href_2 = create_repo_and_dist(gc_admin, test_repo_name_2)
 
+        # FIXME - the POST call will often result in an error with the oci+insights profile ...
+        # root:client.py:216 Cannot parse expected JSON response
+        # (http://localhost:38080/api/<prefix>/pulp/api/v3/repositories/ansible/ansible/
+        #   <uuid>/move_collection_version/):
+        # Post "http://pulp:55001/api/<prefix>/pulp/api/v3/repositories/ansible/ansible/
+        #   <uuid>/move_collection_version/":
+        # readfrom tcp 172.18.0.3:37490->172.18.0.2:55001:
+        #   write tcp 172.18.0.3:37490->172.18.0.2:55001: use of closed network connection
         retries = 10
         for x in range(0, retries):
             try:

--- a/galaxy_ng/tests/integration/api/test_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_repositories.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import time
 
 from galaxy_ng.tests.integration.utils.iqe_utils import is_ocp_env
 from galaxy_ng.tests.integration.utils.rbac_utils import upload_test_artifact
@@ -111,7 +112,17 @@ class TestRepositories:
         test_repo_name_2 = f"repo-test-{generate_random_string()}"
         repo_pulp_href_2 = create_repo_and_dist(gc_admin, test_repo_name_2)
 
-        move_content_between_repos(gc_admin, content_units, repo_pulp_href_1, [repo_pulp_href_2])
+        retries = 10
+        for x in range(0, retries):
+            try:
+                move_content_between_repos(
+                    gc_admin, content_units, repo_pulp_href_1, [repo_pulp_href_2]
+                )
+                break
+            except Exception as e:
+                print(e)
+                time.sleep(5)
+
         # verify cv is only in destination repo
         _, results = search_collection_endpoint(gc_admin, name=artifact.name)
         expected = [{"cv_name": artifact.name, "repo_name": test_repo_name_2, "is_signed": False}]


### PR DESCRIPTION
The  mock insights proxy occasionally has trouble reading/writing to the nginx service and results in a broken pipe error. This PR attempts to retry 2 problematic calls that make tests regularly fail in github actions.

The failures can be reproduced locally by starting up the oci insights profile and running test_move_cv in a loop. It seems to happen less often on my local system than it does on github, but I'm chalking that up to resource constraints in the action workers.