### PR TITLE
Update all dependencies.

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -33,7 +33,6 @@ attrs==22.2.0
     #   aiohttp
     #   galaxy-importer
     #   jsonschema
-    #   referencing
 backoff==2.2.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -65,11 +64,11 @@ charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.6
+click==8.1.3
     # via
     #   black
     #   pulpcore
-cryptography==41.0.3
+cryptography==41.0.1
     # via
     #   ansible-core
     #   pulpcore
@@ -109,7 +108,7 @@ django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
 django-filter==23.2
     # via pulpcore
-django-guid==3.3.1
+django-guid==3.3.0
     # via pulpcore
 django-import-export==3.2.0
     # via pulpcore
@@ -133,7 +132,7 @@ drf-access-policy==1.5.0
     # via pulpcore
 drf-nested-routers==0.93.4
     # via pulpcore
-drf-spectacular==0.26.4
+drf-spectacular==0.26.2
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
@@ -169,7 +168,7 @@ googleapis-common-protos==1.60.0
     #   opentelemetry-exporter-otlp-proto-http
 grpcio==1.57.0
     # via opentelemetry-exporter-otlp-proto-grpc
-gunicorn==21.2.0
+gunicorn==20.1.0
     # via pulpcore
 idna==3.4
     # via
@@ -191,15 +190,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.18.6
+jsonschema==4.17.3
     # via
     #   ansible-builder
     #   ansible-lint
     #   drf-spectacular
     #   pulp-ansible
     #   pulp-container
-jsonschema-specifications==2023.7.1
-    # via jsonschema
 markdown==3.4.4
     # via galaxy-importer
 markdown-it-py==3.0.0
@@ -230,7 +227,7 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opentelemetry-api==1.19.0
+opentelemetry-api==1.18.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -239,47 +236,47 @@ opentelemetry-api==1.19.0
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-distro[otlp]==0.40b0
+opentelemetry-distro[otlp]==0.39b0
     # via pulpcore
-opentelemetry-exporter-otlp==1.19.0
+opentelemetry-exporter-otlp==1.18.0
     # via opentelemetry-distro
-opentelemetry-exporter-otlp-proto-common==1.19.0
+opentelemetry-exporter-otlp-proto-common==1.18.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.19.0
+opentelemetry-exporter-otlp-proto-grpc==1.18.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.19.0
+opentelemetry-exporter-otlp-proto-http==1.18.0
     # via
     #   opentelemetry-exporter-otlp
     #   pulpcore
-opentelemetry-instrumentation==0.40b0
+opentelemetry-instrumentation==0.39b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.40b0
+opentelemetry-instrumentation-django==0.39b0
     # via pulpcore
-opentelemetry-instrumentation-wsgi==0.40b0
+opentelemetry-instrumentation-wsgi==0.39b0
     # via
     #   opentelemetry-instrumentation-django
     #   pulpcore
-opentelemetry-proto==1.19.0
+opentelemetry-proto==1.18.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.19.0
+opentelemetry-sdk==1.18.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.40b0
+opentelemetry-semantic-conventions==0.39b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.40b0
+opentelemetry-util-http==0.39b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
@@ -291,7 +288,6 @@ packaging==23.1
     #   black
     #   bleach
     #   django-lifecycle
-    #   gunicorn
     #   marshmallow
     #   pulp-glue
 parsley==1.3
@@ -309,22 +305,22 @@ platformdirs==3.10.0
     # via black
 prometheus-client==0.17.1
     # via django-prometheus
-protobuf==4.23.4
+protobuf==4.23.2
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   pulpcore
-psycopg[binary]==3.1.10
+psycopg[binary]==3.1.9
     # via pulpcore
-psycopg-binary==3.1.10
+psycopg-binary==3.1.9
     # via psycopg
 pulp-ansible==0.19.0
     # via galaxy-ng (setup.py)
-pulp-container==2.16.0
+pulp-container==2.15.2
     # via galaxy-ng (setup.py)
-pulp-glue==0.21.2
+pulp-glue==0.19.5
     # via pulpcore
-pulpcore==3.30.0
+pulpcore==3.28.10
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -351,15 +347,17 @@ pygtrie==2.5.0
     # via pulpcore
 pyjwkest==1.4.2
     # via pulp-container
-pyjwt[crypto]==2.8.0
+pyjwt[crypto]==2.7.0
     # via
     #   pulp-container
     #   social-auth-core
 pyparsing==3.1.1
     # via drf-access-policy
+pyrsistent==0.19.3
+    # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-python-gnupg==0.5.1
+python-gnupg==0.5.0
     # via pulpcore
 python-ldap==3.4.3
     # via django-auth-ldap
@@ -367,7 +365,7 @@ python3-openid==3.2.0
     # via social-auth-core
 pytz==2023.3
     # via djangorestframework
-pyyaml==6.0.1
+pyyaml==6.0
     # via
     #   ansible-builder
     #   ansible-core
@@ -378,12 +376,8 @@ pyyaml==6.0.1
     #   pulpcore
     #   tablib
     #   yamllint
-redis==4.6.0
+redis==4.5.5
     # via pulpcore
-referencing==0.30.2
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   galaxy-importer
@@ -401,10 +395,6 @@ resolvelib==1.0.1
     # via ansible-core
 rich==13.5.2
     # via ansible-lint
-rpds-py==0.9.2
-    # via
-    #   jsonschema
-    #   referencing
 ruamel-yaml==0.17.32
     # via ansible-lint
 ruamel-yaml-clib==0.2.7
@@ -458,7 +448,7 @@ wcmatch==8.4.1
     # via ansible-lint
 webencodings==0.5.1
     # via bleach
-whitenoise==6.5.0
+whitenoise==6.4.0
     # via pulpcore
 wrapt==1.15.0
     # via

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -8,26 +8,24 @@ aiodns==3.0.0
     # via pulpcore
 aiofiles==23.1.0
     # via pulpcore
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via pulpcore
 aiosignal==1.3.1
     # via aiohttp
-ansible-builder==1.2.0
+ansible-builder==3.0.0
     # via galaxy-importer
