### PR TITLE
test for test_x_repo_search_acl_social_user instability in CI

### DIFF
--- a/CHANGES/2638.misc
+++ b/CHANGES/2638.misc
@@ -1,0 +1,1 @@
+Improve ``test_x_repo_search_acl_social_user`` and ``test_x_repo_search_acl_anonymous_user`` integration test stability

--- a/galaxy_ng/tests/integration/api/test_cross_repository_search.py
+++ b/galaxy_ng/tests/integration/api/test_cross_repository_search.py
@@ -67,7 +67,7 @@ def test_x_repo_search_acl_anonymous_user(ansible_config, auto_approved_artifact
     search_url = (
         api_prefix
         + '/v3/plugin/ansible/search/collection-versions/'
-        + f'?namespace={namespace}&name={name}'
+        + f'?namespace={namespace}&name={name}&repository_name=published'
     )
     resp = api_client.request(search_url)
     assert resp['meta']['count'] == 2
@@ -106,14 +106,14 @@ def test_x_repo_search_acl_social_user(ansible_config, auto_approved_artifacts):
     search_url = (
         api_prefix
         + '/v3/plugin/ansible/search/collection-versions/'
-        + f'?namespace={namespace}&name={name}'
+        + f'?namespace={namespace}&name={name}&repository_name=published'
     )
     resp = api_client.request(search_url)
     assert resp['meta']['count'] == 2
 
     search_url = (
         'v3/plugin/ansible/search/collection-versions/'
-        + f'?namespace={namespace}&name={name}'
+        + f'?namespace={namespace}&name={name}&repository_name=published'
     )
     cfg = ansible_config('github_user_1')
     with SocialGithubClient(config=cfg) as client:


### PR DESCRIPTION
No-Issue [AAH-2638](https://issues.redhat.com/browse/AAH-2638)

https://gist.github.com/jerabekjiri/f05ed52c1f3c1fdb68522f063f98fa1f

The `search_url` response includes the incremented collection version (`autohubtest2.immijnge-1.0.1`) in both the `staging` and `published` repositories at the same time. 
I'm not sure why this is happening, since in https://github.com/ansible/galaxy_ng/blob/01e89102e973c57581d3b6bafca6eb6be1b74080/galaxy_ng/tests/integration/conftest.py#L249C32-L249C32, after the collection is built, it waits for the collection to be in the published repository. Nevertheless, this solution fixes the issue by searching only in the published repository.
