### PR TITLE
nginx: add entry for /api, use client_max_body_size

### DIFF
--- a/galaxy_ng/app/webserver_snippets/nginx.conf
+++ b/galaxy_ng/app/webserver_snippets/nginx.conf
@@ -8,3 +8,14 @@ location /ui/ {
     proxy_redirect off;
     proxy_pass http://pulp-api/static/galaxy_ng/index.html;
 }
+
+location /api/ {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Host $http_host;
+    # we don't want nginx trying to do something clever with
+    # redirects, we set the Host: header above already.
+    proxy_redirect off;
+    proxy_pass http://pulp-api;
+    client_max_body_size 0;
+}


### PR DESCRIPTION
When running oci-env, I can not upload some collections, because the upload size limit is too small.

On actual galaxy.ansible.com, this is [20M](https://github.com/ansible/galaxy-deploy/blob/next/helm-ng/charts/galaxy/charts/galaxy-ui/templates/configmap.yaml#L71), but the oci-env config uses a [10M](https://github.com/pulp/pulp-oci-images/blob/latest/images/s6_assets/nginx.conf#L39) default, only overriding it for `/pulp/api/v3/` (in https://github.com/pulp/pulp-oci-images/blob/latest/images/s6_assets/nginx.conf#L62).

Our api calls go to `/api/automation-hub/`, `/api/galaxy/` or `/api/` so that `client_max_body_size 0;` doesn't apply.

---

I'm *assuming* this is something to fix in galaxy_ng, as those URLs are galaxy-specific, is that right?

(=> added an `/api/` entry in the galaxy_ng nginx snippet, copied from `/pulp/api/v3` in `pulp-oci-images`)

---

Testing: try uploading arista.avd 4.2.0 from the UI.