-ansible-core==2.14.5
+ansible-core==2.15.3
     # via
     #   ansible-lint
     #   galaxy-importer
 ansible-lint==6.14.3
     # via galaxy-importer
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-async-lru==2.0.2
+async-lru==2.0.4
     # via pulp-ansible
-async-timeout==4.0.2
-    # via
-    #   aiohttp
-    #   redis
+async-timeout==4.0.3
+    # via aiohttp
 asyncio-throttle==1.0.2
     # via pulpcore
 attrs==22.2.0
@@ -35,6 +33,7 @@ attrs==22.2.0
     #   aiohttp
     #   galaxy-importer
     #   jsonschema
+    #   referencing
 backoff==2.2.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -42,35 +41,35 @@ backoff==2.2.1
     #   pulpcore
 bindep==2.11.0
     # via ansible-builder
-black==23.3.0
+black==23.7.0
     # via ansible-lint
 bleach==3.3.1
     # via galaxy-importer
 bleach-allowlist==1.0.3
     # via galaxy-importer
-boto3==1.26.132
+boto3==1.28.26
     # via galaxy-ng (setup.py)
-botocore==1.29.132
+botocore==1.31.26
     # via
     #   boto3
     #   s3transfer
 bracex==2.3.post1
     # via wcmatch
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
 cffi==1.15.1
     # via
     #   cryptography
     #   pycares
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.6
     # via
     #   black
     #   pulpcore
-cryptography==39.0.2
+cryptography==41.0.3
     # via
     #   ansible-core
     #   pulpcore
@@ -92,7 +91,7 @@ distro==1.8.0
     # via
     #   bindep
     #   galaxy-ng (setup.py)
-django==4.2.3
+django==4.2.4
     # via
     #   django-auth-ldap
     #   django-filter
@@ -110,9 +109,9 @@ django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
 django-filter==23.2
     # via pulpcore
-django-guid==3.3.0
+django-guid==3.3.1
     # via pulpcore
-django-import-export==3.1.0
+django-import-export==3.2.0
     # via pulpcore
 django-ipware==3.0.7
     # via galaxy-ng (setup.py)
@@ -134,7 +133,7 @@ drf-access-policy==1.5.0
     # via pulpcore
 drf-nested-routers==0.93.4
     # via pulpcore
-drf-spectacular==0.26.2
+drf-spectacular==0.26.4
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
@@ -146,11 +145,11 @@ ecdsa==0.18.0
     # via pulp-container
 et-xmlfile==1.1.0
     # via openpyxl
-filelock==3.12.0
+filelock==3.12.2
     # via ansible-lint
-flake8==6.0.0
+flake8==6.1.0
     # via galaxy-importer
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
@@ -162,15 +161,15 @@ galaxy-importer==0.4.12
     #   pulp-ansible
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.32
     # via pulp-ansible
-googleapis-common-protos==1.59.0
+googleapis-common-protos==1.60.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.54.2
+grpcio==1.57.0
     # via opentelemetry-exporter-otlp-proto-grpc
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via pulpcore
 idna==3.4
     # via
@@ -192,21 +191,24 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.16.0
+jsonschema==4.18.6
     # via
+    #   ansible-builder
     #   ansible-lint
     #   drf-spectacular
     #   pulp-ansible
     #   pulp-container
-markdown==3.4.3
+jsonschema-specifications==2023.7.1
+    # via jsonschema
+markdown==3.4.4
     # via galaxy-importer
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
 markuppy==1.14
     # via tablib
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-marshmallow==3.19.0
+marshmallow==3.20.1
     # via galaxy-ng (setup.py)
 mccabe==0.7.0
     # via flake8
@@ -228,7 +230,7 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opentelemetry-api==1.18.0
+opentelemetry-api==1.19.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -237,47 +239,47 @@ opentelemetry-api==1.18.0
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-distro[otlp]==0.39b0
+opentelemetry-distro[otlp]==0.40b0
     # via pulpcore
-opentelemetry-exporter-otlp==1.18.0
+opentelemetry-exporter-otlp==1.19.0
     # via opentelemetry-distro
-opentelemetry-exporter-otlp-proto-common==1.18.0
+opentelemetry-exporter-otlp-proto-common==1.19.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.18.0
+opentelemetry-exporter-otlp-proto-grpc==1.19.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.18.0
+opentelemetry-exporter-otlp-proto-http==1.19.0
     # via
     #   opentelemetry-exporter-otlp
     #   pulpcore
-opentelemetry-instrumentation==0.39b0
+opentelemetry-instrumentation==0.40b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.39b0
+opentelemetry-instrumentation-django==0.40b0
     # via pulpcore
-opentelemetry-instrumentation-wsgi==0.39b0
+opentelemetry-instrumentation-wsgi==0.40b0
     # via
     #   opentelemetry-instrumentation-django
     #   pulpcore
-opentelemetry-proto==1.18.0
+opentelemetry-proto==1.19.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.18.0
+opentelemetry-sdk==1.19.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.39b0
+opentelemetry-semantic-conventions==0.40b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.39b0
+opentelemetry-util-http==0.40b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
@@ -289,39 +291,40 @@ packaging==23.1
     #   black
     #   bleach
     #   django-lifecycle
+    #   gunicorn
     #   marshmallow
     #   pulp-glue
 parsley==1.3
     # via bindep
-pathspec==0.11.0
+pathspec==0.11.2
     # via
     #   ansible-lint
     #   black
     #   yamllint
 pbr==5.11.1
     # via bindep
-pillow==9.4.0
+pillow==10.0.0
     # via pulp-ansible
-platformdirs==3.5.0
+platformdirs==3.10.0
     # via black
-prometheus-client==0.16.0
+prometheus-client==0.17.1
     # via django-prometheus
-protobuf==4.22.1
+protobuf==4.23.4
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   pulpcore
-psycopg[binary]==3.1.9
+psycopg[binary]==3.1.10
     # via pulpcore
-psycopg-binary==3.1.9
+psycopg-binary==3.1.10
     # via psycopg
 pulp-ansible==0.19.0
     # via galaxy-ng (setup.py)
