### PR TITLE
fix markdown when linking to ansible-hub-ui

### DIFF
--- a/docs/dev/getting_started.md
+++ b/docs/dev/getting_started.md
@@ -38,7 +38,7 @@ Issues for Galaxy NG are tracked in Jira at https://issues.redhat.com/browse/AAH
 
 ## Submitting a Pull Request
 
-UI PRs should be submitted at (github.com/ansible/ansible-hub-ui)[https://github.com/ansible/ansible-hub-ui].
+UI PRs should be submitted at [github.com/ansible/ansible-hub-ui](https://github.com/ansible/ansible-hub-ui).
 
 When submitting a PR to either the UI or backend:
 


### PR DESCRIPTION
#### What is this PR doing:
fixes the markdown link syntax

<!-- Add Jira issue link or replace with No-Issue -->
Issue: No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
