### PR TITLE
Enable social auth users to see other users.

### DIFF
--- a/CHANGES/2781.bugfix
+++ b/CHANGES/2781.bugfix
@@ -1,1 +1,1 @@
-Allow all authenticated users to list and retrieve other users.
+Allow all authenticated users to list and retrieve other users when using github social auth.

--- a/CHANGES/2781.bugfix
+++ b/CHANGES/2781.bugfix
@@ -1,0 +1,1 @@
+Allow all authenticated users to list and retrieve other users.

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -81,9 +81,6 @@ class GalaxyStatements:
         return self._STATEMENTS
 
     def _get_statements(self):
-        print(f'_GET_STATEMENTS settings.GALAXY_DEPLOYMENT_MODE:{settings.GALAXY_DEPLOYMENT_MODE}')
-        res = self.galaxy_statements[settings.GALAXY_DEPLOYMENT_MODE]
-        print(res)
         return self.galaxy_statements[settings.GALAXY_DEPLOYMENT_MODE]
 
     def get_pulp_access_policy(self, name, default=None):

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -198,13 +198,17 @@ STANDALONE_STATEMENTS = {
             "action": ["list"],
             "principal": "authenticated",
             "effect": "allow",
-            # "condition": "has_model_perms:galaxy.view_user"
+            # "condition": "has_model_perms:galaxy.view_user",
+            #"condition": ["has_model_perms:galaxy.view_user", "v3_can_view_users"],
+            "condition": ["v3_can_view_users"],
         },
         {
             "action": ["retrieve"],
             "principal": "authenticated",
             "effect": "allow",
-            # "condition": "has_model_perms:galaxy.view_user"
+            # "condition": "has_model_perms:galaxy.view_user",
+            #"condition": ["has_model_perms:galaxy.view_user", "v3_can_view_users"],
+            "condition": ["v3_can_view_users"],
         },
         {
             "action": "destroy",

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -198,13 +198,13 @@ STANDALONE_STATEMENTS = {
             "action": ["list"],
             "principal": "authenticated",
             "effect": "allow",
-            "condition": "has_model_perms:galaxy.view_user"
+            # "condition": "has_model_perms:galaxy.view_user"
         },
         {
             "action": ["retrieve"],
             "principal": "authenticated",
             "effect": "allow",
-            "condition": "has_model_perms:galaxy.view_user"
+            # "condition": "has_model_perms:galaxy.view_user"
         },
         {
             "action": "destroy",

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -198,16 +198,12 @@ STANDALONE_STATEMENTS = {
             "action": ["list"],
             "principal": "authenticated",
             "effect": "allow",
-            # "condition": "has_model_perms:galaxy.view_user",
-            #"condition": ["has_model_perms:galaxy.view_user", "v3_can_view_users"],
             "condition": ["v3_can_view_users"],
         },
         {
             "action": ["retrieve"],
             "principal": "authenticated",
             "effect": "allow",
-            # "condition": "has_model_perms:galaxy.view_user",
-            #"condition": ["has_model_perms:galaxy.view_user", "v3_can_view_users"],
             "condition": ["v3_can_view_users"],
         },
         {

--- a/galaxy_ng/tests/integration/api/test_rbac_roles.py
+++ b/galaxy_ng/tests/integration/api/test_rbac_roles.py
@@ -613,7 +613,6 @@ ACTIONS_FOR_ALL_USERS = {
     view_tasks,
     view_role,
     view_pulp_groups,
-    view_users,
 }
 
 DENIED_FOR_ALL_USERS = {

--- a/galaxy_ng/tests/integration/api/test_rbac_roles.py
+++ b/galaxy_ng/tests/integration/api/test_rbac_roles.py
@@ -613,6 +613,7 @@ ACTIONS_FOR_ALL_USERS = {
     view_tasks,
     view_role,
     view_pulp_groups,
+    view_users,
 }
 
 DENIED_FOR_ALL_USERS = {

--- a/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings as django_settings
 from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -168,7 +169,7 @@ class TestUiUserViewSet(BaseTestCase):
             self.client.force_authenticate(user=self.admin_user)
             url = "{}{}/".format(self.user_url, self.user.id)
             response = self.client.get(url)
-            self.assertEqual(response.status_code, expected)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             data = response.data
             self.assertEqual(data["email"], self.user.email)
             self.assertEqual(data["first_name"], self.user.first_name)

--- a/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
@@ -151,16 +151,16 @@ class TestUiUserViewSet(BaseTestCase):
 
     def test_user_get(self):
         def _test_user_get():
-            # Check test user cannot view themselves on the users/ api
+            # Check test user can* view themselves on the users/ api
             self.client.force_authenticate(user=self.user)
             url = "{}{}/".format(self.user_url, self.user.id)
             response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-            # Check test user cannot view other users
+            # Check test user can* view other users
             url = "{}{}/".format(self.user_url, self.admin_user.id)
             response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
             # Check admin user can view others
             self.client.force_authenticate(user=self.admin_user)

--- a/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings as django_settings
 from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APIClient

--- a/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
@@ -200,7 +200,6 @@ class TestUiUserViewSet(BaseTestCase):
         with self.settings(**kwargs):
             _test_user_get(expected=status.HTTP_200_OK)
 
-
     def _test_create_or_update(self, method_call, url, new_user_data, crud_status, auth_user):
         self.client.force_authenticate(user=auth_user)
         # set user with invalid password

--- a/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
+++ b/galaxy_ng/tests/unit/api/test_api_ui_user_viewsets.py
@@ -146,10 +146,19 @@ class TestUiUserViewSet(BaseTestCase):
             self.assertEqual(len(data), auth_models.User.objects.all().count())
 
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
-            _test_user_list(expected=status.HTTP_200_OK)
+            _test_user_list(expected=status.HTTP_403_FORBIDDEN)
 
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.INSIGHTS.value):
             _test_user_list(expected=status.HTTP_403_FORBIDDEN)
+
+        # community
+        kwargs = {
+            'GALAXY_DEPLOYMENT_MODE': DeploymentMode.STANDALONE.value,
+            'SOCIAL_AUTH_GITHUB_KEY': '1234',
+            'SOCIAL_AUTH_GITHUB_SECRET': '1234'
+        }
+        with self.settings(**kwargs):
+            _test_user_list(expected=status.HTTP_200_OK)
 
     def test_user_get(self):
         def _test_user_get(expected=None):
@@ -177,10 +186,20 @@ class TestUiUserViewSet(BaseTestCase):
                 self.assertTrue(self.user.groups.exists(id=group["id"]))
 
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.STANDALONE.value):
-            _test_user_get(expected=status.HTTP_200_OK)
+            _test_user_get(expected=status.HTTP_403_FORBIDDEN)
 
         with self.settings(GALAXY_DEPLOYMENT_MODE=DeploymentMode.INSIGHTS.value):
             _test_user_get(expected=status.HTTP_403_FORBIDDEN)
+
+        # community
+        kwargs = {
+            'GALAXY_DEPLOYMENT_MODE': DeploymentMode.STANDALONE.value,
+            'SOCIAL_AUTH_GITHUB_KEY': '1234',
+            'SOCIAL_AUTH_GITHUB_SECRET': '1234'
+        }
+        with self.settings(**kwargs):
+            _test_user_get(expected=status.HTTP_200_OK)
+
 
     def _test_create_or_update(self, method_call, url, new_user_data, crud_status, auth_user):
         self.client.force_authenticate(user=auth_user)


### PR DESCRIPTION
Users can't see the list of users when trying to add owners to their namespaces.