-pulp-container==2.15.1
+pulp-container==2.16.0
     # via galaxy-ng (setup.py)
-pulp-glue==0.19.1
+pulp-glue==0.21.2
     # via pulpcore
-pulpcore==3.28.10
+pulpcore==3.30.0
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -334,31 +337,29 @@ pyasn1-modules==0.3.0
     # via python-ldap
 pycares==4.3.0
     # via aiodns
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via flake8
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
+pycryptodomex==3.18.0
     # via pyjwkest
-pyflakes==3.0.1
+pyflakes==3.1.0
     # via flake8
-pygments==2.15.1
+pygments==2.16.1
     # via rich
 pygtrie==2.5.0
     # via pulpcore
 pyjwkest==1.4.2
     # via pulp-container
-pyjwt[crypto]==2.5.0
+pyjwt[crypto]==2.8.0
     # via
     #   pulp-container
     #   social-auth-core
-pyparsing==3.0.9
+pyparsing==3.1.1
     # via drf-access-policy
-pyrsistent==0.19.3
-    # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-python-gnupg==0.5.0
+python-gnupg==0.5.1
     # via pulpcore
 python-ldap==3.4.3
     # via django-auth-ldap
@@ -366,7 +367,7 @@ python3-openid==3.2.0
     # via social-auth-core
 pytz==2023.3
     # via djangorestframework
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   ansible-builder
     #   ansible-core
@@ -377,9 +378,13 @@ pyyaml==6.0
     #   pulpcore
     #   tablib
     #   yamllint
-redis==4.5.1
+redis==4.6.0
     # via pulpcore
-requests==2.30.0
+referencing==0.30.2
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+requests==2.31.0
     # via
     #   galaxy-importer
     #   insights-analytics-collector
@@ -392,11 +397,15 @@ requests-oauthlib==1.3.1
     # via social-auth-core
 requirements-parser==0.5.0
     # via ansible-builder
-resolvelib==0.8.1
+resolvelib==1.0.1
     # via ansible-core
-rich==13.3.5
+rich==13.5.2
     # via ansible-lint
-ruamel-yaml==0.17.26
+rpds-py==0.9.2
+    # via
+    #   jsonschema
+    #   referencing
+ruamel-yaml==0.17.32
     # via ansible-lint
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -425,22 +434,19 @@ sqlparse==0.4.4
     # via django
 subprocess-tee==0.4.1
     # via ansible-lint
-tablib[html,ods,xls,xlsx,yaml]==3.4.0
+tablib[html,ods,xls,xlsx,yaml]==3.5.0
     # via django-import-export
-types-cryptography==3.3.23.2
-    # via pyjwt
-types-setuptools==67.7.0.2
+types-setuptools==68.0.0.3
     # via requirements-parser
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via
-    #   async-lru
     #   opentelemetry-sdk
     #   psycopg
 uritemplate==4.1.1
     # via drf-spectacular
 url-normalize==1.4.3
     # via pulpcore
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   requests
@@ -452,7 +458,7 @@ wcmatch==8.4.1
     # via ansible-lint
 webencodings==0.5.1
     # via bleach
-whitenoise==6.4.0
+whitenoise==6.5.0
     # via pulpcore
 wrapt==1.15.0
     # via
@@ -462,13 +468,13 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-yamllint==1.31.0
+yamllint==1.32.0
     # via ansible-lint
-yarl==1.8.2
+yarl==1.9.2
     # via
     #   aiohttp
     #   pulpcore
-zipp==3.15.0
+zipp==3.16.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -35,7 +35,6 @@ attrs==22.2.0
     #   aiohttp
     #   galaxy-importer
     #   jsonschema
-    #   referencing
 backoff==2.2.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -71,11 +70,11 @@ charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.6
+click==8.1.3
     # via
     #   black
     #   pulpcore
-cryptography==41.0.3
+cryptography==41.0.1
     # via
     #   ansible-core
     #   pulpcore
@@ -116,7 +115,7 @@ django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
 django-filter==23.2
     # via pulpcore
-django-guid==3.3.1
+django-guid==3.3.0
     # via pulpcore
 django-import-export==3.2.0
     # via pulpcore
@@ -142,7 +141,7 @@ drf-access-policy==1.5.0
     # via pulpcore
 drf-nested-routers==0.93.4
     # via pulpcore
-drf-spectacular==0.26.4
+drf-spectacular==0.26.2
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
@@ -178,7 +177,7 @@ googleapis-common-protos==1.60.0
     #   opentelemetry-exporter-otlp-proto-http
 grpcio==1.57.0
     # via opentelemetry-exporter-otlp-proto-grpc
-gunicorn==21.2.0
+gunicorn==20.1.0
     # via pulpcore
 idna==3.4
     # via
@@ -200,15 +199,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.18.6
+jsonschema==4.17.3
     # via
     #   ansible-builder
     #   ansible-lint
     #   drf-spectacular
     #   pulp-ansible
     #   pulp-container
-jsonschema-specifications==2023.7.1
-    # via jsonschema
 logstash-formatter==0.5.17
     # via -r requirements/requirements.insights.in
 markdown==3.4.4
@@ -241,7 +238,7 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opentelemetry-api==1.19.0
+opentelemetry-api==1.18.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -250,47 +247,47 @@ opentelemetry-api==1.19.0
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-distro[otlp]==0.40b0
+opentelemetry-distro[otlp]==0.39b0
     # via pulpcore
-opentelemetry-exporter-otlp==1.19.0
+opentelemetry-exporter-otlp==1.18.0
     # via opentelemetry-distro
-opentelemetry-exporter-otlp-proto-common==1.19.0
+opentelemetry-exporter-otlp-proto-common==1.18.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.19.0
+opentelemetry-exporter-otlp-proto-grpc==1.18.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.19.0
+opentelemetry-exporter-otlp-proto-http==1.18.0
     # via
     #   opentelemetry-exporter-otlp
     #   pulpcore
