### PR TITLE
Allow to disable signing tests for containerized AAP

### DIFF
--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -246,9 +246,10 @@ def is_beta_galaxy_stage():
 
 def is_ocp_env():
     # this check will not be necessary when content signing is enabled in operator
-    return "ocp4.testing.ansible.com" in os.getenv(
-        "HUB_API_ROOT", "http://localhost:5001/api/automation-hub/"
-    )
+    # we also have containerized aap, in that case check proper env var as well
+    return ("ocp4.testing.ansible.com" in os.getenv(
+        "HUB_API_ROOT", "http://localhost:5001/api/automation-hub/")
+        or os.getenv("HUB_CONTENT_SIGNING_ENABLED", 'true') not in ['1', 'True', 'true'])
 
 
 def is_stage_environment():


### PR DESCRIPTION
We have now the containerized installer where the automation hub is running inside the container. We don't yet have content signing configured for such deployment. This PR should allow to disable content_signing tests by setting the HUB_CONTENT_SIGNING_ENABLED env var. 