### PR TITLE
hotfix: jsonschema import error

### DIFF
--- a/integration_requirements.txt
+++ b/integration_requirements.txt
@@ -5,7 +5,7 @@ ansible-core<2.13.0
 pytest
 orionutils
 openapi-spec-validator
-jsonschema
+jsonschema<=4.19.0
 hvac
 importlib_resources
 galaxykit @ git+https://github.com/ansible/galaxykit


### PR DESCRIPTION
Cannot import _legacy_validators from JSONSchema
due to: https://github.com/python-openapi/openapi-schema-validator/issues/131

No-Issue