-opentelemetry-instrumentation==0.40b0
+opentelemetry-instrumentation==0.39b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.40b0
+opentelemetry-instrumentation-django==0.39b0
     # via pulpcore
-opentelemetry-instrumentation-wsgi==0.40b0
+opentelemetry-instrumentation-wsgi==0.39b0
     # via
     #   opentelemetry-instrumentation-django
     #   pulpcore
-opentelemetry-proto==1.19.0
+opentelemetry-proto==1.18.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.19.0
+opentelemetry-sdk==1.18.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.40b0
+opentelemetry-semantic-conventions==0.39b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.40b0
+opentelemetry-util-http==0.39b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
@@ -302,7 +299,6 @@ packaging==23.1
     #   black
     #   bleach
     #   django-lifecycle
-    #   gunicorn
     #   marshmallow
     #   pulp-glue
 parsley==1.3
@@ -320,22 +316,22 @@ platformdirs==3.10.0
     # via black
 prometheus-client==0.17.1
     # via django-prometheus
-protobuf==4.23.4
+protobuf==4.23.2
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   pulpcore
-psycopg[binary]==3.1.10
+psycopg[binary]==3.1.9
     # via pulpcore
-psycopg-binary==3.1.10
+psycopg-binary==3.1.9
     # via psycopg
 pulp-ansible==0.19.0
     # via galaxy-ng (setup.py)
-pulp-container==2.16.0
+pulp-container==2.15.2
     # via galaxy-ng (setup.py)
-pulp-glue==0.21.2
+pulp-glue==0.19.5
     # via pulpcore
-pulpcore==3.30.0
+pulpcore==3.28.10
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -362,15 +358,17 @@ pygtrie==2.5.0
     # via pulpcore
 pyjwkest==1.4.2
     # via pulp-container
-pyjwt[crypto]==2.8.0
+pyjwt[crypto]==2.7.0
     # via
     #   pulp-container
     #   social-auth-core
 pyparsing==3.1.1
     # via drf-access-policy
+pyrsistent==0.19.3
+    # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-python-gnupg==0.5.1
+python-gnupg==0.5.0
     # via pulpcore
 python-ldap==3.4.3
     # via django-auth-ldap
@@ -378,7 +376,7 @@ python3-openid==3.2.0
     # via social-auth-core
 pytz==2023.3
     # via djangorestframework
-pyyaml==6.0.1
+pyyaml==6.0
     # via
     #   ansible-builder
     #   ansible-core
@@ -389,12 +387,8 @@ pyyaml==6.0.1
     #   pulpcore
     #   tablib
     #   yamllint
-redis==4.6.0
+redis==4.5.5
     # via pulpcore
-referencing==0.30.2
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   galaxy-importer
@@ -412,10 +406,6 @@ resolvelib==1.0.1
     # via ansible-core
 rich==13.5.2
     # via ansible-lint
-rpds-py==0.9.2
-    # via
-    #   jsonschema
-    #   referencing
 ruamel-yaml==0.17.32
     # via ansible-lint
 ruamel-yaml-clib==0.2.7
@@ -471,7 +461,7 @@ wcmatch==8.4.1
     # via ansible-lint
 webencodings==0.5.1
     # via bleach
-whitenoise==6.5.0
+whitenoise==6.4.0
     # via pulpcore
 wrapt==1.15.0
     # via

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -8,28 +8,26 @@ aiodns==3.0.0
     # via pulpcore
 aiofiles==23.1.0
     # via pulpcore
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via pulpcore
 aiosignal==1.3.1
     # via aiohttp
-ansible-builder==1.2.0
+ansible-builder==3.0.0
     # via galaxy-importer
-ansible-core==2.14.5
+ansible-core==2.15.3
     # via
     #   ansible-lint
     #   galaxy-importer
 ansible-lint==6.14.3
     # via galaxy-importer
-app-common-python==0.2.5
+app-common-python==0.2.6
     # via -r requirements/requirements.insights.in
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-async-lru==2.0.2
+async-lru==2.0.4
     # via pulp-ansible
-async-timeout==4.0.2
-    # via
-    #   aiohttp
-    #   redis
+async-timeout==4.0.3
+    # via aiohttp
 asyncio-throttle==1.0.2
     # via pulpcore
 attrs==22.2.0
@@ -37,6 +35,7 @@ attrs==22.2.0
     #   aiohttp
     #   galaxy-importer
     #   jsonschema
+    #   referencing
 backoff==2.2.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -44,39 +43,39 @@ backoff==2.2.1
     #   pulpcore
 bindep==2.11.0
     # via ansible-builder
-black==23.3.0
+black==23.7.0
     # via ansible-lint
 bleach==3.3.1
     # via galaxy-importer
 bleach-allowlist==1.0.3
     # via galaxy-importer
-boto3==1.26.132
+boto3==1.28.26
     # via
     #   -r requirements/requirements.insights.in
     #   django-storages
     #   galaxy-ng (setup.py)
     #   watchtower
-botocore==1.29.132
+botocore==1.31.26
     # via
     #   boto3
     #   s3transfer
 bracex==2.3.post1
     # via wcmatch
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
 cffi==1.15.1
     # via
     #   cryptography
     #   pycares
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.6
     # via
     #   black
     #   pulpcore
-cryptography==39.0.2
+cryptography==41.0.3
     # via
     #   ansible-core
     #   pulpcore
@@ -98,7 +97,7 @@ distro==1.8.0
     # via
     #   bindep
     #   galaxy-ng (setup.py)
-django==4.2.3
+django==4.2.4
     # via
     #   django-auth-ldap
     #   django-filter
@@ -117,9 +116,9 @@ django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
 django-filter==23.2
     # via pulpcore
-django-guid==3.3.0
+django-guid==3.3.1
     # via pulpcore
-django-import-export==3.1.0
+django-import-export==3.2.0
     # via pulpcore
 django-ipware==3.0.7
     # via galaxy-ng (setup.py)
@@ -143,7 +142,7 @@ drf-access-policy==1.5.0
     # via pulpcore
 drf-nested-routers==0.93.4
     # via pulpcore
