### PR TITLE
set proper CONTENT_ORIGIN for ephemeral pr checks

### DIFF
--- a/CHANGES/2775.misc
+++ b/CHANGES/2775.misc
@@ -1,0 +1,1 @@
+set proper CONTENT_ORIGIN for ephemeral pr checks

--- a/dev/ephemeral/patch_ephemeral.sh
+++ b/dev/ephemeral/patch_ephemeral.sh
@@ -5,9 +5,14 @@ FE_ROUTE=$(oc get routes | awk '{print $1}' | grep front-end-aggregator)
 if [ -n "${FE_ROUTE}" ]; then
   CONTENT_ORIGIN=$(oc get route front-end-aggregator -o jsonpath='https://{.spec.host}{"\n"}')
 else
-  CONTENT_ORIGIN=$(bonfire namespace describe ${NAMESPACE} | grep "Frontend route" | awk '{print $3}')
+  CONTENT_ORIGIN=$(bonfire namespace describe ${NAMESPACE} | grep "Gateway route" | awk '{print $3}')
 fi
-echo "CONTENT_ORIGIN = ${CONTENT_ORIGIN}"
+if [ -z "${CONTENT_ORIGIN}" ]; then
+  echo "ERROR: unable to determine CONTENT_ORIGIN"
+  exit 1
+else
+  echo "CONTENT_ORIGIN = ${CONTENT_ORIGIN}"
+fi
 oc patch clowdapp automation-hub --type=json \
     -p '[{"op": "replace",
             "path": "/spec/deployments/1/podSpec/env/1/value",


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
* updates the patch_ephemeral.sh script to set CONTENT_ORIGIN properly based on changes in crc-bonfire 4.19
* adds error logic so this issue can be more easily identified if it happens again

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAH-2775

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
