### PR TITLE
[stable-4.8] Bump pulp_ansible to 0.20.1 and pulpcore to 3.28.17

### DIFF
--- a/galaxy_ng/app/management/commands/sync-collection-download-counts.py
+++ b/galaxy_ng/app/management/commands/sync-collection-download-counts.py
@@ -13,7 +13,7 @@ from pulp_ansible.app.models import Collection, CollectionDownloadCount
 log = logging.getLogger(__name__)
 
 
-DEFAULT_UPSTREAM = 'https://galaxy.ansible.com'
+DEFAULT_UPSTREAM = 'https://old-galaxy.ansible.com'
 
 SKIPLIST = [
     'larrymou9',

--- a/galaxy_ng/tests/integration/cli/test_community_sync.py
+++ b/galaxy_ng/tests/integration/cli/test_community_sync.py
@@ -25,7 +25,7 @@ def test_community_collection_download_count_sync(ansible_config):
 
     # pick an upstream collection at random that does not exist locally ...
     sync_collection = None
-    base_url = 'https://galaxy.ansible.com'
+    base_url = 'https://old-galaxy.ansible.com'
     next_url = base_url + '/api/v2/collections/'
     while next_url:
         rr = requests.get(next_url)
@@ -58,7 +58,7 @@ def test_community_collection_download_count_sync(ansible_config):
     remotes = dict((x['name'], x) for x in resp['results'])
     community_remote_config = {
         'name': 'community',
-        'url': 'https://galaxy.ansible.com/',
+        'url': 'https://old-galaxy.ansible.com/',
         'sync_dependencies': False,
         'requirements_file': json.dumps({'collections': ['.'.join(list(sync_collection))]}),
     }

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -314,13 +314,13 @@ psycopg[binary]==3.1.9
     # via pulpcore
 psycopg-binary==3.1.9
     # via psycopg
-pulp-ansible==0.19.0
+pulp-ansible==0.20.1
     # via galaxy-ng (setup.py)
 pulp-container==2.15.2
     # via galaxy-ng (setup.py)
 pulp-glue==0.19.5
     # via pulpcore
-pulpcore==3.28.12
+pulpcore==3.28.17
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -325,13 +325,13 @@ psycopg[binary]==3.1.9
     # via pulpcore
 psycopg-binary==3.1.9
     # via psycopg
-pulp-ansible==0.19.0
+pulp-ansible==0.20.1
     # via galaxy-ng (setup.py)
 pulp-container==2.15.2
     # via galaxy-ng (setup.py)
 pulp-glue==0.19.5
     # via pulpcore
-pulpcore==3.28.12
+pulpcore==3.28.17
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -314,13 +314,13 @@ psycopg[binary]==3.1.9
     # via pulpcore
 psycopg-binary==3.1.9
     # via psycopg
-pulp-ansible==0.19.0
+pulp-ansible==0.20.1
     # via galaxy-ng (setup.py)
 pulp-container==2.15.2
     # via galaxy-ng (setup.py)
 pulp-glue==0.19.5
     # via pulpcore
-pulpcore==3.28.12
+pulpcore==3.28.17
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/setup.py
+++ b/setup.py
@@ -112,8 +112,8 @@ def _format_pulp_requirement(plugin, specifier=None, ref=None, gh_namespace="pul
 
 requirements = [
     "galaxy-importer>=0.4.13,<0.5.0",
-    "pulpcore>=3.28.12,<3.29.0",
-    "pulp_ansible>=0.19.0,<0.20.0",
+    "pulpcore>=3.28.17,<3.29.0",
+    "pulp_ansible>=0.20.0,<0.21.0",
     "django-prometheus>=2.0.0",
     "drf-spectacular",
     "pulp-container>=2.15.0,<2.16.0",


### PR DESCRIPTION
No-Issue

https://github.com/pulp/pulp_ansible/blob/main/template_config.yml#L15-L21 `pulp_ansible` 0.19 is unsupported.