-drf-spectacular==0.26.2
+drf-spectacular==0.26.4
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
@@ -155,11 +154,11 @@ ecdsa==0.18.0
     # via pulp-container
 et-xmlfile==1.1.0
     # via openpyxl
-filelock==3.12.0
+filelock==3.12.2
     # via ansible-lint
-flake8==6.0.0
+flake8==6.1.0
     # via galaxy-importer
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
@@ -171,15 +170,15 @@ galaxy-importer==0.4.12
     #   pulp-ansible
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.32
     # via pulp-ansible
-googleapis-common-protos==1.59.0
+googleapis-common-protos==1.60.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.54.2
+grpcio==1.57.0
     # via opentelemetry-exporter-otlp-proto-grpc
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via pulpcore
 idna==3.4
     # via
@@ -201,23 +200,26 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.16.0
+jsonschema==4.18.6
     # via
+    #   ansible-builder
     #   ansible-lint
     #   drf-spectacular
     #   pulp-ansible
     #   pulp-container
+jsonschema-specifications==2023.7.1
+    # via jsonschema
 logstash-formatter==0.5.17
     # via -r requirements/requirements.insights.in
-markdown==3.4.3
+markdown==3.4.4
     # via galaxy-importer
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
 markuppy==1.14
     # via tablib
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-marshmallow==3.19.0
+marshmallow==3.20.1
     # via galaxy-ng (setup.py)
 mccabe==0.7.0
     # via flake8
@@ -239,7 +241,7 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opentelemetry-api==1.18.0
+opentelemetry-api==1.19.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -248,47 +250,47 @@ opentelemetry-api==1.18.0
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-distro[otlp]==0.39b0
+opentelemetry-distro[otlp]==0.40b0
     # via pulpcore
-opentelemetry-exporter-otlp==1.18.0
+opentelemetry-exporter-otlp==1.19.0
     # via opentelemetry-distro
-opentelemetry-exporter-otlp-proto-common==1.18.0
+opentelemetry-exporter-otlp-proto-common==1.19.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.18.0
+opentelemetry-exporter-otlp-proto-grpc==1.19.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.18.0
+opentelemetry-exporter-otlp-proto-http==1.19.0
     # via
     #   opentelemetry-exporter-otlp
     #   pulpcore
-opentelemetry-instrumentation==0.39b0
+opentelemetry-instrumentation==0.40b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.39b0
+opentelemetry-instrumentation-django==0.40b0
     # via pulpcore
-opentelemetry-instrumentation-wsgi==0.39b0
+opentelemetry-instrumentation-wsgi==0.40b0
     # via
     #   opentelemetry-instrumentation-django
     #   pulpcore
-opentelemetry-proto==1.18.0
+opentelemetry-proto==1.19.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.18.0
+opentelemetry-sdk==1.19.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.39b0
+opentelemetry-semantic-conventions==0.40b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.39b0
+opentelemetry-util-http==0.40b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
@@ -300,39 +302,40 @@ packaging==23.1
     #   black
     #   bleach
     #   django-lifecycle
+    #   gunicorn
     #   marshmallow
     #   pulp-glue
 parsley==1.3
     # via bindep
-pathspec==0.11.0
+pathspec==0.11.2
     # via
     #   ansible-lint
     #   black
     #   yamllint
 pbr==5.11.1
     # via bindep
-pillow==9.4.0
+pillow==10.0.0
     # via pulp-ansible
-platformdirs==3.5.0
+platformdirs==3.10.0
     # via black
-prometheus-client==0.16.0
+prometheus-client==0.17.1
     # via django-prometheus
-protobuf==4.22.1
+protobuf==4.23.4
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   pulpcore
-psycopg[binary]==3.1.9
+psycopg[binary]==3.1.10
     # via pulpcore
-psycopg-binary==3.1.9
+psycopg-binary==3.1.10
     # via psycopg
 pulp-ansible==0.19.0
     # via galaxy-ng (setup.py)
-pulp-container==2.15.1
+pulp-container==2.16.0
     # via galaxy-ng (setup.py)
-pulp-glue==0.19.1
+pulp-glue==0.21.2
     # via pulpcore
-pulpcore==3.28.10
+pulpcore==3.30.0
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -345,31 +348,29 @@ pyasn1-modules==0.3.0
     # via python-ldap
 pycares==4.3.0
     # via aiodns
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via flake8
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
+pycryptodomex==3.18.0
     # via pyjwkest
-pyflakes==3.0.1
+pyflakes==3.1.0
     # via flake8
-pygments==2.15.1
+pygments==2.16.1
     # via rich
 pygtrie==2.5.0
     # via pulpcore
 pyjwkest==1.4.2
     # via pulp-container
-pyjwt[crypto]==2.5.0
+pyjwt[crypto]==2.8.0
     # via
     #   pulp-container
     #   social-auth-core
-pyparsing==3.0.9
+pyparsing==3.1.1
     # via drf-access-policy
-pyrsistent==0.19.3
-    # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-python-gnupg==0.5.0
+python-gnupg==0.5.1
     # via pulpcore
 python-ldap==3.4.3
     # via django-auth-ldap
@@ -377,7 +378,7 @@ python3-openid==3.2.0
     # via social-auth-core
 pytz==2023.3
     # via djangorestframework
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   ansible-builder
     #   ansible-core
@@ -388,9 +389,13 @@ pyyaml==6.0
     #   pulpcore
     #   tablib
     #   yamllint
-redis==4.5.1
+redis==4.6.0
     # via pulpcore
-requests==2.30.0
+referencing==0.30.2
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+requests==2.31.0
     # via
     #   galaxy-importer
     #   insights-analytics-collector
@@ -403,11 +408,15 @@ requests-oauthlib==1.3.1
     # via social-auth-core
 requirements-parser==0.5.0
     # via ansible-builder
-resolvelib==0.8.1
+resolvelib==1.0.1
     # via ansible-core
-rich==13.3.5
+rich==13.5.2
     # via ansible-lint
