### PR TITLE
Metrics Collection: Added GALAXY_API_PATH_PREFIX to API call

### DIFF
--- a/galaxy_ng/app/metrics_collection/common_data.py
+++ b/galaxy_ng/app/metrics_collection/common_data.py
@@ -21,10 +21,10 @@ def api_status():
         else:
             logger.error(f"export metrics_collection: failed API call {status_path}: "
                          f"HTTP status {response.status_code}")
-            return f"Wrong status: {response.status_code}"
+            return {}
     except Exception as e:
         logger.error(f"export metrics_collection: failed API call {status_path}: {e}")
-        return f"Error happened: {str(e)}"
+        return {}
 
 
 def hub_version():

--- a/galaxy_ng/app/metrics_collection/common_data.py
+++ b/galaxy_ng/app/metrics_collection/common_data.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import logging
 from urllib.parse import urljoin
@@ -10,19 +11,20 @@ logger = logging.getLogger("metrics_collection.export_data")
 
 
 def api_status():
-    status_path = '/pulp/api/v3/status/'
+    status_path = 'pulp/api/v3/status/'
     try:
-        url = urljoin(settings.ANSIBLE_API_HOSTNAME, status_path)
+        path = os.path.join(settings.GALAXY_API_PATH_PREFIX or '', status_path)
+        url = urljoin(settings.ANSIBLE_API_HOSTNAME, path)
         response = requests.request("GET", url)
         if response.status_code == 200:
             return response.json()
         else:
             logger.error(f"export metrics_collection: failed API call {status_path}: "
                          f"HTTP status {response.status_code}")
-            return {}
+            return f"Wrong status: {response.status_code}"
     except Exception as e:
         logger.error(f"export metrics_collection: failed API call {status_path}: {e}")
-        return {}
+        return f"Error happened: {str(e)}"
 
 
 def hub_version():

--- a/galaxy_ng/tests/unit/app/management/commands/analytics/automation_analytics/test_collector.py
+++ b/galaxy_ng/tests/unit/app/management/commands/analytics/automation_analytics/test_collector.py
@@ -6,7 +6,6 @@ import tarfile
 from unittest.mock import MagicMock, patch, ANY
 from insights_analytics_collector import register
 import insights_analytics_collector.package
-import galaxy_ng.app.metrics_collection.common_data
 from galaxy_ng.app.metrics_collection.automation_analytics.collector import Collector
 from galaxy_ng.app.metrics_collection.automation_analytics.package import Package
 from django.test import TestCase, override_settings
@@ -56,14 +55,18 @@ def csv_exception(since, **kwargs):
 class TestAutomationAnalyticsCollector(TestCase):
     def setUp(self):
         super().setUp()
-        self.api_status = MagicMock()
+
+        self.api_status_patch = patch('galaxy_ng.app.metrics_collection.common_data.api_status')
+        self.api_status = self.api_status_patch.start()
         self.api_status.return_value = {}
-        galaxy_ng.app.metrics_collection.common_data.api_status = self.api_status
 
         self.logger = MagicMock()
         self.log = MagicMock("log")
         self.logger.log = self.log
         self.logger.exception = MagicMock("exception")
+
+    def tearDown(self):
+        self.api_status_patch.stop()
 
     def test_no_config_gather(self):
         """Config is missing, no data are collected"""

--- a/galaxy_ng/tests/unit/app/management/commands/analytics/automation_analytics/test_data.py
+++ b/galaxy_ng/tests/unit/app/management/commands/analytics/automation_analytics/test_data.py
@@ -1,9 +1,6 @@
 import galaxy_ng.app.metrics_collection.common_data
 from django.test import TestCase, override_settings
 from unittest.mock import MagicMock, patch
-from django.conf import settings
-from urllib.parse import urljoin
-import os
 
 
 class TestAutomationAnalyticsData(TestCase):
@@ -20,16 +17,10 @@ class TestAutomationAnalyticsData(TestCase):
         json_response.return_value = mocked_api_status
         mock_response.json = json_response
 
