### PR TITLE
Update django security release 4.2.6

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -90,7 +90,7 @@ distro==1.8.0
     # via
     #   bindep
     #   galaxy-ng (setup.py)
-django==4.2.4
+django==4.2.6
     # via
     #   django-auth-ldap
     #   django-filter

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -96,7 +96,7 @@ distro==1.8.0
     # via
     #   bindep
     #   galaxy-ng (setup.py)
-django==4.2.4
+django==4.2.6
     # via
     #   django-auth-ldap
     #   django-filter

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -90,7 +90,7 @@ distro==1.8.0
     # via
     #   bindep
     #   galaxy-ng (setup.py)
-django==4.2.4
+django==4.2.6
     # via
     #   django-auth-ldap
     #   django-filter


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-2728
https://bugzilla.redhat.com/show_bug.cgi?id=2241046
https://www.djangoproject.com/weblog/2023/oct/04/security-releases/