-ruamel-yaml==0.17.26
+rpds-py==0.9.2
+    # via
+    #   jsonschema
+    #   referencing
+ruamel-yaml==0.17.32
     # via ansible-lint
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -436,22 +445,19 @@ sqlparse==0.4.4
     # via django
 subprocess-tee==0.4.1
     # via ansible-lint
-tablib[html,ods,xls,xlsx,yaml]==3.4.0
+tablib[html,ods,xls,xlsx,yaml]==3.5.0
     # via django-import-export
-types-cryptography==3.3.23.2
-    # via pyjwt
-types-setuptools==67.7.0.2
+types-setuptools==68.0.0.3
     # via requirements-parser
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via
-    #   async-lru
     #   opentelemetry-sdk
     #   psycopg
 uritemplate==4.1.1
     # via drf-spectacular
 url-normalize==1.4.3
     # via pulpcore
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   requests
@@ -465,7 +471,7 @@ wcmatch==8.4.1
     # via ansible-lint
 webencodings==0.5.1
     # via bleach
-whitenoise==6.4.0
+whitenoise==6.5.0
     # via pulpcore
 wrapt==1.15.0
     # via
@@ -475,13 +481,13 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-yamllint==1.31.0
+yamllint==1.32.0
     # via ansible-lint
-yarl==1.8.2
+yarl==1.9.2
     # via
     #   aiohttp
     #   pulpcore
-zipp==3.15.0
+zipp==3.16.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -33,7 +33,6 @@ attrs==22.2.0
     #   aiohttp
     #   galaxy-importer
     #   jsonschema
-    #   referencing
 backoff==2.2.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -65,11 +64,11 @@ charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.6
+click==8.1.3
     # via
     #   black
     #   pulpcore
-cryptography==41.0.3
+cryptography==41.0.1
     # via
     #   ansible-core
     #   pulpcore
@@ -109,7 +108,7 @@ django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
 django-filter==23.2
     # via pulpcore
-django-guid==3.3.1
+django-guid==3.3.0
     # via pulpcore
 django-import-export==3.2.0
     # via pulpcore
@@ -133,7 +132,7 @@ drf-access-policy==1.5.0
     # via pulpcore
 drf-nested-routers==0.93.4
     # via pulpcore
-drf-spectacular==0.26.4
+drf-spectacular==0.26.2
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
@@ -169,7 +168,7 @@ googleapis-common-protos==1.60.0
     #   opentelemetry-exporter-otlp-proto-http
 grpcio==1.57.0
     # via opentelemetry-exporter-otlp-proto-grpc
-gunicorn==21.2.0
+gunicorn==20.1.0
     # via pulpcore
 idna==3.4
     # via
@@ -191,15 +190,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.18.6
+jsonschema==4.17.3
     # via
     #   ansible-builder
     #   ansible-lint
     #   drf-spectacular
     #   pulp-ansible
     #   pulp-container
-jsonschema-specifications==2023.7.1
-    # via jsonschema
 markdown==3.4.4
     # via galaxy-importer
 markdown-it-py==3.0.0
@@ -230,7 +227,7 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opentelemetry-api==1.19.0
+opentelemetry-api==1.18.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -239,47 +236,47 @@ opentelemetry-api==1.19.0
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-distro[otlp]==0.40b0
+opentelemetry-distro[otlp]==0.39b0
     # via pulpcore
-opentelemetry-exporter-otlp==1.19.0
+opentelemetry-exporter-otlp==1.18.0
     # via opentelemetry-distro
-opentelemetry-exporter-otlp-proto-common==1.19.0
+opentelemetry-exporter-otlp-proto-common==1.18.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.19.0
+opentelemetry-exporter-otlp-proto-grpc==1.18.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.19.0
+opentelemetry-exporter-otlp-proto-http==1.18.0
     # via
     #   opentelemetry-exporter-otlp
     #   pulpcore
-opentelemetry-instrumentation==0.40b0
+opentelemetry-instrumentation==0.39b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.40b0
+opentelemetry-instrumentation-django==0.39b0
     # via pulpcore
-opentelemetry-instrumentation-wsgi==0.40b0
+opentelemetry-instrumentation-wsgi==0.39b0
     # via
     #   opentelemetry-instrumentation-django
     #   pulpcore
-opentelemetry-proto==1.19.0
+opentelemetry-proto==1.18.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.19.0
+opentelemetry-sdk==1.18.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.40b0
+opentelemetry-semantic-conventions==0.39b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.40b0
+opentelemetry-util-http==0.39b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
@@ -291,7 +288,6 @@ packaging==23.1
     #   black
     #   bleach
     #   django-lifecycle
-    #   gunicorn
     #   marshmallow
     #   pulp-glue
 parsley==1.3
@@ -309,22 +305,22 @@ platformdirs==3.10.0
     # via black
 prometheus-client==0.17.1
     # via django-prometheus
-protobuf==4.23.4
+protobuf==4.23.2
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   pulpcore
-psycopg[binary]==3.1.10
+psycopg[binary]==3.1.9
     # via pulpcore
-psycopg-binary==3.1.10
+psycopg-binary==3.1.9
     # via psycopg
 pulp-ansible==0.19.0
     # via galaxy-ng (setup.py)
-pulp-container==2.16.0
+pulp-container==2.15.2
     # via galaxy-ng (setup.py)
-pulp-glue==0.21.2
+pulp-glue==0.19.5
     # via pulpcore
-pulpcore==3.30.0
+pulpcore==3.28.10
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -351,15 +347,17 @@ pygtrie==2.5.0
     # via pulpcore
 pyjwkest==1.4.2
     # via pulp-container
-pyjwt[crypto]==2.8.0
+pyjwt[crypto]==2.7.0
     # via
     #   pulp-container
     #   social-auth-core
 pyparsing==3.1.1
     # via drf-access-policy
+pyrsistent==0.19.3
+    # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-python-gnupg==0.5.1
+python-gnupg==0.5.0
     # via pulpcore
 python-ldap==3.4.3
     # via django-auth-ldap
@@ -367,7 +365,7 @@ python3-openid==3.2.0
     # via social-auth-core
 pytz==2023.3
     # via djangorestframework
