### PR TITLE
v1 to v3 namespace rbac shim

### DIFF
--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -23,6 +23,7 @@ from galaxy_ng.app import models
 from galaxy_ng.app.api.v1.models import LegacyNamespace
 from galaxy_ng.app.api.v1.models import LegacyRole
 from galaxy_ng.app.constants import COMMUNITY_DOMAINS
+from galaxy_ng.app.utils.rbac import get_v3_namespace_owners
 
 from galaxy_ng.app.access_control.statements import PULP_VIEWSETS
 
@@ -770,8 +771,14 @@ class LegacyAccessPolicy(AccessPolicyBase):
         if namespace is None and github_user and user.username == github_user:
             return True
 
-        # allow owners to do things in the namespace
-        if namespace and user.username in [x.username for x in namespace.owners.all()]:
+        # v1 namespace rbac is controlled via their v3 namespace
+        v3_namespace = namespace.namespace
+        if not v3_namespace:
+            return False
+
+        # use the helper to get the list of owners
+        owners = get_v3_namespace_owners(v3_namespace)
+        if owners and user in owners:
             return True
 
         return False

--- a/galaxy_ng/app/api/v1/models.py
+++ b/galaxy_ng/app/api/v1/models.py
@@ -108,6 +108,9 @@ class LegacyNamespace(models.Model):
         editable=True
     )
 
+    def __repr__(self):
+        return f'<LegacyNamespace: {self.name}>'
+
 
 class LegacyRole(models.Model):
     """
@@ -147,6 +150,9 @@ class LegacyRole(models.Model):
         null=False,
         default=dict
     )
+
+    def __repr__(self):
+        return f'<LegacyRole: {self.namespace.name}.{self.name}>'
 
 
 class LegacyRoleDownloadCount(models.Model):

--- a/galaxy_ng/app/api/v1/urls.py
+++ b/galaxy_ng/app/api/v1/urls.py
@@ -10,6 +10,7 @@ from galaxy_ng.app.api.v1.viewsets import (
     LegacyRolesSyncViewSet,
     LegacyNamespacesViewSet,
     LegacyNamespaceOwnersViewSet,
+    LegacyNamespaceProvidersViewSet,
     LegacyUsersViewSet
 )
 
@@ -86,7 +87,7 @@ urlpatterns = [
     ),
     path(
         'namespaces/',
-        LegacyNamespacesViewSet.as_view({"get": "list"}),
+        LegacyNamespacesViewSet.as_view({"get": "list", "post": "create"}),
         name='legacy_namespace-list'
     ),
     path(
@@ -98,6 +99,11 @@ urlpatterns = [
         'namespaces/<int:pk>/owners/',
         LegacyNamespaceOwnersViewSet.as_view({"get": "list", "put": "update"}),
         name='legacy_namespace_owners-list'
+    ),
+    path(
+        'namespaces/<int:pk>/providers/',
+        LegacyNamespaceProvidersViewSet.as_view({"get": "list", "put": "update", "post": "update"}),
+        name='legacy_namespace_providers-list'
     ),
 
     path('', LegacyRootView.as_view(), name='legacy-root')

--- a/galaxy_ng/app/api/v1/viewsets/__init__.py
+++ b/galaxy_ng/app/api/v1/viewsets/__init__.py
@@ -1,6 +1,7 @@
 from .namespaces import (
     LegacyNamespacesViewSet,
     LegacyNamespaceOwnersViewSet,
+    LegacyNamespaceProvidersViewSet,
 )
 
 from .users import (
@@ -23,6 +24,7 @@ from .sync import (
 __all__ = (
     LegacyNamespacesViewSet,
     LegacyNamespaceOwnersViewSet,
+    LegacyNamespaceProvidersViewSet,
     LegacyUsersViewSet,
     LegacyRolesViewSet,
     LegacyRolesSyncViewSet,

--- a/galaxy_ng/app/api/v1/viewsets/namespaces.py
+++ b/galaxy_ng/app/api/v1/viewsets/namespaces.py
@@ -14,14 +14,19 @@ from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
 
 from galaxy_ng.app.access_control.access_policy import LegacyAccessPolicy
+from galaxy_ng.app.utils.rbac import get_v3_namespace_owners
+from galaxy_ng.app.utils.rbac import add_user_to_v3_namespace
+from galaxy_ng.app.utils.rbac import remove_user_from_v3_namespace
 
 from galaxy_ng.app.models.auth import User
+from galaxy_ng.app.models import Namespace
 from galaxy_ng.app.api.v1.models import (
     LegacyNamespace,
 )
 from galaxy_ng.app.api.v1.serializers import (
     LegacyNamespacesSerializer,
     LegacyNamespaceOwnerSerializer,
+    LegacyNamespaceProviderSerializer,
     LegacyUserSerializer
 )
 
@@ -83,6 +88,18 @@ class LegacyNamespacesViewSet(
     def destroy(self, request, pk=None):
         return super().destroy(self, request, pk)
 
+    def create(self, request):
+
+        ns_name = request.data.get('name')
+        namespace, created = LegacyNamespace.objects.get_or_create(name=ns_name)
+
+        return Response(
+            self.serializer_class(
+                namespace,
+                many=False
+            ).data
+        )
+
 
 class LegacyNamespaceOwnersViewSet(viewsets.GenericViewSet, mixins.ListModelMixin):
     """