-        path = os.path.join(settings.GALAXY_API_PATH_PREFIX or '', 'pulp/api/v3/status/')
-        url = urljoin(settings.ANSIBLE_API_HOSTNAME, path)
-        assert path == '/api-test/xxx/pulp/api/v3/status/'
-        assert url == 'https://example.com/api-test/xxx/pulp/api/v3/status/'
-
         response = galaxy_ng.app.metrics_collection.common_data.api_status()
 
-        assert response == mocked_api_status
+        self.assertEqual(response, mocked_api_status)
 
-        mock_request.assert_called_once()
-        # mock_request.assert_called_with("GET",
-        #                                 'https://example.com/api-test/xxx/pulp/api/v3/status/')
+        mock_request.assert_called_with("GET",
+                                        'https://example.com/api-test/xxx/pulp/api/v3/status/')
         json_response.assert_called_once()

--- a/galaxy_ng/tests/unit/app/management/commands/analytics/automation_analytics/test_data.py
+++ b/galaxy_ng/tests/unit/app/management/commands/analytics/automation_analytics/test_data.py
@@ -1,0 +1,35 @@
+import galaxy_ng.app.metrics_collection.common_data
+from django.test import TestCase, override_settings
+from unittest.mock import MagicMock, patch
+from django.conf import settings
+from urllib.parse import urljoin
+import os
+
+
+class TestAutomationAnalyticsData(TestCase):
+    @override_settings(ANSIBLE_API_HOSTNAME='https://example.com')
+    @override_settings(GALAXY_API_PATH_PREFIX='/api-test/xxx')
+    @patch('galaxy_ng.app.metrics_collection.common_data.requests.request')
+    def test_api_status_request(self, mock_request):
+        mock_response = MagicMock(name="mock_response")
+        mock_response.status_code = 200
+        mock_request.return_value = mock_response
+
+        json_response = MagicMock(name="json")
+        mocked_api_status = MagicMock(name="api_status")
+        json_response.return_value = mocked_api_status
+        mock_response.json = json_response
+
+        path = os.path.join(settings.GALAXY_API_PATH_PREFIX or '', 'pulp/api/v3/status/')
+        url = urljoin(settings.ANSIBLE_API_HOSTNAME, path)
+        assert path == '/api-test/xxx/pulp/api/v3/status/'
+        assert url == 'https://example.com/api-test/xxx/pulp/api/v3/status/'
+
+        response = galaxy_ng.app.metrics_collection.common_data.api_status()
+
+        assert response == mocked_api_status
+
+        mock_request.assert_called_once()
+        # mock_request.assert_called_with("GET",
+        #                                 'https://example.com/api-test/xxx/pulp/api/v3/status/')
+        json_response.assert_called_once()

--- a/galaxy_ng/tests/unit/app/management/commands/test_metrics_collection_lightspeed.py
+++ b/galaxy_ng/tests/unit/app/management/commands/test_metrics_collection_lightspeed.py
@@ -2,7 +2,6 @@ from unittest.mock import patch, mock_open, MagicMock
 from django.core.management import call_command
 from django.test import TestCase
 import os
-import galaxy_ng.app.metrics_collection.common_data
 
 s3_details = {
     "aws_access_key_id": "blah",
@@ -15,9 +14,12 @@ s3_details = {
 class TestMetricsCollectionLightspeedCommand(TestCase):
     def setUp(self):
         super().setUp()
-        self.api_status = MagicMock()
+        self.api_status_patch = patch('galaxy_ng.app.metrics_collection.common_data.api_status')
+        self.api_status = self.api_status_patch.start()
         self.api_status.return_value = {}
-        galaxy_ng.app.metrics_collection.common_data.api_status = self.api_status
+
+    def tearDown(self):
+        self.api_status_patch.stop()
 
     def test_command_output(self):
         call_command("metrics-collection-lightspeed")


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Fixes current API call, which uses only base url and `/pulp/api/v3/status` and doesn't work on galaxy-dev. 

<!-- Add Jira issue link or replace with No-Issue -->
Issue: [AA-1892](https://issues.redhat.com/browse/AA-1892)

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