-pyyaml==6.0.1
+pyyaml==6.0
     # via
     #   ansible-builder
     #   ansible-core
@@ -378,12 +376,8 @@ pyyaml==6.0.1
     #   pulpcore
     #   tablib
     #   yamllint
-redis==4.6.0
+redis==4.5.5
     # via pulpcore
-referencing==0.30.2
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   galaxy-importer
@@ -401,10 +395,6 @@ resolvelib==1.0.1
     # via ansible-core
 rich==13.5.2
     # via ansible-lint
-rpds-py==0.9.2
-    # via
-    #   jsonschema
-    #   referencing
 ruamel-yaml==0.17.32
     # via ansible-lint
 ruamel-yaml-clib==0.2.7
@@ -458,7 +448,7 @@ wcmatch==8.4.1
     # via ansible-lint
 webencodings==0.5.1
     # via bleach
-whitenoise==6.5.0
+whitenoise==6.4.0
     # via pulpcore
 wrapt==1.15.0
     # via

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -8,26 +8,24 @@ aiodns==3.0.0
     # via pulpcore
 aiofiles==23.1.0
     # via pulpcore
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via pulpcore
 aiosignal==1.3.1
     # via aiohttp
-ansible-builder==1.2.0
+ansible-builder==3.0.0
     # via galaxy-importer
-ansible-core==2.14.5
+ansible-core==2.15.3
     # via
     #   ansible-lint
     #   galaxy-importer
 ansible-lint==6.14.3
     # via galaxy-importer
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-async-lru==2.0.2
+async-lru==2.0.4
     # via pulp-ansible
-async-timeout==4.0.2
-    # via
-    #   aiohttp
-    #   redis
+async-timeout==4.0.3
+    # via aiohttp
 asyncio-throttle==1.0.2
     # via pulpcore
 attrs==22.2.0
@@ -35,6 +33,7 @@ attrs==22.2.0
     #   aiohttp
     #   galaxy-importer
     #   jsonschema
+    #   referencing
 backoff==2.2.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -42,35 +41,35 @@ backoff==2.2.1
     #   pulpcore
 bindep==2.11.0
     # via ansible-builder
-black==23.3.0
+black==23.7.0
     # via ansible-lint
 bleach==3.3.1
     # via galaxy-importer
 bleach-allowlist==1.0.3
     # via galaxy-importer
-boto3==1.26.132
+boto3==1.28.26
     # via galaxy-ng (setup.py)
-botocore==1.29.132
+botocore==1.31.26
     # via
     #   boto3
     #   s3transfer
 bracex==2.3.post1
     # via wcmatch
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
 cffi==1.15.1
     # via
     #   cryptography
     #   pycares
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.6
     # via
     #   black
     #   pulpcore
-cryptography==39.0.2
+cryptography==41.0.3
     # via
     #   ansible-core
     #   pulpcore
@@ -92,7 +91,7 @@ distro==1.8.0
     # via
     #   bindep
     #   galaxy-ng (setup.py)
-django==4.2.3
+django==4.2.4
     # via
     #   django-auth-ldap
     #   django-filter
@@ -110,9 +109,9 @@ django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
 django-filter==23.2
     # via pulpcore
-django-guid==3.3.0
+django-guid==3.3.1
     # via pulpcore
-django-import-export==3.1.0
+django-import-export==3.2.0
     # via pulpcore
 django-ipware==3.0.7
     # via galaxy-ng (setup.py)
@@ -134,7 +133,7 @@ drf-access-policy==1.5.0
     # via pulpcore
 drf-nested-routers==0.93.4
     # via pulpcore
-drf-spectacular==0.26.2
+drf-spectacular==0.26.4
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
@@ -146,11 +145,11 @@ ecdsa==0.18.0
     # via pulp-container
 et-xmlfile==1.1.0
     # via openpyxl
-filelock==3.12.0
+filelock==3.12.2
     # via ansible-lint
-flake8==6.0.0
+flake8==6.1.0
     # via galaxy-importer
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
@@ -162,15 +161,15 @@ galaxy-importer==0.4.12
     #   pulp-ansible
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.32
     # via pulp-ansible
-googleapis-common-protos==1.59.0
+googleapis-common-protos==1.60.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.54.2
+grpcio==1.57.0
     # via opentelemetry-exporter-otlp-proto-grpc
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via pulpcore
 idna==3.4
     # via
@@ -192,21 +191,24 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.16.0
+jsonschema==4.18.6
     # via
+    #   ansible-builder
     #   ansible-lint
     #   drf-spectacular
     #   pulp-ansible
     #   pulp-container
-markdown==3.4.3
+jsonschema-specifications==2023.7.1
+    # via jsonschema
+markdown==3.4.4
     # via galaxy-importer
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
 markuppy==1.14
     # via tablib
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-marshmallow==3.19.0
+marshmallow==3.20.1
     # via galaxy-ng (setup.py)
 mccabe==0.7.0
     # via flake8
@@ -228,7 +230,7 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opentelemetry-api==1.18.0
+opentelemetry-api==1.19.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -237,47 +239,47 @@ opentelemetry-api==1.18.0
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-distro[otlp]==0.39b0
+opentelemetry-distro[otlp]==0.40b0
     # via pulpcore
-opentelemetry-exporter-otlp==1.18.0
+opentelemetry-exporter-otlp==1.19.0
     # via opentelemetry-distro
-opentelemetry-exporter-otlp-proto-common==1.18.0
+opentelemetry-exporter-otlp-proto-common==1.19.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.18.0
+opentelemetry-exporter-otlp-proto-grpc==1.19.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.18.0
+opentelemetry-exporter-otlp-proto-http==1.19.0
     # via
     #   opentelemetry-exporter-otlp
     #   pulpcore
-opentelemetry-instrumentation==0.39b0
+opentelemetry-instrumentation==0.40b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.39b0
+opentelemetry-instrumentation-django==0.40b0
     # via pulpcore
-opentelemetry-instrumentation-wsgi==0.39b0
+opentelemetry-instrumentation-wsgi==0.40b0
     # via
     #   opentelemetry-instrumentation-django
     #   pulpcore
