### PR TITLE
Revamp legacyrole versions.

### DIFF
--- a/galaxy_ng/app/api/v1/serializers.py
+++ b/galaxy_ng/app/api/v1/serializers.py
@@ -296,7 +296,7 @@ class LegacyRoleSerializer(serializers.ModelSerializer):
 
         versions = obj.full_metadata.get('versions', [])
         if versions:
-            versions = sorted(versions, key=lambda x: x['commit_date'])
+            # the versions data should have been sorted at sync or import time
             versions = versions[::-1]
             if len(versions) > 10:
                 versions = versions[:11]

--- a/galaxy_ng/app/api/v1/tasks.py
+++ b/galaxy_ng/app/api/v1/tasks.py
@@ -182,6 +182,9 @@ def sort_versions(versions):
 
 
 def normalize_versions(versions):
+
+    original = [copy.deepcopy(x) for x in versions]
+
     # convert old integer based IDs to uuid
     for vix, version in enumerate(versions):
         if isinstance(version.get('id', ''), int):
@@ -201,6 +204,9 @@ def normalize_versions(versions):
     # where previous galaxy_ng import code mistakenly thought
     # the branch+commit should be a version instead of only tags.
     for version in versions[:]:
+        if not version.get('tag'):
+            versions.remove(version)
+            continue
         lver = LooseVersion(version['tag'].lower())
         if not all(isinstance(x, int) for x in lver.version):
             versions.remove(version)

--- a/galaxy_ng/app/api/v1/tasks.py
+++ b/galaxy_ng/app/api/v1/tasks.py
@@ -4,6 +4,9 @@ import logging
 import os
 import subprocess
 import tempfile
+import uuid
+
+import semantic_version
 
 from django.db import transaction
 
@@ -11,8 +14,10 @@ from galaxy_importer.config import Config
 from galaxy_importer.legacy_role import import_legacy_role
 
 from galaxy_ng.app.models.auth import User
+from galaxy_ng.app.models import Namespace
 from galaxy_ng.app.utils.galaxy import upstream_role_iterator
 from galaxy_ng.app.utils.legacy import process_namespace
+from galaxy_ng.app.utils.namespaces import generate_v3_namespace_from_attributes
 
 from galaxy_ng.app.api.v1.models import LegacyNamespace
 from galaxy_ng.app.api.v1.models import LegacyRole
@@ -22,6 +27,15 @@ from git import Repo
 
 
 logger = logging.getLogger(__name__)
+
+
+def parse_version_tag(value):
+    value = str(value)
+    if not value:
+        raise ValueError('Empty version value')
+    if value[0].lower() == 'v':
+        value = value[1:]
+    return semantic_version.Version(value)
 
 
 def find_real_role(github_user, github_repo):
@@ -76,12 +90,92 @@ def find_real_role(github_user, github_repo):
     return real_role, real_namespace_name, real_github_user, real_github_repo, clone_url
 
 
