### PR TITLE
CRC: move ANSIBLE_COLLECT_DOWNLOAD to envvars in clowd-app

### DIFF
--- a/docker/etc/settings.py
+++ b/docker/etc/settings.py
@@ -21,8 +21,6 @@ if one want to enable signing, then set the following variables
 on the per environment basis. e.g: export PULP_GALAXY_....
 """
 
-ANSIBLE_COLLECT_DOWNLOAD_LOG = True
-
 X_PULP_CONTENT_HOST = "pulp-content-app"
 X_PULP_CONTENT_PORT = 24816
 

--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -179,6 +179,10 @@ objects:
             value: ${GALAXY_FEATURE_FLAGS_DISPLAY_SIGNATURES}
           - name: PULP_GALAXY_FEATURE_FLAGS__execution_environments
             value: 'false'
+          - name: PULP_ANSIBLE_COLLECT_DOWNLOAD_LOG
+            value: ${ANSIBLE_COLLECT_DOWNLOAD_LOG}
+          - name: PULP_ANSIBLE_COLLECT_DOWNLOAD_COUNT
+            value: ${ANSIBLE_COLLECT_DOWNLOAD_COUNT}
         volumeMounts:
           - name: pulp-key
             mountPath: /etc/pulp/certs/database_fields.symmetric.key
@@ -397,6 +401,10 @@ parameters:
   value: "false"
 - name: PROMETHEUS_DIR
   value: "/tmp"
+- name: ANSIBLE_COLLECT_DOWNLOAD_LOG
+  value: "true"
+- name: ANSIBLE_COLLECT_DOWNLOAD_COUNT
+  value: "true"
 
 # signing requirements
 - name: ENABLE_SIGNING


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
* moves ANSIBLE_COLLECT_DOWNLOAD_LOG from settings.py to an envvar in clowd-app.yaml
* adds ANSIBLE_COLLECT_DOWNLOAD_COUNT as an envvar in clowd-app.yaml

This will allows for a more explicit configuration between crc and community deployments.

<!-- Add Jira issue link or replace with No-Issue -->
No-Issue

