### PR TITLE
Add the github id to the v1/user serializer for auditing purposes.

### DIFF
--- a/galaxy_ng/app/api/v1/serializers.py
+++ b/galaxy_ng/app/api/v1/serializers.py
@@ -2,8 +2,6 @@ import datetime
 
 from rest_framework import serializers
 
-from social_django.models import UserSocialAuth
-
 from pulpcore.plugin.util import get_url
 
 from galaxy_ng.app.models.auth import User
@@ -182,6 +180,12 @@ class LegacyUserSerializer(serializers.ModelSerializer):
         return url
 
     def get_github_id(self, obj):
+
+        # have to defer this import because of the other
+        # deployment profiles trying to access the missing
+        # database table.
+        from social_django.models import UserSocialAuth
+
         try:
             social_user = UserSocialAuth.objects.filter(user=obj).first()
             if not social_user:
@@ -189,6 +193,8 @@ class LegacyUserSerializer(serializers.ModelSerializer):
             return social_user.id
         except Exception:
             return None
+
+        return None
 
 
 class LegacyRoleSerializer(serializers.ModelSerializer):

--- a/galaxy_ng/app/api/v1/serializers.py
+++ b/galaxy_ng/app/api/v1/serializers.py
@@ -182,10 +182,13 @@ class LegacyUserSerializer(serializers.ModelSerializer):
         return url
 
     def get_github_id(self, obj):
-        social_user = UserSocialAuth.objects.filter(user=obj).first()
-        if not social_user:
+        try:
+            social_user = UserSocialAuth.objects.filter(user=obj).first()
+            if not social_user:
+                return None
+            return social_user.id
+        except Exception:
             return None
-        return social_user.id
 
 
 class LegacyRoleSerializer(serializers.ModelSerializer):

--- a/galaxy_ng/app/api/v1/serializers.py
+++ b/galaxy_ng/app/api/v1/serializers.py
@@ -2,6 +2,8 @@ import datetime
 
 from rest_framework import serializers
 
+from social_django.models import UserSocialAuth
+
 from pulpcore.plugin.util import get_url
 
 from galaxy_ng.app.models.auth import User
@@ -125,6 +127,7 @@ class LegacyUserSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField()
     username = serializers.SerializerMethodField()
     avatar_url = serializers.SerializerMethodField()
+    github_id = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -138,7 +141,7 @@ class LegacyUserSerializer(serializers.ModelSerializer):
             'full_name',
             'date_joined',
             'avatar_url',
-            # 'active'
+            'github_id',
         ]
 
     def get_username(self, obj):
@@ -177,6 +180,12 @@ class LegacyUserSerializer(serializers.ModelSerializer):
             username = obj.username
         url = f'https://github.com/{username}.png'
         return url
+
+    def get_github_id(self, obj):
+        social_user = UserSocialAuth.objects.filter(user=obj).first()
+        if not social_user:
+            return None
+        return social_user.id
 
 
 class LegacyRoleSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
To match data from old and new galaxy, we need the github id for each user. It's squirreled away in the social auth table and can be fetched by filtering on the user.
