### PR TITLE
bump pulpcore to 3.28.12

### DIFF
--- a/CHANGES/2654.misc
+++ b/CHANGES/2654.misc
@@ -1,0 +1,1 @@
+Enable use of pulpcore SystemID in galaxy_ng

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -320,7 +320,7 @@ pulp-container==2.15.2
     # via galaxy-ng (setup.py)
 pulp-glue==0.19.5
     # via pulpcore
-pulpcore==3.28.10
+pulpcore==3.28.12
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -331,7 +331,7 @@ pulp-container==2.15.2
     # via galaxy-ng (setup.py)
 pulp-glue==0.19.5
     # via pulpcore
-pulpcore==3.28.10
+pulpcore==3.28.12
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -320,7 +320,7 @@ pulp-container==2.15.2
     # via galaxy-ng (setup.py)
 pulp-glue==0.19.5
     # via pulpcore
-pulpcore==3.28.10
+pulpcore==3.28.12
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ def _format_pulp_requirement(plugin, specifier=None, ref=None, gh_namespace="pul
 
 requirements = [
     "galaxy-importer>=0.4.13,<0.5.0",
-    "pulpcore>=3.28.10,<3.29.0",
+    "pulpcore>=3.28.12,<3.29.0",
     "pulp_ansible>=0.19.0,<0.20.0",
     "django-prometheus>=2.0.0",
     "drf-spectacular",


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Bump pulpcore to 3.28.12 to enable using SystemID in analytics.

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAH-2654

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->
```
from pulpcore.plugin.models import system_id
system_id() 
```
Should return system id ie: `'0189f470-a428-7310-a635-92cf916a6349'`

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
