### PR TITLE
github_user should override namespace.name for legacy roles.

### DIFF
--- a/galaxy_ng/app/api/v1/serializers.py
+++ b/galaxy_ng/app/api/v1/serializers.py
@@ -169,11 +169,27 @@ class LegacyUserSerializer(serializers.ModelSerializer):
 
 class LegacyRoleSerializer(serializers.ModelSerializer):
 
+    # core cli uses this field to emit the list of
+    # results from a role search so it must exit
     username = serializers.SerializerMethodField()
+
+    # this has to be the real github org/user so that
+    # role installs will work
     github_user = serializers.SerializerMethodField()
+
+    # this has to be the real github repository name
+    # so that role installs will work
     github_repo = serializers.SerializerMethodField()
+
+    # this is the default or non-default branch
+    # the cli will use will installing the role.
+    # in old galaxy this was internall renamed to
+    # import_branch.
     github_branch = serializers.SerializerMethodField()
+
     commit = serializers.SerializerMethodField()
+    commit_message = serializers.SerializerMethodField()
+
     description = serializers.SerializerMethodField()
     summary_fields = serializers.SerializerMethodField()
     upstream_id = serializers.SerializerMethodField()
@@ -191,6 +207,7 @@ class LegacyRoleSerializer(serializers.ModelSerializer):
             'github_repo',
             'github_branch',
             'commit',
+            'commit_message',
             'name',
             'description',
             'summary_fields',
@@ -229,6 +246,8 @@ class LegacyRoleSerializer(serializers.ModelSerializer):
         of the role in the form of:
             https://github.com/<github_user>/<github_repo>/...
         """
+        if obj.full_metadata.get('github_user'):
+            return obj.full_metadata['github_user']
         return obj.namespace.name
 
     def get_username(self, obj):
@@ -252,10 +271,15 @@ class LegacyRoleSerializer(serializers.ModelSerializer):
         at install time. If not branch is given, the cli will default to
         the "master" branch.
         """
-        return obj.full_metadata.get('github_reference')
+        if obj.full_metadata.get('github_reference'):
+            return obj.full_metadata.get('github_reference')
+        return obj.full_metadata.get('github_branch')
 
     def get_commit(self, obj):
         return obj.full_metadata.get('commit')
+
+    def get_commit_message(self, obj):
+        return obj.full_metadata.get('commit_message')
 
     def get_description(self, obj):
         return obj.full_metadata.get('description')