+def do_git_checkout(clone_url, checkout_path, github_reference):
+    """
+    Handle making a clone, setting a branch/tag and
+    enumerating the last commit for a role.
+
+    :param clone_url:
+        A valid anonymous/public github clone url.
+    :param checkout_path:
+        Where to make the clone.
+    :param github_reference:
+        A valid branch or a tag name.
+
+    :return: A tuple with the following members:
+        - the git.Repo object
+        - the enumerated github_reference (aka branch or tag)
+        - the last commit object from the github_reference or $HEAD
+    :rtype: tuple(git.Repo, string, git.Commit)
+    """
+    logger.info(f'CLONING {clone_url}')
+
+    # pygit didn't have an obvious way to prevent interactive clones ...
+    pid = subprocess.run(
+        f'GIT_TERMINAL_PROMPT=0 git clone --recurse-submodules {clone_url} {checkout_path}',
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if pid.returncode != 0:
+        error = pid.stdout.decode('utf-8')
+        logger.error(f'cloning failed: {error}')
+        raise Exception(f'git clone for {clone_url} failed')
+
+    # bind the checkout to a pygit object
+    gitrepo = Repo(checkout_path)
+
+    # the github_reference could be a branch OR a tag name ...
+    if github_reference is not None:
+
+        branch_names = [x.name for x in gitrepo.branches]
+        tag_names = [x.name for x in gitrepo.tags]
+
+        cmd = None
+        if github_reference in branch_names:
+            current_branch = gitrepo.active_branch.name
+            if github_reference != current_branch:
+                cmd = f'git checkout origin/{github_reference}'
+
+        elif github_reference in tag_names:
+            cmd = f'git checkout tags/{github_reference} -b local_${github_reference}'
+
+        else:
+            raise Exception(f'{github_reference} is not a valid branch or tag name')
+
+        if cmd:
+            logger.info(f'switching to {github_reference} in checkout via {cmd}')
+            pid = subprocess.run(
+                cmd,
+                cwd=checkout_path,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            if pid.returncode != 0:
+                error = pid.stdout.decode('utf-8')
+                logger.error('{cmd} failed: {error}')
+                raise Exception(f'{cmd} failed')
+
+        last_commit = [x for x in gitrepo.iter_commits()][0]
+
+    else:
+        # use the default branch ...
+        github_reference = gitrepo.active_branch.name
+
+        # use latest commit on HEAD
+        last_commit = gitrepo.head.commit
+
+    return gitrepo, github_reference, last_commit
+
+
 def legacy_role_import(
     request_username=None,
     github_user=None,
     github_repo=None,
     github_reference=None,
-    alternate_role_name=None
+    alternate_role_name=None,
+    superuser_can_create_namespaces=False
 ):
     """
     Import a legacy role by user, repo and or reference.
@@ -112,9 +206,12 @@ def legacy_role_import(
     logger.info(f'GITHUB_REPO:{github_repo}')
     logger.info(f'GITHUB_REFERENCE:{github_reference}')
     logger.info(f'ALTERNATE_ROLE_NAME:{alternate_role_name}')
+    logger.info(f'superuser_can_create_namespaces: {superuser_can_create_namespaces}')
 
     clone_url = None
-    github_reference_is_tag = False
+
+    request_user = User.objects.filter(username=request_username).first()
+    logger.info(f'REQUEST_USER: {request_user}')
 
     # prevent empty strings?
     if not github_reference:
@@ -134,14 +231,30 @@ def legacy_role_import(
     # the user should have a legacy and v3 namespace if they logged in ...
     namespace = LegacyNamespace.objects.filter(name=real_namespace_name).first()
     if not namespace:
-        logger.error(f'No legacy namespace exists for {github_user}')
-        raise Exception(f'No legacy namespace exists for {github_user}')
+
+        if not request_user.is_superuser or \
+                (request_user.is_superuser and not superuser_can_create_namespaces):
+            logger.error(f'No legacy namespace exists for {github_user}')
+            raise Exception(f'No legacy namespace exists for {github_user}')
+
+        logger.info(f'create legacynamespace {real_namespace_name}')
+        namespace, _ = LegacyNamespace.objects.get_or_create(name=real_namespace_name)
 
     # we have to have a v3 namespace because of the rbac based ownership ...
     v3_namespace = namespace.namespace
     if not v3_namespace:
-        logger.error(f'No v3 namespace exists for {github_user}')
-        raise Exception(f'No v3 namespace exists for {github_user}')
+
+        if not request_user.is_superuser or \
+                (request_user.is_superuser and not superuser_can_create_namespaces):
+            logger.error(f'No v3 namespace exists for {github_user}')
+            raise Exception(f'No v3 namespace exists for {github_user}')
+
+        # transformed name ... ?
+        v3_name = generate_v3_namespace_from_attributes(username=real_namespace_name)
+        logger.info(f'creating namespace {v3_name}')
+        v3_namespace, _ = Namespace.objects.get_or_create(name=v3_name)
+        namespace.namespace = v3_namespace
+        namespace.save()
 
     with tempfile.TemporaryDirectory() as tmp_path:
         # galaxy-importer requires importing legacy roles from the role's parent directory.
@@ -152,62 +265,9 @@ def legacy_role_import(
         if clone_url is None:
             clone_url = f'https://github.com/{github_user}/{github_repo}'
 
-        logger.info(f'CLONING {clone_url}')
-
-        # pygit didn't have an obvious way to prevent interactive clones ...
-        pid = subprocess.run(
-            f'GIT_TERMINAL_PROMPT=0 git clone --recurse-submodules {clone_url} {checkout_path}',
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-        if pid.returncode != 0:
-            error = pid.stdout.decode('utf-8')
-            logger.error(f'cloning failed: {error}')
-            raise Exception(f'git clone for {clone_url} failed')
-
-        # bind the checkout to a pygit object
-        gitrepo = Repo(checkout_path)
-
-        # the github_reference could be a branch OR a tag name ...
-        if github_reference is not None:
-
-            branch_names = [x.name for x in gitrepo.branches]
-            tag_names = [x.name for x in gitrepo.tags]
-
-            cmd = None
-            if github_reference in branch_names:
-                current_branch = gitrepo.active_branch.name
-                if github_reference != current_branch:
-                    cmd = f'git checkout origin/{github_reference}'
-            elif github_reference in tag_names:
-                github_reference_is_tag = True
-                cmd = f'git checkout tags/{github_reference} -b local_${github_reference}'
-            else:
-                raise Exception(f'{github_reference} is not a valid branch or tag name')
-
-            if cmd:
-                logger.info(f'switching to {github_reference} in checkout via {cmd}')
-                pid = subprocess.run(
-                    cmd,
-                    cwd=checkout_path,
-                    shell=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                )
-                if pid.returncode != 0:
-                    error = pid.stdout.decode('utf-8')
-                    logger.error('{cmd} failed: {error}')
-                    raise Exception(f'{cmd} failed')
-
-            last_commit = [x for x in gitrepo.iter_commits()][0]
-
-        else:
-            # use the default branch ...
-            github_reference = gitrepo.active_branch.name
-
-            # use latest commit on HEAD
-            last_commit = gitrepo.head.commit
+        # process the checkout ...
+        gitrepo, github_reference, last_commit = \
+            do_git_checkout(clone_url, checkout_path, github_reference)
 
         # relevant data for this new role version ...
         github_commit = last_commit.hexsha
@@ -236,7 +296,9 @@ def legacy_role_import(
             'commit': github_commit,
             'github_user': real_github_user,
             'github_repo': real_github_repo,
+            'github_branch': github_reference,
             'github_reference': github_reference,
+            'import_branch': github_reference,
             'commit': github_commit,
             'commit_message': github_commit_message,
             'issue_tracker_url': galaxy_info["issue_tracker_url"] or clone_url + "/issues",
@@ -251,7 +313,7 @@ def legacy_role_import(
             'readme_html': result["readme_html"]
         }
 
-        # Make the object
+        # Make or get the object
         if real_role:
             this_role = real_role
         else:
@@ -262,42 +324,58 @@ def legacy_role_import(
 
         # Combine old versions with new ...
         old_metadata = copy.deepcopy(this_role.full_metadata)
+        versions = old_metadata.get('versions', [])
 
-        new_full_metadata['versions'] = old_metadata.get('versions', [])
-        ts = datetime.datetime.now().isoformat()
+        # Clean out non-semver versions due to bad import code
+        for version in versions:
+            try:
+                parse_version_tag(version['version'])
+            except ValueError:
+                versions.remove(version)
 
-        # only make a download url for tags?
-        download_url = None
-        if github_reference_is_tag:
-            download_url = (
-                f'https://github.com/{real_github_user}/{real_github_repo}'
-                + f'/archive/{github_reference}.tar.gz'
-            )
+        # ALL semver tags should become versions
+        current_tags = []
+        for cversion in versions:
+            # we want tag but the sync'ed roles don't have it
+            # because the serializer returns "name" instead.
+            tag = cversion.get('tag')
+            if not tag:
+                tag = cversion.get('name')
+            current_tags.append(tag)
+        for tag in gitrepo.tags:
 
-        new_version = {
-            'name': github_reference,
-            'version': github_reference,
-            'release_date': ts,
-            'created': ts,
-            'modified': ts,
-            'active': None,
-            'download_url': download_url,
-            'url': None,
-            'commit_date': github_commit_date,
-            'commit_sha': github_commit
-        }
-        versions_by_sha = dict((x['commit_sha'], x) for x in new_full_metadata.get('versions', []))
-        if github_commit not in versions_by_sha:
-            new_full_metadata['versions'].append(new_version)
-        else:
-            msg = (
-                f'{namespace.name}.{role_name} {github_reference} commit:{github_commit}'
-                + ' has already been imported'
-            )
-            raise Exception(msg)
+            # must be a semver compliant value ...
+            try:
+                version = parse_version_tag(tag.name)
+            except ValueError:
+                continue
+
+            if str(version) in current_tags:
+                continue
+
+            ts = datetime.datetime.now().isoformat()
+            vdata = {
+                'id': str(uuid.uuid4()),
+                'tag': tag.name,
+                'version': str(version),
+                'commit_date': tag.commit.committed_datetime.isoformat(),
+                'commit_sha': tag.commit.hexsha,
+                'created': ts,
+                'modified': ts,
+            }
+            logger.info(f'adding new version from tag: {vdata}')
+            versions.append(vdata)
+
+        # set the enumerated versions ...
+        new_full_metadata['versions'] = versions
 
         # Save the new metadata
         this_role.full_metadata = new_full_metadata
+
+        # Set the correct name ...
+        if this_role.name != role_name:
+            this_role.name = role_name
+
         this_role.save()
 
     logger.debug('STOP LEGACY ROLE IMPORT')

--- a/galaxy_ng/app/api/v1/tasks.py
+++ b/galaxy_ng/app/api/v1/tasks.py
@@ -111,9 +111,11 @@ def do_git_checkout(clone_url, checkout_path, github_reference):
     logger.info(f'CLONING {clone_url}')
 
     # pygit didn't have an obvious way to prevent interactive clones ...
+    cmd_args = ['git', 'clone', '--recurse-submodules', clone_url, checkout_path]
     pid = subprocess.run(
-        f'GIT_TERMINAL_PROMPT=0 git clone --recurse-submodules {clone_url} {checkout_path}',
-        shell=True,
+        cmd_args,
+        shell=False,
+        env={'GIT_TERMINAL_PROMPT': '0'},
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )

--- a/galaxy_ng/app/api/v1/tasks.py
+++ b/galaxy_ng/app/api/v1/tasks.py
@@ -202,7 +202,7 @@ def compute_all_versions(this_role, gitrepo):
         except ValueError:
             continue
 
-        if str(version) in current_tags:
+        if str(tag.name) in current_tags:
             continue
 
         ts = datetime.datetime.now().isoformat()
@@ -221,8 +221,11 @@ def compute_all_versions(this_role, gitrepo):
     # remove old tag versions if they no longer exist in the repo
     git_tags = [x.name for x in gitrepo.tags]
     for version in versions[:]:
-        if version.get('version') not in git_tags:
-            logger.info(f"removing {version['version']} because it no longer has a tag")
+        vname = version.get('tag')
+        if not vname:
+            vname = version.get('name')
+        if vname not in git_tags:
+            logger.info(f"removing {vname} because it no longer has a tag")
             versions.remove(version)
 
     return versions

--- a/galaxy_ng/app/api/v1/tasks.py
+++ b/galaxy_ng/app/api/v1/tasks.py
@@ -183,8 +183,6 @@ def sort_versions(versions):
 
 def normalize_versions(versions):
 
-    original = [copy.deepcopy(x) for x in versions]
-
     # convert old integer based IDs to uuid
     for vix, version in enumerate(versions):
         if isinstance(version.get('id', ''), int):

--- a/galaxy_ng/app/management/commands/import-galaxy-role.py
+++ b/galaxy_ng/app/management/commands/import-galaxy-role.py
@@ -1,7 +1,11 @@
 import django_guid
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
 from galaxy_ng.app.api.v1.tasks import legacy_role_import
+
+
+User = get_user_model()
 
 
 # Set logging_uid, this does not seem to get generated when task called via management command
@@ -21,13 +25,22 @@ class Command(BaseCommand):
         parser.add_argument("--role_name", help="find and sync only this namespace name")
         parser.add_argument("--branch", help="find and sync only this namespace name")
         parser.add_argument("--request_username", help="set the uploader's username")
+        parser.add_argument("--superuser_can_create_namespaces", action="store_true")
 
     def handle(self, *args, **options):
+
+        username = options['request_username']
+        if username is None:
+            superuser = User.objects.filter(is_superuser=True).first()
+            if superuser:
+                username = superuser.username
+
         # This is the same function that api/v1/imports eventually calls ...
         legacy_role_import(
-            request_username=options['request_username'],
+            request_username=username,
             github_user=options['github_user'],
             github_repo=options['github_repo'],
             github_reference=options['branch'],
             alternate_role_name=options['role_name'],
+            superuser_can_create_namespaces=options['superuser_can_create_namespaces']
         )

--- a/galaxy_ng/app/utils/galaxy.py
+++ b/galaxy_ng/app/utils/galaxy.py
@@ -130,13 +130,20 @@ def get_namespace_owners_details(baseurl, ns_id):
     while next_owners_url:
         logger.info(f'fetch {next_owners_url}')
         o_data = safe_fetch(next_owners_url).json()
-        for owner in o_data['results']:
-            owners.append(owner)
-        if not o_data.get('next'):
+        if isinstance(o_data, dict):
+            # old galaxy
+            for owner in o_data['results']:
+                owners.append(owner)
+            if not o_data.get('next'):
+                break
+            if 'next_link' in o_data and not o_data.get('next_link'):
+                break
+            next_owners_url = baseurl + o_data['next_link']
+        else:
+            # new galaxy
+            for owner in o_data:
+                owners.append(owner)
             break
-        if 'next_link' in o_data and not o_data.get('next_link'):
-            break
-        next_owners_url = baseurl + o_data['next_link']
     return owners
 
 

--- a/galaxy_ng/app/utils/galaxy.py
+++ b/galaxy_ng/app/utils/galaxy.py
@@ -517,9 +517,12 @@ def upstream_role_iterator(
         if limit is not None and role_count >= limit:
             break
 
-        # break if no next page
-        if not ds.get('next_link'):
+        if ds.get('next'):
+            next_url = ds['next']
+        elif ds.get('next_link'):
+            next_url = _baseurl + ds['next_link']
+        else:
+            # break if no next page
             break
 
         pagenum += 1
-        next_url = _baseurl + ds['next_link']

--- a/galaxy_ng/app/utils/legacy.py
+++ b/galaxy_ng/app/utils/legacy.py
@@ -79,18 +79,18 @@ def process_namespace(namespace_name, namespace_info, force=False):
             namespace.avatar_url = avatar_url
             changed = True
 
-    if namespace_info['company'] and (not namespace.company or force):
+    if namespace_info.get('company') and (not namespace.company or force):
         if len(namespace_info['company']) >= 60:
             namespace.company = namespace_info['company'][:60]
         else:
             namespace.company = namespace_info['company']
         changed = True
 
-    if namespace_info['email'] and (not namespace.email or force):
+    if namespace_info.get('email') and (not namespace.email or force):
         namespace.email = namespace_info['email']
         changed = True
 
-    if namespace_info['description'] and (not namespace.description or force):
+    if namespace_info.get('description') and (not namespace.description or force):
         if len(namespace_info['description']) >= 60:
             namespace.description = namespace_info['description'][:60]
         else:
@@ -106,7 +106,10 @@ def process_namespace(namespace_name, namespace_info, force=False):
 
         logger.info(f'check {legacy_namespace} owner {owner_info["username"]}')
 
-        unverified_email = generate_unverified_email(owner_info['github_id'])
+        if owner_info.get('github_id'):
+            unverified_email = generate_unverified_email(owner_info['github_id'])
+        else:
+            unverified_email = owner_info['username'] + '@localhost'
 
         owner_created = False
         owner = User.objects.filter(username=unverified_email).first()

--- a/galaxy_ng/app/utils/legacy.py
+++ b/galaxy_ng/app/utils/legacy.py
@@ -52,7 +52,7 @@ def process_namespace(namespace_name, namespace_info, force=False):
 
         namespace = legacy_namespace.namespace
         _owners = namespace_info['summary_fields']['owners']
-        _owners = [(x['github_id'], x['username']) for x in _owners]
+        _owners = [(x.get('github_id', -1), x['username']) for x in _owners]
         _matched_owners = [x for x in _owners if x[1].lower() == namespace_name.lower()]
 
         if _matched_owners:

--- a/galaxy_ng/tests/integration/api/test_community.py
+++ b/galaxy_ng/tests/integration/api/test_community.py
@@ -803,7 +803,7 @@ def test_v1_role_versions(ansible_config):
     versions = resp["results"][0]["summary_fields"]["versions"]
 
     resp = api_client(f'/api/v1/roles/{id}/versions')
-    assert len(versions) == resp["count"]
+    assert resp["count"] >= len(versions)
 
     with pytest.raises(AnsibleError) as html:
         api_client(f"v1/roles/{id}/versions", headers={"Accept": "text/html"})

--- a/galaxy_ng/tests/integration/cli/test_community.py
+++ b/galaxy_ng/tests/integration/cli/test_community.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.qa  # noqa: F821
 
 
 @pytest.mark.deployment_community
-def test_import_role_as_owner(ansible_config):
+def test_import_role_as_owner_no_tags(ansible_config):
     """ Tests role import workflow with a social auth user and anonymous install """
 
     # https://github.com/jctannerTEST/role1
@@ -70,15 +70,14 @@ def test_import_role_as_owner(ansible_config):
     assert role['github_repo'] == github_repo
     assert role['github_branch'] is not None
     assert role['commit'] is not None
-    assert len(role['summary_fields']['versions']) == 1
+    assert len(role['summary_fields']['versions']) == 0
 
     # validate the versions url
     versions_url = f'v1/roles/{role_id}/versions/'
     versions_resp = client.get(versions_url)
     assert versions_resp.status_code == 200
     versions = versions_resp.json()
-    assert versions['results'][0]['version'] == \
-        role['summary_fields']['versions'][0]['version']
+    assert versions['count'] == 0
 
     # validate the content url
     content_url = f'v1/roles/{role_id}/content/'
@@ -122,7 +121,7 @@ def test_import_role_as_owner(ansible_config):
 
 
 @pytest.mark.deployment_community
-def test_import_role_as_not_owner(ansible_config):
+def test_import_role_as_not_owner_no_tags(ansible_config):
     """ Tests role import workflow with non-owner """
 
     # https://github.com/jctannerTEST/role1
@@ -172,7 +171,7 @@ def test_import_role_as_not_owner(ansible_config):
 
 
 @pytest.mark.deployment_community
-def test_import_role_fields(ansible_config):
+def test_import_role_fields_no_tags(ansible_config):
     """Test role serializer fields after import with galaxy-importer>=0.4.11."""
 
     github_user = "jctannerTEST"
@@ -214,12 +213,7 @@ def test_import_role_fields(ansible_config):
     assert summary_fields["repository"]["name"] == "role1"
     assert summary_fields["tags"] == list()
 
-    assert len(summary_fields["versions"]) == 1
-    for field in [
-        "active", "commit_date", "commit_sha", "created", "download_url",
-        "modified", "name", "release_date", "url", "version"
-    ]:
-        assert field in summary_fields["versions"][0]
+    assert len(summary_fields["versions"]) == 0
 
     # Cleanup all roles.
     clean_all_roles(ansible_config)

--- a/galaxy_ng/tests/unit/app/api/v1/test_tasks.py
+++ b/galaxy_ng/tests/unit/app/api/v1/test_tasks.py
@@ -117,15 +117,19 @@ def test_legacy_role_import_altered_github_org_name():
     # make sure it's the right id
     assert role.id == this_role.id
 
+    # make sure the name is correct ...
+    assert role.name == alternate_role_name
+
     # make sure the github_user is correct ...
     assert role.full_metadata.get('github_user') == github_user
     assert role.full_metadata.get('github_repo') == github_repo
 
     # should have used the default branch ..
     assert role.full_metadata.get('github_reference') == github_reference
+    assert role.full_metadata.get('github_branch') == github_reference
 
-    # should have only the old version ...
-    assert role.full_metadata['versions'] == [{'version': '0.0.1', 'name': 'v0.0.1'}]
+    # the old version isn't a tag so it should have been removed.
+    assert role.full_metadata['versions'] == []
 
 
 @pytest.mark.django_db

--- a/galaxy_ng/tests/unit/app/api/v1/test_tasks.py
+++ b/galaxy_ng/tests/unit/app/api/v1/test_tasks.py
@@ -51,13 +51,15 @@ def test_legacy_role_import_simple():
 
     # make sure the github_user is correct ...
     assert role.full_metadata.get('github_user') == github_user
+
+    # make sure the github_repo is correct ...
     assert role.full_metadata.get('github_repo') == github_repo
 
     # should have used the default branch ..
     assert role.full_metadata.get('github_reference') == 'master'
 
-    # should have one version
-    assert len(role.full_metadata['versions']) == 1
+    # should have many versions
+    assert len(role.full_metadata['versions']) >= 1
 
 
 @pytest.mark.django_db
@@ -89,7 +91,7 @@ def test_legacy_role_import_altered_github_org_name():
     this_role, _ = LegacyRole.objects.get_or_create(namespace=legacy_ns, name=alternate_role_name)
     this_role.full_metadata['github_user'] = github_user
     this_role.full_metadata['github_repo'] = github_repo
-    this_role.full_metadata['versions'] = [{'commit_sha': '1111', 'name': '1111'}]
+    this_role.full_metadata['versions'] = [{'version': '0.0.1', 'name': 'v0.0.1'}]
     this_role.save()
 
     # import it
@@ -122,8 +124,8 @@ def test_legacy_role_import_altered_github_org_name():
     # should have used the default branch ..
     assert role.full_metadata.get('github_reference') == github_reference
 
-    # should have two versions
-    assert len(role.full_metadata['versions']) == 2
+    # should have only the old version ...
+    assert role.full_metadata['versions'] == [{'version': '0.0.1', 'name': 'v0.0.1'}]
 
 
 @pytest.mark.django_db
@@ -171,35 +173,13 @@ def test_legacy_role_import_with_tag_name():
     assert found.count() == 1
     role = found.first()
 
-    # should have the one version ..
-    assert len(role.full_metadata['versions']) == 1
-    v1 = role.full_metadata['versions'][0]
-    assert v1['name'] == github_reference
-    assert v1['version'] == github_reference
+    # the branch and the reference should be the tag name ...
+    assert role.full_metadata['github_reference'] == github_reference
+    assert role.full_metadata['github_branch'] == github_reference
 
-    # import again with new ref
-    github_reference_2 = '1.24.3'
-    with patch('galaxy_ng.app.api.v1.tasks.Config', spec=Config) as MockConfig:
+    # should have ALL the tag versions ...
+    assert len(role.full_metadata['versions']) >= 1
 
-        MockConfig.return_value = Config()
-        MockConfig.return_value.run_ansible_lint = False
-
-        legacy_role_import(
-            github_user=github_user,
-            github_repo=github_repo,
-            github_reference=github_reference_2,
-            alternate_role_name=alternate_role_name,
-        )
-
-    # find the role
-    found = LegacyRole.objects.filter(
-        full_metadata__github_user=github_user, name=alternate_role_name
-    )
-    assert found.count() == 1
-    role = found.first()
-
-    # should have the second version ..
-    assert len(role.full_metadata['versions']) == 2
-    v2 = role.full_metadata['versions'][1]
-    assert v2['name'] == github_reference_2
-    assert v2['version'] == github_reference_2
+    # the tag should be in the versions ...
+    vmap = dict((x['version'], x) for x in role.full_metadata['versions'])
+    assert github_reference in vmap


### PR DESCRIPTION
https://forum.ansible.com/t/role-import-from-github-results-in-master-release-not-the-tag-release-breaking-installs/1856

After digging around and mapping out the code from github.com/ansible/galaxy ...

- At import time, all tags for the repo are enumerated and added as versions (if semantic version compliant).
- tags should be valid semantic versions or a semantic version starting with 'v'
- the "name" field for a role version is the original tag name.
- the "version" field for a role version is the tag name stripped of any 'v' prefix.
- if the import command includes `--branch=<older-tag>` the old tag will set the role's commit, but ALL tags get added as versions anyway.
- if a tag is removed from the repo, the related role version is also removed.
- in the list view and detail view, versions are limit to the 10 most recent in descending order and only a few fields
- in the versions list page, more fields are given and the order is ascending
- role repos without tags do not end up with a list of versions
- the role's commit, commit date, etc are updated from HEAD of the checkout -after- the branch or tag is switched
- in old-galaxy if github_branch is given at import time with a tag name, the role will end up with HEAD as the github_branch ... which we don't want to do new galaxy. We should either use the tag value or the default branch.
- the cli's `--role-name` option passes the value as `alternate_role_name` in the POST request, but this will not change the actual name in the current old-galaxy code. It instead transforms the repository name's hyphens to underscores and nothing more. In the API `alternate_role_name` is stored in the `repository_alt_name` column.
- the galaxy_info.role_name field in meta/main.yml can change the role's name in the database.