### PR TITLE
Add check for ANSIBLE_COLLECT_DOWNLOAD_COUNT setting

### DIFF
--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -179,7 +179,7 @@ class CollectionArtifactDownloadView(api_base.APIView):
                 request, filename, distro_base_path
             )
 
-        if settings.ANSIBLE_COLLECT_DOWNLOAD_COUNT:
+        if settings.get("ANSIBLE_COLLECT_DOWNLOAD_COUNT", False):
             pulp_ansible_views.CollectionArtifactDownloadView.count_download(filename)
 
         if settings.GALAXY_DEPLOYMENT_MODE == DeploymentMode.INSIGHTS.value:

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -179,6 +179,9 @@ class CollectionArtifactDownloadView(api_base.APIView):
                 request, filename, distro_base_path
             )
 
+        if settings.ANSIBLE_COLLECT_DOWNLOAD_COUNT:
+            pulp_ansible_views.CollectionArtifactDownloadView.count_download(filename)
+
         if settings.GALAXY_DEPLOYMENT_MODE == DeploymentMode.INSIGHTS.value:
             url = 'http://{host}:{port}/{prefix}/{distro_base_path}/{filename}'.format(
                 host=settings.X_PULP_CONTENT_HOST,


### PR DESCRIPTION
Missed integrating this feature when galaxy_ng was bumped to pulp_ansible 0.19.0
No-Issue