--- a/galaxy_ng/app/api/v1/tasks.py
+++ b/galaxy_ng/app/api/v1/tasks.py
@@ -149,6 +149,7 @@ def legacy_role_import(
             'clone_url': clone_url,
             'tags': galaxy_info["galaxy_tags"],
             'commit': github_commit,
+            'github_user': github_user,
             'github_repo': github_repo,
             'github_reference': github_reference,
             'issue_tracker_url': galaxy_info["issue_tracker_url"] or clone_url + "/issues",
@@ -253,17 +254,18 @@ def legacy_sync_from_upstream(
         else:
             namespace, v3_namespace = nsmap[ns_data['name']]
 
-        ruser = rdata.get('github_user')
-        rname = rdata.get('name')
+        github_user = rdata.get('github_user')
+        role_name = rdata.get('name')
 
-        logger.info(f'POPULATE {ruser}.{rname}')
+        logger.info(f'POPULATE {github_user}.{role_name}')
 
-        rkey = (ruser, rname)
+        rkey = (github_user, role_name)
         remote_id = rdata['id']
         role_versions = rversions[:]
+        # github_user = rdata['github_user']
         github_repo = rdata['github_repo']
         github_branch = rdata['github_branch']
-        clone_url = f'https://github.com/{ruser}/{github_repo}'
+        clone_url = f'https://github.com/{github_user}/{github_repo}'
         sfields = rdata.get('summary_fields', {})
         role_tags = sfields.get('tags', [])
         commit_hash = rdata.get('commit')
@@ -288,7 +290,7 @@ def legacy_sync_from_upstream(
             logger.debug(f'SYNC create initial role for {rkey}')
             this_role, _ = LegacyRole.objects.get_or_create(
                 namespace=namespace,
-                name=rname
+                name=role_name
             )
             rmap[rkey] = this_role
         else:
@@ -305,6 +307,7 @@ def legacy_sync_from_upstream(
             'commit': commit_hash,
             'commit_message': commit_msg,
             'commit_url': commit_url,
+            'github_user': github_user,
             'github_repo': github_repo,
             'github_branch': github_branch,
             # 'github_reference': github_reference,

--- a/galaxy_ng/tests/integration/api/test_community.py
+++ b/galaxy_ng/tests/integration/api/test_community.py
@@ -513,7 +513,7 @@ def test_v1_autocomplete_search(ansible_config):
     # query by user
     resp = api_client(f'/api/v1/roles/?owner__username={github_user}')
     assert resp['count'] > 0
-    usernames = sorted(set([x['username'] for x in resp['results']]))
+    usernames = sorted(set([x['github_user'] for x in resp['results']]))
     assert usernames == [github_user]
 
     # validate autocomplete search only finds the relevant roles
@@ -566,11 +566,11 @@ def test_v1_role_pagination(ansible_config):
     urls, all_roles = get_roles(page_size=1, order_by='created')
     roles = [[x['created'], x['id']] for x in all_roles]
 
-    # make sure all 10 show up ...
-    assert len(roles) == 10
+    total_count = len(urls)
+    assert total_count >= 10
 
-    # make sure all pages were visited
-    assert len(urls) == 10
+    # make sure all 10 show up ...
+    assert len(roles) == total_count
 
     # make sure no duplicates found
     assert [x[1] for x in roles] == sorted(set([x[1] for x in roles]))
@@ -581,9 +581,10 @@ def test_v1_role_pagination(ansible_config):
     # repeat with ordered by name ...
     urls, all_roles = get_roles(page_size=1, order_by='name')
     roles = [x['name'] for x in all_roles]
+
     assert roles == sorted(roles)
-    assert len(roles) == 10
-    assert len(sorted(set(roles))) == 10
+    assert len(roles) == total_count
+    assert len(sorted(set(roles))) == total_count
 
     # cleanup
     clean_all_roles(ansible_config)

--- a/galaxy_ng/tests/integration/community/test_community_hijacking.py
+++ b/galaxy_ng/tests/integration/community/test_community_hijacking.py
@@ -42,13 +42,13 @@ def test_community_hijacking(ansible_config):
 
     usermap = {
         'jctannerTESTME': {
-            'uid': 1000,
+            'uid': 2000,
             'login': 'jctannerTESTME',
             # 'email': 'jctannerTESTME@haxx.net',
             'email': '',
         },
         'drod0258X': {
-            'uid': 1001,
+            'uid': 2001,
             'login': 'drod0258X',
             # 'email': 'drod0258X@haxx.net',
             'email': ''

--- a/galaxy_ng/tests/integration/utils/legacy.py
+++ b/galaxy_ng/tests/integration/utils/legacy.py
@@ -50,7 +50,7 @@ def clean_all_roles(ansible_config):
             break
         next_url = resp['next']
 
-    usernames = [x['username'] for x in pre_existing]
+    usernames = [x['github_user'] for x in pre_existing]
     usernames = sorted(set(usernames))
     for username in usernames:
         cleanup_social_user(username, ansible_config)


### PR DESCRIPTION
there are 5408 roles on old galaxy where the github_user doesn't match the role's namespace name

So when you install laniakea.galaxy, the role found via `?owner_username=laniakea&name=galaxy` is http://old-galaxy.ansible.com/api/v1/roles/51041/ ... which has a github_user key with value Laniakea-elixir-it

The way that worked was the role model linked to a repository model and the repository model linked to a provider namespace model ... the provider namespace's "name" property is what the role serializer emits for github_user

I'm not sure what this means for future imports of the roles considering the authors need to provide the proper org|user name to the CLI ... so I'll have to do some testing on that.

After this fix is deployed, we'll have to inject the missing field into all of the relevant roles' full_metadata column.