### PR TITLE
Ensure beta-galaxy users can delete and deprecate their collections

### DIFF
--- a/CHANGES/2632.bugfix
+++ b/CHANGES/2632.bugfix
@@ -1,0 +1,1 @@
+Ensure beta-galaxy users can delete and deprecate their collections

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -259,6 +259,27 @@ class AccessPolicyBase(AccessPolicyFromDB):
 
         return True
 
+    def v3_can_destroy_collections(self, request, view, action):
+        SOCIAL_AUTH_GITHUB_KEY = settings.get("SOCIAL_AUTH_GITHUB_KEY", default=None)
+        SOCIAL_AUTH_GITHUB_SECRET = settings.get("SOCIAL_AUTH_GITHUB_SECRET", default=None)
+        is_social_auth = all([SOCIAL_AUTH_GITHUB_KEY, SOCIAL_AUTH_GITHUB_SECRET])
+
+        user = request.user
+        perm = "ansible.delete_collection"
+        social_perm = "galaxy.change_namespace"
+        collection = view.get_object()
+        namespace = models.Namespace.objects.get(name=collection.namespace)
+
+        if not is_social_auth and user.has_perm(perm) and self.v3_can_view_repo_content(
+            request,
+            view,
+            action,
+        ):
+            return True
+        elif is_social_auth and user.has_perm(social_perm, namespace):
+            return True
+        return False
+
     def has_ansible_repo_perms(self, request, view, action, permission):
         """
         Check if the user has model or object-level permissions

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -35,7 +35,7 @@ _collection_statements = [
         "action": "destroy",
         "principal": "authenticated",
         "effect": "allow",
-        "condition": ["has_model_perms:ansible.delete_collection", "v3_can_view_repo_content"],
+        "condition": ["v3_can_destroy_collections"],
     },
     {
         "action": ["download"],

--- a/galaxy_ng/tests/integration/utils/client_social_github.py
+++ b/galaxy_ng/tests/integration/utils/client_social_github.py
@@ -201,6 +201,30 @@ class SocialGithubClient:
         resp = self._rs.put(this_url, headers=pheaders, json=data)
         return resp
 
+    def patch(
+        self,
+        relative_url: str = None,
+        absolute_url: str = None,
+        data=None
+    ) -> requests.models.Response:
+
+        pheaders = {
+            'Accept': 'application/json',
+            'X-CSRFToken': self.csrftoken,
+            'Cookie': f'csrftoken={self.csrftoken}; sessionid={self.sessionid}'
+        }
+
+        this_url = None
+        if absolute_url:
+            uri = urlparse(self.baseurl)
+            this_url = f"{uri.scheme}://{uri.netloc}{absolute_url}"
+        else:
+            this_url = self.baseurl + relative_url
+
+        # call patch
+        resp = self._rs.patch(this_url, headers=pheaders, json=data)
+        return resp
+
     def post(
         self,
         relative_url: str = None,


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
This PR adds an access policy condition to continue checking non-beta galaxy users permissions to delete/deprecate collections and and verifies social auth users have `galaxy.change_namespace` object permission on the collection's namespace in order to delete a collection.

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAH-2632

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