@@ -100,7 +117,11 @@ class LegacyNamespaceOwnersViewSet(viewsets.GenericViewSet, mixins.ListModelMixi
     authentication_classes = GALAXY_AUTHENTICATION_CLASSES
 
     def get_queryset(self):
-        return get_object_or_404(LegacyNamespace, pk=self.kwargs["pk"]).owners.all()
+        # return get_object_or_404(LegacyNamespace, pk=self.kwargs["pk"]).owners.all()
+        ns = get_object_or_404(LegacyNamespace, pk=self.kwargs["pk"])
+        if ns.namespace:
+            return get_v3_namespace_owners(ns.namespace)
+        return []
 
     @extend_schema(
         parameters=[LegacyNamespaceOwnerSerializer(many=True)],
@@ -120,6 +141,52 @@ class LegacyNamespaceOwnersViewSet(viewsets.GenericViewSet, mixins.ListModelMixi
         if len(pks) != new_owners.count():
             raise exceptions.ValidationError("user doesn't exist", code="invalid")
 
-        ns.owners.set(new_owners)
+        # get the foreign key ...
+        v3_namespace = ns.namespace
 
-        return Response(self.serializer_class(ns.owners.all(), many=True).data)
+        # get the list of current owners
+        current_owners = get_v3_namespace_owners(v3_namespace)
+
+        # remove all owners not in the new list
+        for current_owner in current_owners:
+            if current_owner not in new_owners:
+                remove_user_from_v3_namespace(current_owner, v3_namespace)
+
+        # add new owners if not in the list
+        for new_owner in new_owners:
+            if new_owner not in current_owners:
+                add_user_to_v3_namespace(new_owner, v3_namespace)
+
+        return Response(
+            self.serializer_class(
+                get_v3_namespace_owners(v3_namespace),
+                many=True
+            ).data
+        )
+
+
+class LegacyNamespaceProvidersViewSet(viewsets.GenericViewSet, mixins.ListModelMixin):
+
+    serializer_class = LegacyNamespaceProviderSerializer
+    pagination_class = None
+    permission_classes = [LegacyAccessPolicy]
+    authentication_classes = GALAXY_AUTHENTICATION_CLASSES
+
+    def get_queryset(self):
+        ns = get_object_or_404(LegacyNamespace, pk=self.kwargs["pk"])
+        if ns.namespace:
+            return [ns.namespace]
+        return []
+
+    def update(self, request, pk):
+        '''Bind a v3 namespace to the legacy namespace'''
+        legacy_ns = get_object_or_404(LegacyNamespace, pk=pk)
+
+        v3_id = request.data['id']
+        v3_namespace = get_object_or_404(Namespace, id=v3_id)
+
+        if legacy_ns.namespace != v3_namespace:
+            legacy_ns.namespace = v3_namespace
+            legacy_ns.save()
+
+        return Response({})

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -222,17 +222,15 @@ def configure_socialauth(settings: Dynaconf) -> Dict[str, Any]:
             "rest_framework.authentication.BasicAuthentication",
         ]
 
-        # Override the get_username step so that social users
-        # are associated to existing users instead of creating
-        # a whole new randomized username.
+        # Override the get_username and create_user steps
+        # to conform to our super special user validation
+        # requirements
         data['SOCIAL_AUTH_PIPELINE'] = [
             'social_core.pipeline.social_auth.social_details',
             'social_core.pipeline.social_auth.social_uid',
             'social_core.pipeline.social_auth.auth_allowed',
             'social_core.pipeline.social_auth.social_user',
-            # 'social_core.pipeline.user.get_username',
             'galaxy_ng.social.pipeline.user.get_username',
-            # 'social_core.pipeline.user.create_user',
             'galaxy_ng.social.pipeline.user.create_user',
             'social_core.pipeline.social_auth.associate_user',
             'social_core.pipeline.social_auth.load_extra_data',

--- a/galaxy_ng/app/management/commands/import-galaxy-role.py
+++ b/galaxy_ng/app/management/commands/import-galaxy-role.py
@@ -1,0 +1,33 @@
+import django_guid
+from django.core.management.base import BaseCommand
+
+from galaxy_ng.app.api.v1.tasks import legacy_role_import
+
+
+# Set logging_uid, this does not seem to get generated when task called via management command
+django_guid.set_guid(django_guid.utils.generate_guid())
+
+
+class Command(BaseCommand):
+    """
+    Import a role using the same functions the API uses.
+    """
+
+    help = 'Import a role using the same functions the API uses.'
+
+    def add_arguments(self, parser):
+        parser.add_argument("--github_user", required=True)
+        parser.add_argument("--github_repo", required=True)
+        parser.add_argument("--role_name", help="find and sync only this namespace name")
+        parser.add_argument("--branch", help="find and sync only this namespace name")
+        parser.add_argument("--request_username", help="set the uploader's username")
+
+    def handle(self, *args, **options):
+        # This is the same function that api/v1/imports eventually calls ...
+        legacy_role_import(
+            request_username=options['request_username'],
+            github_user=options['github_user'],
+            github_repo=options['github_repo'],
+            github_reference=options['branch'],
+            alternate_role_name=options['role_name'],
+        )

--- a/galaxy_ng/app/management/commands/sync-galaxy-namespaces.py
+++ b/galaxy_ng/app/management/commands/sync-galaxy-namespaces.py
@@ -1,0 +1,63 @@
+import django_guid
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+from galaxy_ng.app.utils.galaxy import upstream_namespace_iterator
+from galaxy_ng.app.utils.galaxy import find_namespace
+from galaxy_ng.app.utils.legacy import process_namespace
+
+
+# Set logging_uid, this does not seem to get generated when task called via management command
+django_guid.set_guid(django_guid.utils.generate_guid())
+
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Iterates through every upstream namespace and syncs it.
+    """
+
+    help = 'Sync upstream namespaces+owners from [old-]galaxy.ansible.com'
+
+    def add_arguments(self, parser):
+        parser.add_argument("--baseurl", default="https://galaxy.ansible.com")
+        parser.add_argument("--name", help="find and sync only this namespace name")
+        parser.add_argument("--id", help="find and sync only this namespace id")
+        parser.add_argument("--limit", type=int)
+        parser.add_argument("--start_page", type=int)
+
+    def echo(self, message, style=None):
+        style = style or self.style.SUCCESS
+        self.stdout.write(style(message))
+
+    def handle(self, *args, **options):
+
+        if options.get('name'):
+            ns_name, ns_info = find_namespace(baseurl=options['baseurl'], name=options['name'])
+            self.echo(f'PROCESSING {ns_info["id"]}:{ns_name}')
+            process_namespace(ns_name, ns_info)
+
+        elif options.get('id'):
+            ns_name, ns_info = find_namespace(baseurl=options['baseurl'], id=options['id'])
+            self.echo(f'PROCESSING {ns_info["id"]}:{ns_name}')
+            process_namespace(ns_name, ns_info)
+
+        else:
+
+            count = 0
+            for total, namespace_info in upstream_namespace_iterator(
+                baseurl=options['baseurl'],
+                start_page=options['start_page'],
+                limit=options['limit'],
+            ):
+
+                count += 1
+                namespace_name = namespace_info['name']
+
+                self.echo(
+                    f'({total}|{count})'
+                    + f' PROCESSING {namespace_info["id"]}:{namespace_name}'
+                )
+                process_namespace(namespace_name, namespace_info)

--- a/galaxy_ng/app/management/commands/sync-galaxy-roles.py
+++ b/galaxy_ng/app/management/commands/sync-galaxy-roles.py
@@ -1,0 +1,37 @@
+import django_guid
+from django.core.management.base import BaseCommand
+from galaxy_ng.app.api.v1.tasks import legacy_sync_from_upstream
+
+
+# Set logging_uid, this does not seem to get generated when task called via management command
+django_guid.set_guid(django_guid.utils.generate_guid())
+
+
+class Command(BaseCommand):
+    """
+    Iterates through api/v1/roles and sync all roles found.
+    """
+
+    help = 'Sync upstream roles from [old-]galaxy.ansible.com'
+
+    def add_arguments(self, parser):
+        parser.add_argument("--baseurl", default="https://galaxy.ansible.com")
+        parser.add_argument("--github_user", help="find and sync only this namespace name")
+        parser.add_argument("--role_name", help="find and sync only this role name")
+        parser.add_argument("--limit", type=int)
+        parser.add_argument("--start_page", type=int)
+
+    def echo(self, message, style=None):
+        style = style or self.style.SUCCESS
+        self.stdout.write(style(message))
+
+    def handle(self, *args, **options):
+
+        # This is the function that api/v1/sync eventually calls in a task ...
+        legacy_sync_from_upstream(
+            baseurl=options['baseurl'],
+            github_user=options['github_user'],
+            role_name=options['role_name'],
+            limit=options['limit'],
+            start_page=options['start_page'],
+        )

--- a/galaxy_ng/app/utils/galaxy.py
+++ b/galaxy_ng/app/utils/galaxy.py
@@ -1,9 +1,14 @@
 import logging
 import requests
+import time
 from urllib.parse import urlparse
 
 
 logger = logging.getLogger(__name__)
+
+
+def generate_unverified_email(github_id):
+    return str(github_id) + '@GALAXY.GITHUB.UNVERIFIED.COM'
 
 
 def uuid_to_int(uuid):
@@ -24,6 +29,22 @@ def int_to_uuid(num):
     return uuid
 
 
+def safe_fetch(url):
+    rr = None
+    counter = 0
+    while True:
+        counter += 1
+        logger.info(f'fetch {url}')
+        rr = requests.get(url)
+        if rr.status_code < 500:
+            return rr
+
+        logger.info(f'waiting 60s to refetch {url}')
+        time.sleep(60)
+
+    return rr
+
+
 def paginated_results(next_url):
     """Iterate through a paginated query and combine the results."""
     parsed = urlparse(next_url)
@@ -31,14 +52,257 @@ def paginated_results(next_url):
     results = []
     while next_url:
         logger.info(f'fetch {next_url}')
-        rr = requests.get(next_url)
+        rr = safe_fetch(next_url)
         ds = rr.json()
+
         results.extend(ds['results'])
-        if ds['next_link']:
+        if 'next' in ds:
+            next_url = ds['next']
+        elif ds['next_link']:
             next_url = _baseurl + ds['next_link']
         else:
             next_url = None
+
+        if next_url and not next_url.startswith(_baseurl + '/api/v1'):
+            next_url = _baseurl + '/api/v1' + next_url
+
+        if next_url and not next_url.startswith(_baseurl):
+            next_url = _baseurl + next_url
+
     return results
+
+
+def find_namespace(baseurl=None, name=None, id=None):
+
+    logger.info(f'baseurl1: {baseurl}')
+    if baseurl is None or not baseurl:
+        baseurl = 'https://galaxy.ansible.com'
+    baseurl += '/api/v1/namespaces'
+    logger.info(f'baseurl2: {baseurl}')
+
+    parsed = urlparse(baseurl)
+    _baseurl = parsed.scheme + '://' + parsed.netloc
+
+    ns_name = None
+    ns_info = None
+
+    if name:
+        qurl = baseurl + f'/?name={name}'
+        rr = safe_fetch(qurl)
+        ds = rr.json()
+
+        ns_info = ds['results'][0]
+        ns_name = ns_info['name']
+
+    elif id:
+        qurl = baseurl + f'/{id}/'
+        rr = safe_fetch(qurl)
+        ds = rr.json()
+
+        ns_name = ds['name']
+        ns_info = ds
+
+    # get the owners too
+    ns_id = ns_info['id']
+    owners = []
+    next_owners_url = _baseurl + f'/api/v1/namespaces/{ns_id}/owners/'
+    while next_owners_url:
+        o_data = safe_fetch(next_owners_url).json()
+        for owner in o_data['results']:
+            owners.append(owner)
+        if not o_data.get('next'):
+            break
+        next_owners_url = _baseurl + o_data['next_link']
+
+    ns_info['summary_fields']['owners'] = owners
+
+    return ns_name, ns_info
+
+
+def get_namespace_owners_details(baseurl, ns_id):
+    # get the owners too
+    owners = []
+    next_owners_url = baseurl + f'/api/v1/namespaces/{ns_id}/owners/'
+    while next_owners_url:
+        o_data = safe_fetch(next_owners_url).json()
+        for owner in o_data['results']:
+            owners.append(owner)
+        if not o_data.get('next'):
+            break
+        if 'next_link' in o_data and not o_data.get('next_link'):
+            break
+        next_owners_url = baseurl + o_data['next_link']
+    return owners
+
+
+def upstream_namespace_iterator(
+    baseurl=None,
+    limit=None,
+    start_page=None,
+    require_content=True,
+):
+
+    """Abstracts the pagination of v2 collections into a generator with error handling."""
+    logger.info(f'baseurl1: {baseurl}')
+    if baseurl is None or not baseurl:
+        baseurl = 'https://galaxy.ansible.com/api/v1/namespaces'
+    if not baseurl.rstrip().endswith('/api/v1/namespaces'):
+        baseurl = baseurl.rstrip() + '/api/v1/namespaces'
+    logger.info(f'baseurl2: {baseurl}')
+
+    # normalize the upstream url
+    parsed = urlparse(baseurl)
+    _baseurl = parsed.scheme + '://' + parsed.netloc
+
+    # default to baseurl or construct from parameters
+    next_url = baseurl
+
+    pagenum = 0
+    namespace_count = 0
+
+    if start_page:
+        pagenum = start_page
+        next_url = next_url + f'?page={pagenum}'
+
+    while next_url:
+        logger.info(f'fetch {pagenum} {next_url}')
+
+        page = safe_fetch(next_url)
+
+        # Some upstream pages return ISEs for whatever reason.
+        if page.status_code >= 500:
+            if 'page=' in next_url:
+                next_url = next_url.replace(f'page={pagenum}', f'page={pagenum+1}')
+            else:
+                next_url = next_url.rstrip('/') + '/?page={pagenum+1}'
+            pagenum += 1
+            continue
+
+        ds = page.json()
+        total = ds['count']
+
+        for ndata in ds['results']:
+
+            if not ndata['summary_fields']['content_counts'] and require_content:
+                continue
+
+            ns_id = ndata['id']
+
+            # get the owners too
+            ndata['summary_fields']['owners'] = get_namespace_owners_details(_baseurl, ns_id)
+
+            # send the collection
+            namespace_count += 1
+            yield total, ndata
+
+            # break early if count reached
+            if limit is not None and namespace_count >= limit:
+                break
+
+        # break early if count reached
+        if limit is not None and namespace_count >= limit:
+            break
+
+        # break if no next page
+        if not ds.get('next_link'):
+            break
+
+        pagenum += 1
+        next_url = _baseurl + ds['next_link']
+
+
+def upstream_collection_iterator(
+    baseurl=None,
+    limit=None,
+    collection_namespace=None,
+    collection_name=None,
+    get_versions=True,
+):
+    """Abstracts the pagination of v2 collections into a generator with error handling."""
+    logger.info(f'baseurl1: {baseurl}')
+    if baseurl is None or not baseurl:
+        baseurl = 'https://galaxy.ansible.com/api/v2/collections'
+    logger.info(f'baseurl2: {baseurl}')
+
+    # normalize the upstream url
+    parsed = urlparse(baseurl)
+    _baseurl = parsed.scheme + '://' + parsed.netloc
+
+    # default to baseurl or construct from parameters
+    next_url = baseurl
+
+    '''
+    params = []
+    if github_user or github_repo or role_name:
+        if github_user:
+            params.append(f'owner__username={github_user}')
+        if role_name:
+            params.append(f'name={role_name}')
+        next_url = _baseurl + '/api/v1/roles/?' + '&'.join(params)
+    '''
+
+    namespace_cache = {}
+
+    pagenum = 0
+    collection_count = 0
+    while next_url:
+        logger.info(f'fetch {pagenum} {next_url}')
+
+        page = safe_fetch(next_url)
+
+        # Some upstream pages return ISEs for whatever reason.
+        if page.status_code >= 500:
+            if 'page=' in next_url:
+                next_url = next_url.replace(f'page={pagenum}', f'page={pagenum+1}')
+            else:
+                next_url = next_url.rstrip('/') + '/?page={pagenum+1}'
+            pagenum += 1
+            continue
+
+        ds = page.json()
+
+        for cdata in ds['results']:
+
+            # Get the namespace+owners
+            ns_id = cdata['namespace']['id']
+            if ns_id not in namespace_cache:
+                logger.info(_baseurl + f'/api/v1/namespaces/{ns_id}/')
+                ns_url = _baseurl + f'/api/v1/namespaces/{ns_id}/'
+                namespace_data = safe_fetch(ns_url).json()
+                # logger.info(namespace_data)
+                namespace_cache[ns_id] = namespace_data
+
+                # get the owners too
+                namespace_cache[ns_id]['summary_fields']['owners'] = \
+                    get_namespace_owners_details(_baseurl, ns_id)
+
+            else:
+                namespace_data = namespace_cache[ns_id]
+
+            # get the versions
+            if get_versions:
+                collection_versions = paginated_results(cdata['versions_url'])
+            else:
+                collection_versions = []
+
+            # send the collection
+            collection_count += 1
+            yield namespace_data, cdata, collection_versions
+
+            # break early if count reached
+            if limit is not None and collection_count >= limit:
+                break
+
+        # break early if count reached
+        if limit is not None and collection_count >= limit:
+            break
+
+        # break if no next page
+        if not ds.get('next_link'):
+            break
+
+        pagenum += 1
+        next_url = _baseurl + ds['next_link']
 
 
 def upstream_role_iterator(
@@ -46,7 +310,9 @@ def upstream_role_iterator(
     limit=None,
     github_user=None,
     github_repo=None,
-    role_name=None
+    role_name=None,
+    get_versions=True,
+    start_page=None,
 ):
     """Abstracts the pagination of v1 roles into a generator with error handling."""
     logger.info(f'baseurl1: {baseurl}')
@@ -67,15 +333,23 @@ def upstream_role_iterator(
         if role_name:
             params.append(f'name={role_name}')
         next_url = _baseurl + '/api/v1/roles/?' + '&'.join(params)
+    else:
+        next_url = _baseurl + '/api/v1/roles/'
+
+    if start_page:
+        if '?' in next_url:
+            next_url += f'&page={start_page}'
+        else:
+            next_url = next_url.rstrip('/') + f'/?page={start_page}'
 
     namespace_cache = {}
 
     pagenum = 0
     role_count = 0
     while next_url:
-        logger.info(f'fetch {pagenum} {next_url}')
+        logger.info(f'fetch {pagenum} {next_url} role-count:{role_count}')
 
-        page = requests.get(next_url)
+        page = safe_fetch(next_url)
 
         # Some upstream pages return ISEs for whatever reason.
         if page.status_code >= 500:
@@ -95,7 +369,8 @@ def upstream_role_iterator(
             role_upstream_url = _baseurl + f'/api/v1/roles/{remote_id}/'
             logger.info(f'fetch {role_upstream_url}')
 
-            role_page = requests.get(role_upstream_url)
+            # role_page = requests.get(role_upstream_url)
+            role_page = safe_fetch(role_upstream_url)
             if role_page.status_code == 404:
                 continue
 
@@ -110,15 +385,29 @@ def upstream_role_iterator(
             # Get the namespace+owners
             ns_id = role_data['summary_fields']['namespace']['id']
             if ns_id not in namespace_cache:
+                logger.info(_baseurl + f'/api/v1/namespaces/{ns_id}/')
                 ns_url = _baseurl + f'/api/v1/namespaces/{ns_id}/'
-                namespace_data = requests.get(ns_url).json()
+
+                nsd_rr = safe_fetch(ns_url)
+                try:
+                    namespace_data = nsd_rr.json()
+                except requests.exceptions.JSONDecodeError:
+                    continue
                 namespace_cache[ns_id] = namespace_data
+
+                # get the owners too
+                namespace_cache[ns_id]['summary_fields']['owners'] = \
+                    get_namespace_owners_details(_baseurl, ns_id)
+
             else:
                 namespace_data = namespace_cache[ns_id]
 
             # Get all of the versions because they have more info than the summary
-            versions_url = role_upstream_url + 'versions'
-            role_versions = paginated_results(versions_url)
+            if get_versions:
+                versions_url = role_upstream_url + 'versions'
+                role_versions = paginated_results(versions_url)
+            else:
+                role_versions = []
 
             # send the role
             role_count += 1

--- a/galaxy_ng/app/utils/legacy.py
+++ b/galaxy_ng/app/utils/legacy.py
@@ -1,0 +1,134 @@
+# import trio
+
+# import datetime
+import re
+# import sys
+# import time
+# import django_guid
+from django.contrib.auth import get_user_model
+
+# from django.core.management.base import BaseCommand
+# from pulp_ansible.app.models import AnsibleRepository
+# from pulpcore.plugin.constants import TASK_FINAL_STATES, TASK_STATES
+# from pulpcore.plugin.tasking import dispatch
+
+from galaxy_ng.app.api.v1.models import LegacyNamespace
+from galaxy_ng.app.models import Namespace
+# from galaxy_ng.app.tasks.namespaces import _create_pulp_namespace
+# from galaxy_ng.app.utils.galaxy import upstream_collection_iterator
+# from galaxy_ng.app.utils.galaxy import upstream_namespace_iterator
+# from galaxy_ng.app.utils.galaxy import upstream_role_iterator
+# from galaxy_ng.app.utils.galaxy import find_namespace
+from galaxy_ng.app.utils.galaxy import generate_unverified_email
+from galaxy_ng.app.utils.namespaces import generate_v3_namespace_from_attributes
+from galaxy_ng.app.utils.rbac import add_user_to_v3_namespace
+
+# from pulpcore.plugin.files import PulpTemporaryUploadedFile
+# from pulpcore.plugin.download import HttpDownloader
+# from pulp_ansible.app.models import AnsibleNamespaceMetadata, AnsibleNamespace
+# from pulpcore.plugin.tasking import add_and_remove, dispatch
+# from pulpcore.plugin.models import RepositoryContent, Artifact, ContentArtifact
+
+
+User = get_user_model()
+
+
+def sanitize_avatar_url(url):
+    '''Remove all the non-url characters people have put in their avatar urls'''
+    regex = (
+        r"(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)"
+        + r"(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|"
+        + r"(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'\".,<>?«»“”‘’]))"
+    )
+
+    for match in re.findall(regex, url):
+        if match and 'http' in match[0]:
+            return match[0]
+
+    return None
+
+
+def process_namespace(namespace_name, namespace_info):
+    '''Do all the work to sync a legacy namespace and build it's v3 counterpart'''
+
+    # get or create a legacy namespace with an identical name first ...
+    legacy_namespace, legacy_namespace_created = \
+        LegacyNamespace.objects.get_or_create(name=namespace_name)
+
+    if legacy_namespace.namespace:
+        namespace = legacy_namespace.namespace
+        namespace_created = False
+
+    else:
+        _owners = namespace_info['summary_fields']['owners']
+        _owners = [(x['github_id'], x['username']) for x in _owners]
+        _matched_owners = [x for x in _owners if x[1].lower() == namespace_name.lower()]
+
+        if _matched_owners:
+            _owner_id = _matched_owners[0][0]
+            v3_namespace_name = \
+                generate_v3_namespace_from_attributes(username=namespace_name, github_id=_owner_id)
+        else:
+            v3_namespace_name = generate_v3_namespace_from_attributes(username=namespace_name)
+
+        namespace, namespace_created = Namespace.objects.get_or_create(name=v3_namespace_name)
+
+    # bind legacy and v3
+    legacy_namespace.namespace = namespace
+    legacy_namespace.save()
+
+    changed = False
+
+    if namespace_info['avatar_url'] and not namespace.avatar_url:
+        avatar_url = sanitize_avatar_url(namespace_info['avatar_url'])
+        if avatar_url:
+            namespace.avatar_url = avatar_url
+            changed = True
+
+    if namespace_info['company'] and not namespace.company:
+        if len(namespace_info['company']) >= 60:
+            namespace.company = namespace_info['company'][:60]
+        else:
+            namespace.company = namespace_info['company']
+        changed = True
+
+    if namespace_info['email'] and not namespace.email:
+        namespace.email = namespace_info['email']
+        changed = True
+
+    if namespace_info['description'] and not namespace.description:
+        if len(namespace_info['description']) >= 60:
+            namespace.description = namespace_info['description'][:60]
+        else:
+            namespace.description = namespace_info['description']
+        changed = True
+
+    if changed:
+        namespace.save()
+
+    for owner_info in namespace_info['summary_fields']['owners']:
+
+        unverified_email = generate_unverified_email(owner_info['github_id'])
+
+        owner_created = False
+        owner = User.objects.filter(username=unverified_email).first()
+        if not owner:
+            owner = User.objects.filter(email=unverified_email).first()
+
+        # should always have an email set with default of the unverified email
+        if owner and not owner.email:
+            owner.email = unverified_email
+            owner.save()
+
+        if not owner:
+
+            owner, owner_created = User.objects.get_or_create(username=owner_info['username'])
+
+            if owner_created or not owner.email:
+                # the new user should have the unverified email until they actually login
+                owner.email = unverified_email
+                owner.save()
+
+        add_user_to_v3_namespace(owner, namespace)
+
+    return legacy_namespace, namespace

--- a/galaxy_ng/app/utils/namespaces.py
+++ b/galaxy_ng/app/utils/namespaces.py
@@ -1,0 +1,70 @@
+import re
+from galaxy_importer.constants import NAME_REGEXP
+
+
+def generate_v3_namespace_from_attributes(username=None, github_id=None):
+
+    if validate_namespace_name(username):
+        return username
+
+    transformed = transform_namespace_name(username)
+    if validate_namespace_name(transformed):
+        return transformed
+
+    return map_v3_namespace(username)
+
+
+def map_v3_namespace(v1_namespace):
+    """
+    1. remove unwanted characters
+    2. convert - to _
+    3. if name starts with number or _, prepend prefix
+    """
+
+    prefix = "gh_"
+    no_start = tuple(x for x in "0123456789_")
+
+    name = v1_namespace.lower()
+    name = name.replace("-", "_")
+    name = re.sub(r'[^a-z0-9_]', "", name)
+    if name.startswith(no_start) or len(name) <= 2:
+        name = prefix + name.lstrip("_")
+
+    return name
+
+
+def generate_available_namespace_name(Namespace, login, github_id):
+    # we're only here because session_login is already taken as
+    # a namespace name and we need a new one for the user
+
+    # this makes the weird gh_{BLAH} name ...
+    # namespace_name = ns_utils.map_v3_namespace(session_login)
+
+    # we should iterate and append 0,1,2,3,4,5,etc on the login name until we find one that is free
+    counter = -1
+    while True:
+        counter += 1
+        namespace_name = transform_namespace_name(login) + str(counter)
+        if Namespace.objects.filter(name=namespace_name).count() == 0:
+            return namespace_name
+
+
+def validate_namespace_name(name):
+    """Similar validation to the v3 namespace serializer."""
+
+    # galaxy has "extra" requirements for a namespace ...
+    # https://github.com/ansible/galaxy-importer/blob/master/galaxy_importer/constants.py#L45
+    # NAME_REGEXP = re.compile(r"^(?!.*__)[a-z]+[0-9a-z_]*$")
+
+    if not NAME_REGEXP.match(name):
+        return False
+    if len(name) < 2:
+        return False
+    if name.startswith('_'):
+        return False
+    return True
+
+
+def transform_namespace_name(name):
+    """Convert namespace name to valid v3 name."""
+    return name.replace('-', '_').lower()

--- a/galaxy_ng/app/utils/rbac.py
+++ b/galaxy_ng/app/utils/rbac.py
@@ -62,6 +62,11 @@ def add_user_to_v3_namespace(user: User, namespace: Namespace) -> None:
     assign_role(role_name, user, namespace)
 
 
+def remove_user_from_v3_namespace(user: User, namespace: Namespace) -> None:
+    role_name = 'galaxy.collection_namespace_owner'
+    remove_role(role_name, user, namespace)
+
+
 def get_v3_namespace_owners(namespace: Namespace) -> list:
     """
     Return a list of users that own a v3 namespace.
@@ -78,5 +83,19 @@ def get_v3_namespace_owners(namespace: Namespace) -> list:
         include_model_permissions=False
     )
     owners.extend(list(current_users))
-    owners = sorted(set(owners))
-    return owners
+    unique_owners = []
+    for owner in owners:
+        if owner not in unique_owners:
+            unique_owners.append(owner)
+    return unique_owners
+
+
+def get_owned_v3_namespaces(user: User):
+
+    owned = []
+    for namespace in Namespace.objects.all():
+        owners = get_v3_namespace_owners(namespace)
+        if user in owners:
+            owned.append(namespace)
+
+    return owned

--- a/galaxy_ng/social/pipeline/user.py
+++ b/galaxy_ng/social/pipeline/user.py
@@ -2,6 +2,7 @@
 
 
 from galaxy_ng.app.models.auth import User
+from galaxy_ng.app.utils.galaxy import generate_unverified_email
 
 
 USER_FIELDS = ['username', 'email']
@@ -14,6 +15,9 @@ def get_username(strategy, details, backend, user=None, *args, **kwargs):
 def create_user(strategy, details, backend, user=None, *args, **kwargs):
 
     if user:
+        if user.username != details.get('username'):
+            user.username = details.get('username')
+            user.save()
         return {'is_new': False}
 
     fields = dict(
@@ -26,16 +30,102 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
 
     # bypass the strange logic that can't find the user ... ?
     username = details.get('username')
-    if username:
-        found_user = User.objects.filter(username=username).first()
-        if found_user is not None:
-            return {
-                'is_new': False,
-                'user': found_user
-            }
+    email = details.get('email')
+    github_id = details.get('id')
+    if not github_id:
+        github_id = kwargs['response']['id']
+
+    # check for all possible emails ...
+    possible_emails = [generate_unverified_email(github_id), email]
+    for possible_email in possible_emails:
+        found_email = User.objects.filter(email=possible_email).first()
+        if found_email is not None:
+            break
+
+    if found_email is not None:
+
+        # fix the username if they've changed their login since last time
+        if found_email.username != username:
+            found_email.username = username
+            found_email.save()
+
+        if found_email.email != email:
+            found_email.email = email
+            found_email.save()
+
+        return {
+            'is_new': False,
+            'user': found_email
+        }
+
+    found_username = User.objects.filter(username=username).first()
+    if found_username is not None and found_username.email:
+        # we have an old user who's got the username but it's not the same person logging in ...
+        # so change that username? The email should be unique right?
+        found_username.username = found_username.email
+        found_username.save()
+
+    found_username = User.objects.filter(username=username).first()
+    if found_username is not None:
+        return {
+            'is_new': False,
+            'user': found_username
+        }
 
     new_user = strategy.create_user(**fields)
     return {
         'is_new': True,
         'user': new_user
     }
+
+
+def user_details(strategy, details, backend, user=None, *args, **kwargs):
+    """Update user details using data from provider."""
+
+    if not user:
+        return
+
+    changed = False  # flag to track changes
+
+    # Default protected user fields (username, id, pk and email) can be ignored
+    # by setting the SOCIAL_AUTH_NO_DEFAULT_PROTECTED_USER_FIELDS to True
+    if strategy.setting("NO_DEFAULT_PROTECTED_USER_FIELDS") is True:
+        protected = ()
+    else:
+        protected = (
+            "username",
+            "id",
+            "pk",
+            "email",
+            "password",
+            "is_active",
+            "is_staff",
+            "is_superuser",
+        )
+
+    protected = protected + tuple(strategy.setting("PROTECTED_USER_FIELDS", []))
+
+    # Update user model attributes with the new data sent by the current
+    # provider. Update on some attributes is disabled by default, for
+    # example username and id fields. It's also possible to disable update
+    # on fields defined in SOCIAL_AUTH_PROTECTED_USER_FIELDS.
+    field_mapping = strategy.setting("USER_FIELD_MAPPING", {}, backend)
+    for name, value in details.items():
+        # Convert to existing user field if mapping exists
+        name = field_mapping.get(name, name)
+        if value is None or not hasattr(user, name) or name in protected:
+            continue
+
+        current_value = getattr(user, name, None)
+        if current_value == value:
+            continue
+
+        immutable_fields = tuple(strategy.setting("IMMUTABLE_USER_FIELDS", []))
+        if name in immutable_fields and current_value:
+            continue
+
+        changed = True
+        setattr(user, name, value)
+
+    if changed:
+        strategy.storage.user.changed(user)

--- a/galaxy_ng/tests/integration/api/test_aiindex.py
+++ b/galaxy_ng/tests/integration/api/test_aiindex.py
@@ -91,6 +91,7 @@ def test_legacy_namespace_add_list_remove_aiindex(ansible_config, legacy_namespa
 
     cfg = ansible_config("github_user_1")
     with SocialGithubClient(config=cfg) as client:
+
         assert (
             client.post(
                 "_ui/v1/ai_deny_index/legacy_namespace/",

--- a/galaxy_ng/tests/integration/community/test_community_namespace_rbac.py
+++ b/galaxy_ng/tests/integration/community/test_community_namespace_rbac.py
@@ -1,0 +1,470 @@
+"""test_community.py - Tests related to the community featureset.
+"""
+
+import json
+import pytest
+import random
+import string
+
+from ..utils import (
+    get_client,
+    SocialGithubClient,
+    GithubAdminClient,
+    cleanup_namespace,
+)
+from ..utils.legacy import (
+    cleanup_social_user,
+    wait_for_v1_task,
+)
+
+
+pytestmark = pytest.mark.qa  # noqa: F821
+
+
+def extract_default_config(ansible_config):
+    base_cfg = ansible_config('github_user_1')
+    cfg = {}
+    cfg['token'] = None
+    cfg['url'] = base_cfg.get('url')
+    cfg['auth_url'] = base_cfg.get('auth_url')
+    cfg['github_url'] = base_cfg.get('github_url')
+    cfg['github_api_url'] = base_cfg.get('github_api_url')
+    return cfg
+
+
+@pytest.mark.deployment_community
+def test_admin_can_import_legacy_roles(ansible_config):
+
+    github_user = 'jctannerTEST'
+    github_repo = 'role1'
+    cleanup_social_user(github_user, ansible_config)
+    cleanup_social_user(github_user.lower(), ansible_config)
+
+    admin_config = ansible_config("admin")
+    admin_client = get_client(
+        config=admin_config,
+        request_token=False,
+        require_auth=True
+    )
+
+    # do an import with the admin ...
+    payload = {
+        'github_repo': github_repo,
+        'github_user': github_user,
+    }
+    resp = admin_client('/api/v1/imports/', method='POST', args=payload)
+    task_id = resp['results'][0]['id']
+    res = wait_for_v1_task(task_id=task_id, api_client=admin_client, check=False)
+
+    # it should have failed because of the missing v1+v3 namespaces ...
+    assert res['results'][0]['summary_fields']['task_messages'][0]['state'] == 'FAILED', res
+
+    # make the legacy namespace
+    ns_payload = {
+        'name': github_user
+    }
+    resp = admin_client('/api/v1/namespaces/', method='POST', args=ns_payload)
+    assert resp['name'] == github_user, resp
+    assert not resp['summary_fields']['owners'], resp
+    assert not resp['summary_fields']['provider_namespaces'], resp
+    v1_id = resp['id']
+
+    # make the v3 namespace
+    v3_payload = {
+        'name': github_user.lower(),
+        'groups': [],
+    }
+    resp = admin_client('/api/_ui/v1/namespaces/', method='POST', args=v3_payload)
+    assert resp['name'] == github_user.lower(), resp
+    v3_id = resp['id']
+
+    # bind the v3 namespace to the v1 namespace
+    v3_bind = {
+        'id': v3_id
+    }
+    admin_client(f'/api/v1/namespaces/{v1_id}/providers/', method='POST', args=v3_bind)
+
+    # check the providers ...
+    resp = admin_client(f'/api/v1/namespaces/{v1_id}/providers/')
+    assert resp[0]['id'] == v3_id, resp
+
+    # try to import again ...
+    resp = admin_client('/api/v1/imports/', method='POST', args=payload)
+    task_id = resp['results'][0]['id']
+    res = wait_for_v1_task(task_id=task_id, api_client=admin_client, check=False)
+    assert res['results'][0]['summary_fields']['task_messages'][0]['state'] == 'SUCCESS', res
+
+
+@pytest.mark.skip(reason="not ready yet")
+@pytest.mark.deployment_community
+def test_social_auth_v3_rbac_workflow(ansible_config):
+
+    # cleanup_social_user('gh01', ansible_config)
+    base_cfg = ansible_config('github_user_1')
+
+    ga = GithubAdminClient()
+    suffix = ''.join([random.choice(string.ascii_lowercase) for x in range(0, 5)])
+    user_a = ga.create_user(login='0xEEE-32i-' + suffix)
+    user_a['username'] = user_a['login']
+    user_a['token'] = None
+    user_a['url'] = base_cfg.get('url')
+    user_a['auth_url'] = base_cfg.get('auth_url')
+    user_a['github_url'] = base_cfg.get('github_url')
+    user_a['github_api_url'] = base_cfg.get('github_api_url')
+    l_ns_name = user_a['username']
+
+    # login once to confirm v3 namespace creation
+    with SocialGithubClient(config=user_a) as client:
+        a_resp = client.get('_ui/v1/me/')
+        a_ds = a_resp.json()
+        assert a_ds['username'] == user_a['username']
+
+        ns_resp = client.get('_ui/v1/my-namespaces/')
+        ns_ds = ns_resp.json()
+        assert ns_ds['meta']['count'] == 1, ns_ds
+
+        original_namespace = ns_ds['data'][0]['name']
+
+        # verify the new legacy namespace has right owner ...
+        l_ns_name = user_a['username']
+        l_resp = client.get(f'v1/namespaces/?name={l_ns_name}')
+        l_ns_ds = l_resp.json()
+        assert l_ns_ds['count'] == 1, l_ns_ds
+        assert l_ns_ds['results'][0]['name'] == l_ns_name, l_ns_ds
+        assert l_ns_ds['results'][0]['summary_fields']['owners'][0]['username'] == \
+            user_a['username'], l_ns_ds
+
+        # verify the legacy provider namespace is the v3 namespace
+        provider_namespaces = l_ns_ds['results'][0]['summary_fields']['provider_namespaces']
+        assert len(provider_namespaces) == 1
+        provider_namespace = provider_namespaces[0]
+        assert provider_namespace['name'].startswith('gh_')
+
+    # make a new login
+    new_login = user_a['login'] + '-changed'
+
+    # change the user's login and try again
+    user_b = ga.modify_user(uid=user_a['id'], change=('login', new_login))
+    user_b['username'] = user_b['login']
+    user_b['token'] = None
+    user_b['url'] = base_cfg.get('url')
+    user_b['auth_url'] = base_cfg.get('auth_url')
+    user_b['github_url'] = base_cfg.get('github_url')
+    user_b['github_api_url'] = base_cfg.get('github_api_url')
+
+    # current_users = ga.list_users()
+
+    with SocialGithubClient(config=user_b) as client:
+        b_resp = client.get('_ui/v1/me/')
+        b_ds = b_resp.json()
+
+        # the UID should have stayed the same
+        assert b_ds['id'] == a_ds['id']
+
+        # the backend should have changed the username
+        assert b_ds['username'] == user_b['username']
+
+        # now check the namespaces again ...
+        ns_resp2 = client.get('_ui/v1/my-namespaces/')
+        ns_ds2 = ns_resp2.json()
+
+        # there should be 2 ...
+        assert ns_ds2['meta']['count'] == 2, ns_ds2
+
+        # one of them should be the one created with the previous username
+        ns_names = [x['name'] for x in ns_ds2['data']]
+        assert original_namespace in ns_names, ns_names
+
+        # verify the previous legacy namespace has right owner ...
+        l_resp = client.get(f'v1/namespaces/?name={l_ns_name}')
+        l_ns_ds = l_resp.json()
+        assert l_ns_ds['count'] == 1, l_ns_ds
+        assert l_ns_ds['results'][0]['name'] == l_ns_name, l_ns_ds
+        assert l_ns_ds['results'][0]['summary_fields']['owners'][0]['username'] == \
+            user_b['username'], l_ns_ds
+
+        # verify the new legacy namespace has right owner ...
+        new_l_ns = user_b['username']
+        new_l_resp = client.get(f'v1/namespaces/?name={new_l_ns}')
+        new_l_ns_ds = new_l_resp.json()
+        assert new_l_ns_ds['count'] == 1, new_l_ns_ds
+        assert new_l_ns_ds['results'][0]['name'] == new_l_ns, new_l_ns_ds
+        assert new_l_ns_ds['results'][0]['summary_fields']['owners'][0]['username'] == \
+            user_b['username'], new_l_ns_ds
+
+        # verify the new legacy ns has the new provider ns
+        provider_namespaces = new_l_ns_ds['results'][0]['summary_fields']['provider_namespaces']
+        assert len(provider_namespaces) == 1
+        provider_namespace = provider_namespaces[0]
+        assert provider_namespace['name'].startswith('gh_')
+
+    with SocialGithubClient(config=user_b) as client:
+
+        pass
+
+        # the new login should be able to find all of their legacy namespaces
+        # import epdb; epdb.st()
+
+        # the new login should be able to import to BOTH legacy namespaces
+
+        # the new login should be able to find all of their v3 namespaces
+
+        # the new login should be able to upload to BOTH v3 namespaces
+
+    # TODO ... what happens with the other owners of a v1 namespace when
+    #   the original owner changes their login?
+    # TODO ... what happens with the other owners of a v3 namespace when
+    #   the original owner changes their login?
+
+
+@pytest.mark.deployment_community
+def test_social_user_with_reclaimed_login(ansible_config):
+
+    '''
+    [jtanner@jtw530 galaxy_user_analaysis]$ head -n1 data/user_errors.csv
+    galaxy_uid,galaxy_username,github_id,github_login,actual_github_id,actual_github_login
+    [jtanner@jtw530 galaxy_user_analaysis]$ grep sean-m-sullivan data/user_errors.csv
+    33901,Wilk42,30054029,sean-m-sullivan,30054029,sean-m-sullivan
+    '''
+
+    # a user logged into galaxy once with login "foo"
+    # the user then changed their name in github to "bar"
+    # the user then logged back into galaxy ...
+    #
+    #   1) social auth updates it's own data based on the github userid
+    #   2) galaxy's user still has the old login but is linked to the same social account
+
+    # What happens when someone claims the old username ..?
+    #
+    #   Once they login to galaxy they will get the "foo" login as their username?
+    #   the "foo" namespace will not belong to them
+    #   the "bar" namespace will not belong to them
+    #   do they own -any- namespaces?
+
+    ga = GithubAdminClient()
+    ga.delete_user(login='Wilk42')
+    ga.delete_user(login='sean-m-sullivan')
+    cleanup_social_user('Wilk42', ansible_config)
+    cleanup_social_user('sean-m-sullivan', ansible_config)
+    cleanup_social_user('sean-m-sullivan@redhat.com', ansible_config)
+
+    default_cfg = extract_default_config(ansible_config)
+
+    old_login = 'Wilk42'
+    email = 'sean-m-sullivan@redhat.com'
+    user_a = ga.create_user(login=old_login, email=email)
+    user_a.update(default_cfg)
+    user_a['username'] = old_login
+
+    # login once to make user
+    with SocialGithubClient(config=user_a) as client:
+
+        a_resp = client.get('_ui/v1/me/')
+        ns_resp = client.get('_ui/v1/my-namespaces/')
+        ns_ds = ns_resp.json()
+        namespace_names_a = [x['name'] for x in ns_ds['data']]
+
+    # make a sean_m_sullivan namespace owned by the old login ... ?
+
+    # make a new login
+    new_login = 'sean-m-sullivan'
+
+    # change the user's login and try again
+    user_b = ga.modify_user(uid=user_a['id'], change=('login', new_login))
+    user_b.update(default_cfg)
+    user_b['username'] = new_login
+
+    # sean-m-sullivan never logs in again ...
+    '''
+    with SocialGithubClient(config=user_b) as client:
+        b_resp = client.get('_ui/v1/me/')
+    '''
+
+    # Let some new person claim the old login ...
+    user_c = ga.create_user(login=old_login, email='shadyperson@haxx.net')
+    user_c.update(default_cfg)
+    user_c['username'] = old_login
+
+    with SocialGithubClient(config=user_c) as client:
+        c_resp = client.get('_ui/v1/me/')
+        ns_resp_c = client.get('_ui/v1/my-namespaces/')
+        ns_ds_c = ns_resp_c.json()
+        namespace_names_c = [x['name'] for x in ns_ds_c['data']]
+
+    # user_a and user_c should have different galaxy uids
+    assert a_resp.json()['id'] != c_resp.json()['id']
+
+    # user_c should have the old login
+    assert c_resp.json()['username'] == old_login
+
+    # user_c should not own the namespaces of user_a
+    for ns in namespace_names_a:
+        assert ns not in namespace_names_c
+
+    # now sean logs in with his new login ...
+    with SocialGithubClient(config=user_b) as client:
+        b_resp = client.get('_ui/v1/me/')
+        ns_resp_b = client.get('_ui/v1/my-namespaces/')
+        ns_ds_b = ns_resp_b.json()
+        namespace_names_b = [x['name'] for x in ns_ds_b['data']]
+
+    # his ID should be the same
+    assert b_resp.json()['id'] == a_resp.json()['id']
+
+    # his username should be the new login
+    assert b_resp.json()['username'] == new_login
+
+    # he should own his old namespace AND a transformed one from his new login
+    assert namespace_names_b == ['wilk42', 'sean_m_sullivan']
+
+
+@pytest.mark.deployment_community
+def test_social_user_sync_with_changed_login(ansible_config):
+
+    # https://galaxy.ansible.com/api/v1/users/?username=Wilk42
+    #   github_id:30054029
+
+    # https://galaxy.ansible.com/api/v1/roles/21352/
+    #   Wilk42/kerb_ldap_setup
+    #   Wilk42.kerb_ldap_setup
+    # https://galaxy.ansible.com/api/v1/namespaces/1838/
+    #   owner: 33901:Wilk42
+
+    ga = GithubAdminClient()
+    ga.delete_user(login='Wilk42')
+    ga.delete_user(login='sean-m-sullivan')
+    cleanup_social_user('Wilk42', ansible_config)
+    cleanup_social_user('wilk42', ansible_config)
+    cleanup_social_user('wilk420', ansible_config)
+    cleanup_social_user('Wilk420', ansible_config)
+    cleanup_social_user('wilk421', ansible_config)
+    cleanup_social_user('Wilk421', ansible_config)
+    cleanup_social_user('sean-m-sullivan', ansible_config)
+    cleanup_social_user('sean-m-sullivan@redhat.com', ansible_config)
+    cleanup_social_user('30054029@GALAXY.GITHUB.UNVERIFIED.COM', ansible_config)
+
+    default_cfg = extract_default_config(ansible_config)
+
+    # sync the wilk42 v1 namespace ...
+    admin_config = ansible_config("admin")
+    admin_client = get_client(
+        config=admin_config,
+        request_token=False,
+        require_auth=True
+    )
+
+    # find all the wilk* namespaces and clean them up ...
+    resp = admin_client('/api/v3/namespaces/')
+    nsmap = dict((x['name'], x) for x in resp['data'])
+    for nsname, nsdata in nsmap.items():
+        if not nsname.startswith('wilk'):
+            continue
+        cleanup_namespace(nsname, api_client=admin_client)
+
+    # v1 sync the user's roles and namespace ...
+    pargs = json.dumps({"github_user": 'Wilk42', "limit": 1}).encode('utf-8')
+    resp = admin_client('/api/v1/sync/', method='POST', args=pargs)
+    wait_for_v1_task(resp=resp, api_client=admin_client)
+
+    # should have same roles
+    roles_resp = admin_client.request('/api/v1/roles/?namespace=Wilk42')
+    assert roles_resp['count'] >= 1
+    roles = roles_resp['results']
+    v1_namespace_summary = roles[0]['summary_fields']['namespace']
+    v1_namespace_id = v1_namespace_summary['id']
+    v1_namespace_name = v1_namespace_summary['name']
+
+    assert v1_namespace_name == 'Wilk42'
+
+    # should have a v1 namespace with Wilk42 as the owner?
+    ns1_owners_resp = admin_client.request(f'/api/v1/namespaces/{v1_namespace_id}/owners/')
+    assert ns1_owners_resp
+    ns1_owners_ids = [x['id'] for x in ns1_owners_resp]
+    ns1_owners_usernames = [x['username'] for x in ns1_owners_resp]
+    assert 'Wilk42' in ns1_owners_usernames
+
+    # should have a v3 namespace
+    ns1_resp = admin_client.request(f'/api/v1/namespaces/{v1_namespace_id}/')
+    provider_namespaces = ns1_resp['summary_fields']['provider_namespaces']
+    assert provider_namespaces
+    provider_namespace = provider_namespaces[0]
+    # v3_namespace_id = provider_namespace['id']
+    v3_namespace_name = provider_namespace['name']
+    assert v3_namespace_name == 'wilk42'
+
+    # now some new person who took Wilk42 logs in ...
+    hacker = ga.create_user(login='Wilk42', email='1337h@xx.net')
+    hacker['username'] = hacker['login']
+    hacker.update(default_cfg)
+    with SocialGithubClient(config=hacker) as client:
+        hacker_me_resp = client.get('_ui/v1/me/')
+        hacker_me_ds = hacker_me_resp.json()
+
+        # check the hacker's namespaces ...
+        hacker_ns_resp = client.get('_ui/v1/my-namespaces/')
+        hacker_ns_ds = hacker_ns_resp.json()
+        hacker_ns_names = [x['name'] for x in hacker_ns_ds['data']]
+
+    # enure the hacker has a new uid
+    assert hacker_me_ds['id'] != ns1_owners_ids[0]
+
+    # ensure the hacker owns only some newly created v3 namespace
+    assert hacker_ns_names == ['wilk420']
+
+    # now sean-m-sullivan who used to be Wilk42 logs in ...
+    sean = ga.create_user(login='sean-m-sullivan', uid=30054029, email='sean-m-sullivan@redhat.com')
+    sean['username'] = sean['login']
+    sean.update(default_cfg)
+
+    with SocialGithubClient(config=sean) as client:
+        me_resp = client.get('_ui/v1/me/')
+        me_ds = me_resp.json()
+
+        # now check the namespaces again ...
+        ns_resp = client.get('_ui/v1/my-namespaces/')
+        ns_ds = ns_resp.json()
+        sean_ns_names = [x['name'] for x in ns_ds['data']]
+
+    # he should have the appropriate username
+    assert me_ds['username'] == 'sean-m-sullivan'
+    # he should own the old and a new v3 namespaces
+    assert sean_ns_names == ['wilk42', 'sean_m_sullivan']
+    # his uid should have remained the same
+    assert me_ds['id'] == ns1_owners_ids[0]
+
+    # he should own the original v1 namespaces
+    ns1_owners_resp_after = admin_client.request(f'/api/v1/namespaces/{v1_namespace_id}/owners/')
+    ns1_owner_names_after = [x['username'] for x in ns1_owners_resp_after]
+    assert ns1_owner_names_after == ['sean-m-sullivan']
+
+    # he should own a new v1 namespace too ...
+    ns_resp = admin_client('/api/v1/namespaces/?owner=sean-m-sullivan')
+    assert ns_resp['count'] == 2
+    v1_ns_names = [x['name'] for x in ns_resp['results']]
+    assert v1_ns_names == ['Wilk42', 'sean-m-sullivan']
+
+    # what happens when someone installs Wilk42's roles ...
+    #   galaxy.ansible.com shows the role as wilk42/kerb_ldap_setup
+    #   installing with wilk42.kerb_ldap_setup and Wilk42.kerb_ldap_setup should both work
+    #   the backend finds the role with owner__username=wilk42 AND owner__username=Wilk42
+    #   the role data has github_repo=Wilk42 which is what the client uses
+    #    github then has a redirect from Wilk42/kerb_ldap_setup to sean-m-sullivan/kerb_ldap_setup
+    #   i believe that redirect no longer works after someone claims Wilk42
+
+    # core code ...
+    #   url = _urljoin(self.api_server, self.available_api_versions['v1'], "roles",
+    #                   "?owner__username=%s&name=%s" % (user_name, role_name))
+    # 	archive_url = 'https://github.com/%s/%s/archive/%s.tar.gz' %
+    #       (role_data["github_user"], role_data["github_repo"], self.version)
+
+    for role in roles:
+        for owner_username in ['Wilk42', 'wilk42']:
+            role_name = role['name']
+            role_data = admin_client.request(
+                f'/api/v1/roles/?owner__username={owner_username}&name={role_name}'
+            )
+            assert role_data['count'] == 1
+            assert role_data['results'][0]['id'] == role['id']
+            assert role_data['results'][0]['github_user'] == 'Wilk42'
+            assert role_data['results'][0]['github_repo'] == role['github_repo']
+            assert role_data['results'][0]['name'] == role['name']

--- a/galaxy_ng/tests/integration/utils/__init__.py
+++ b/galaxy_ng/tests/integration/utils/__init__.py
@@ -91,5 +91,5 @@ __all__ = (
     AnsibleDistroAndRepo,
     delete_all_collections,
     PulpObjectBase,
-    GithubAdminClient
+    GithubAdminClient,
 )

--- a/galaxy_ng/tests/integration/utils/legacy.py
+++ b/galaxy_ng/tests/integration/utils/legacy.py
@@ -8,7 +8,7 @@ from .users import (
 )
 
 
-def wait_for_v1_task(task_id=None, resp=None, api_client=None):
+def wait_for_v1_task(task_id=None, resp=None, api_client=None, check=True):
 
     if task_id is None:
         task_id = resp['task']
@@ -26,7 +26,10 @@ def wait_for_v1_task(task_id=None, resp=None, api_client=None):
             break
         time.sleep(.5)
 
-    assert state == 'SUCCESS'
+    if check:
+        assert state == 'SUCCESS'
+
+    return task_resp
 
 
 def clean_all_roles(ansible_config):

--- a/profiles/community/github_mock/flaskapp.py
+++ b/profiles/community/github_mock/flaskapp.py
@@ -68,10 +68,10 @@ USERS = {
         'email': 'jctannerTEST@gmail.com',
     },
     'geerlingguy': {
-        'id': 1004,
+        'id': 481677,
         'login': 'geerlingguy',
         'password': 'redhat',
-        'email': 'geerlingguy@gmail.com',
+        'email': 'geerlingguy@nohaxx.me',
     }
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-2197

depends on https://github.com/ansible/galaxy/pull/3248

**What this is doing:**

In the initial v1 implementation, legacy namespaces had an optional foreign key to a v3 namespace. Since many github logins don't conform to v3 namespace name requirements, those foreign keys weren't filled in.

Per AAH-2197 we are forcing all legacy namespaces to have a v3 namespace foreign key and to control access to the legacy namespace via rbac on the v3 namespace.

I've repurposed "provider" namespaces from the old v1 to expose the v3 namespace in the v1 viewsets. Now you can see what the actual v3 namespace for the legacy namespace is and how to get to it. When looking at the /owners endpoint, it will present the list of users that own the v3 namespace. Manipulating the v1 owners endpoint manipulates the v3 namespace's rbac.

**How it works:**

There's a bunch of helper utils written to build up an "algorithm" of sorts to consistently return some v3 suitable namespace name based on the github user's login and github id. The v3 namespace may match their login if valid or be a complete nonsensical name that they'd never use to push collections to, but that was the requirement given.

Along with making a bunch of v3 namespaces and linking them to the v1 namespaces, we have a github user validation scheme going on with trying to flip around email addresses on synced users to `<GITHUBID>@<SOMEPLACE>` until they actually login and have their true email set. 

All of this logic should be encapsulated and shared among the v1 sync code, the social auth code and the new django commands i've added.

Once the go-live date for beta galaaxy is hit, we need to remove all this v1 sync stuff and never do syncs again. If we eventually ship api/v1 downstream, then "sync" needs to be completely rethought. We shouldn't be second guessing our oauth provider and we shouldn't require a custom build of social-auth. 

**Testing**

`pulpcore-manager sync-galaxy-namespaces` encapsulates all of the magic in this PR. I decided not to implement it as a new REST endpoint for various reasons.

architecture ...

    pulpcore-manager sync-galaxy-namespaces
        upstream_namespace_iterator
            process_namespace
                 get or create legacy namespace
                 get or create v3 namespace
                 bind v3 namespace to legacy namespace
                 set v3 namespace metadata
                 set v3 namespace owners
