### PR TITLE
Fix traceback on retrieving role versions.

### DIFF
--- a/galaxy_ng/app/api/v1/viewsets/roles.py
+++ b/galaxy_ng/app/api/v1/viewsets/roles.py
@@ -145,6 +145,9 @@ class LegacyRolesViewSet(viewsets.ModelViewSet):
 class LegacyRoleContentViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     """Documentation for a single legacy role."""
 
+    # FIXME - we shouldn't need this
+    queryset = LegacyRole.objects.all().order_by('created')
+
     permission_classes = [LegacyAccessPolicy]
     authentication_classes = GALAXY_AUTHENTICATION_CLASSES
     serializer_class = LegacyRoleContentSerializer
@@ -155,6 +158,9 @@ class LegacyRoleContentViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixi
 
 class LegacyRoleVersionsViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     """A list of versions for a single legacy role."""
+
+    # FIXME - we shouldn't need this
+    queryset = LegacyRole.objects.all().order_by('created')
 
     permission_classes = [LegacyAccessPolicy]
     authentication_classes = GALAXY_AUTHENTICATION_CLASSES


### PR DESCRIPTION
```
2023-10-22 18:41:47,546 ERROR django.request: Internal Server Error: /api/v1/roles/10984/versions/
Traceback (most recent call last):
File "/venv/lib64/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
response = get_response(request)
^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib64/python3.11/site-packages/django/core/handlers/base.py", line 220, in _get_response
response = response.render()
^^^^^^^^^^^^^^^^^
File "/venv/lib64/python3.11/site-packages/django/template/response.py", line 114, in render
self.content = self.rendered_content
^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib64/python3.11/site-packages/rest_framework/response.py", line 70, in rendered_content
ret = renderer.render(self.data, accepted_media_type, context)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib64/python3.11/site-packages/rest_framework/renderers.py", line 723, in render
context = self.get_context(data, accepted_media_type, renderer_context)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib64/python3.11/site-packages/rest_framework/renderers.py", line 701, in get_context
'filter_form': self.get_filter_form(data, view, request),
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib64/python3.11/site-packages/rest_framework/renderers.py", line 629, in get_filter_form
queryset = view.get_queryset()
^^^^^^^^^^^^^^^^^^^
File "/venv/lib64/python3.11/site-packages/rest_framework/generics.py", line 63, in get_queryset
assert self.queryset is not None, (
^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 'LegacyRoleVersionsViewSet' should either include a `queryset` attribute, or override the `get_queryset()` method.
```