### PR TITLE
optimize user v3 namespace owner lookups.

### DIFF
--- a/galaxy_ng/app/utils/rbac.py
+++ b/galaxy_ng/app/utils/rbac.py
@@ -1,7 +1,10 @@
+from pulpcore.plugin.models.role import Role
+
 from pulpcore.plugin.util import (
     assign_role,
     get_groups_with_perms_attached_roles,
     get_users_with_perms_attached_roles,
+    get_objects_for_user,
     remove_role
 )
 
@@ -92,10 +95,12 @@ def get_v3_namespace_owners(namespace: Namespace) -> list:
 
 def get_owned_v3_namespaces(user: User):
 
-    owned = []
-    for namespace in Namespace.objects.all():
-        owners = get_v3_namespace_owners(namespace)
-        if user in owners:
-            owned.append(namespace)
+    role_name = 'galaxy.collection_namespace_owner'
+    role = Role.objects.filter(name=role_name).first()
+    permission_codenames = role.permissions.values_list("codename", flat=True)
 
-    return owned
+    return get_objects_for_user(
+        user,
+        permission_codenames,
+        Namespace.objects.all()
+    )

--- a/galaxy_ng/tests/integration/community/test_community_namespace_rbac.py
+++ b/galaxy_ng/tests/integration/community/test_community_namespace_rbac.py
@@ -468,3 +468,9 @@ def test_social_user_sync_with_changed_login(ansible_config):
             assert role_data['results'][0]['github_user'] == 'Wilk42'
             assert role_data['results'][0]['github_repo'] == role['github_repo']
             assert role_data['results'][0]['name'] == role['name']
+
+
+@pytest.mark.skip(reason='this should be unit tested')
+@pytest.mark.deployment_community
+def test_rbac_utils_get_owned_v3_namespaces(ansible_config):
+    pass


### PR DESCRIPTION
the old code is probably causing timeouts during social logins because of the number of namespaces it has to iterate through.