### PR TITLE
New OpenAPI Spec Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Project documentation is hosted on [Read The Docs](http://galaxy-ng.readthedocs.
 
 ## OpenAPI Spec
 
-View the latest version of the spec by [clicking here](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/ansible/galaxy_ng/master/openapi/openapi.yaml).
+View the latest version of the spec at https://galaxy.ansible.com/api/v3/swagger-ui/. *(Directlink to [JSON](https://galaxy.ansible.com/api/v3/openapi.json) or [YAML](https://galaxy.ansible.com/api/v3/openapi.yaml))*
 
 ## Contributing
 


### PR DESCRIPTION
Based on this [Forum Thread](https://forum.ansible.com/t/how-to-submit-issues-for-https-github-com-ansible-galaxy-ng/1254?u=l3d) the URL to the OpenAPI Spec changed.

So there is the new one, I guess.

#### What is this PR doing:
Repleace the broken OpenAPI Spec Link


Issue: [AAH-####](https://forum.ansible.com/t/how-to-submit-issues-for-https-github-com-ansible-galaxy-ng/1254?u=l3d)

#### Reviewers must know:
I just changed a link in the README. Please have a look if this is really the correct one. Thanks