-opentelemetry-proto==1.18.0
+opentelemetry-proto==1.19.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.18.0
+opentelemetry-sdk==1.19.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.39b0
+opentelemetry-semantic-conventions==0.40b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.39b0
+opentelemetry-util-http==0.40b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
@@ -289,39 +291,40 @@ packaging==23.1
     #   black
     #   bleach
     #   django-lifecycle
+    #   gunicorn
     #   marshmallow
     #   pulp-glue
 parsley==1.3
     # via bindep
-pathspec==0.11.0
+pathspec==0.11.2
     # via
     #   ansible-lint
     #   black
     #   yamllint
 pbr==5.11.1
     # via bindep
-pillow==9.4.0
+pillow==10.0.0
     # via pulp-ansible
-platformdirs==3.5.0
+platformdirs==3.10.0
     # via black
-prometheus-client==0.16.0
+prometheus-client==0.17.1
     # via django-prometheus
-protobuf==4.22.1
+protobuf==4.23.4
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   pulpcore
-psycopg[binary]==3.1.9
+psycopg[binary]==3.1.10
     # via pulpcore
-psycopg-binary==3.1.9
+psycopg-binary==3.1.10
     # via psycopg
 pulp-ansible==0.19.0
     # via galaxy-ng (setup.py)
-pulp-container==2.15.1
+pulp-container==2.16.0
     # via galaxy-ng (setup.py)
-pulp-glue==0.19.1
+pulp-glue==0.21.2
     # via pulpcore
-pulpcore==3.28.10
+pulpcore==3.30.0
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -334,31 +337,29 @@ pyasn1-modules==0.3.0
     # via python-ldap
 pycares==4.3.0
     # via aiodns
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via flake8
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
+pycryptodomex==3.18.0
     # via pyjwkest
-pyflakes==3.0.1
+pyflakes==3.1.0
     # via flake8
-pygments==2.15.1
+pygments==2.16.1
     # via rich
 pygtrie==2.5.0
     # via pulpcore
 pyjwkest==1.4.2
     # via pulp-container
-pyjwt[crypto]==2.5.0
+pyjwt[crypto]==2.8.0
     # via
     #   pulp-container
     #   social-auth-core
-pyparsing==3.0.9
+pyparsing==3.1.1
     # via drf-access-policy
-pyrsistent==0.19.3
-    # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-python-gnupg==0.5.0
+python-gnupg==0.5.1
     # via pulpcore
 python-ldap==3.4.3
     # via django-auth-ldap
@@ -366,7 +367,7 @@ python3-openid==3.2.0
     # via social-auth-core
 pytz==2023.3
     # via djangorestframework
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   ansible-builder
     #   ansible-core
@@ -377,9 +378,13 @@ pyyaml==6.0
     #   pulpcore
     #   tablib
     #   yamllint
-redis==4.5.1
+redis==4.6.0
     # via pulpcore
-requests==2.30.0
+referencing==0.30.2
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+requests==2.31.0
     # via
     #   galaxy-importer
     #   insights-analytics-collector
@@ -392,11 +397,15 @@ requests-oauthlib==1.3.1
     # via social-auth-core
 requirements-parser==0.5.0
     # via ansible-builder
-resolvelib==0.8.1
+resolvelib==1.0.1
     # via ansible-core
-rich==13.3.5
+rich==13.5.2
     # via ansible-lint
-ruamel-yaml==0.17.26
+rpds-py==0.9.2
+    # via
+    #   jsonschema
+    #   referencing
+ruamel-yaml==0.17.32
     # via ansible-lint
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -425,22 +434,19 @@ sqlparse==0.4.4
     # via django
 subprocess-tee==0.4.1
     # via ansible-lint
-tablib[html,ods,xls,xlsx,yaml]==3.4.0
+tablib[html,ods,xls,xlsx,yaml]==3.5.0
     # via django-import-export
-types-cryptography==3.3.23.2
-    # via pyjwt
-types-setuptools==67.7.0.2
+types-setuptools==68.0.0.3
     # via requirements-parser
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via
-    #   async-lru
     #   opentelemetry-sdk
     #   psycopg
 uritemplate==4.1.1
     # via drf-spectacular
 url-normalize==1.4.3
     # via pulpcore
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   requests
@@ -452,7 +458,7 @@ wcmatch==8.4.1
     # via ansible-lint
 webencodings==0.5.1
     # via bleach
-whitenoise==6.4.0
+whitenoise==6.5.0
     # via pulpcore
 wrapt==1.15.0
     # via
@@ -462,13 +468,13 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-yamllint==1.31.0
+yamllint==1.32.0
     # via ansible-lint
-yarl==1.8.2
+yarl==1.9.2
     # via
     #   aiohttp
     #   pulpcore
-zipp==3.15.0
+zipp==3.16.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -112,11 +112,11 @@ def _format_pulp_requirement(plugin, specifier=None, ref=None, gh_namespace="pul
 
 requirements = [
     "galaxy-importer>=0.4.11,<0.5.0",
-    "pulpcore>=3.28.10,<3.40.0",
+    "pulpcore>=3.28.10,<3.29.0",
     "pulp_ansible>=0.19.0,<0.20.0",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
-    "pulp-container>=2.15.0,<2.17.0",
+    "pulp-container>=2.15.0,<2.16.0",
     "social-auth-core>=4.4.2",
     "social-auth-app-django>=5.2.0",
     "dynaconf>=3.1.12,<3.1.13",


### PR DESCRIPTION
Fixing multiple dependabot and prodsec reports. We have to pin the upper bound on pulpcore because we're standardizing on 3.38 the galaxy_ng 4.8.x release. We have to pin the upper bound on pulp-container because the latest is breaking tests.

https://github.com/ansible/galaxy_ng/pull/1663
https://github.com/ansible/galaxy_ng/pull/1690
https://github.com/ansible/galaxy_ng/pull/1731
https://github.com/ansible/galaxy_ng/pull/1809
https://github.com/ansible/galaxy_ng/pull/1828
https://github.com/ansible/galaxy_ng/pull/1839
