### PR TITLE
Stringify exceptions to avoid failed logging serialization.

### DIFF
--- a/galaxy_ng/app/api/v1/tasks.py
+++ b/galaxy_ng/app/api/v1/tasks.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os
 import subprocess
+import traceback
 import tempfile
 import uuid
 
@@ -409,7 +410,11 @@ def legacy_role_import(
             importer_config = Config()
             result = import_legacy_role(checkout_path, namespace.name, importer_config, logger)
         except Exception as e:
-            logger.exception(e)
+            logger.info('')
+            logger.error(f'Role loading failed! {str(e)}')
+            logger.info('')
+            tb_str = traceback.format_exc()
+            logger.error(tb_str)
             raise e
         logger.info('')
 

--- a/galaxy_ng/tests/integration/community/test_role_import_exceptions.py
+++ b/galaxy_ng/tests/integration/community/test_role_import_exceptions.py
@@ -3,11 +3,8 @@
 
 import pytest
 
-from ansible.errors import AnsibleError
-
 from ..utils import (
     ansible_galaxy,
-    get_client,
     SocialGithubClient,
     GithubAdminClient,
 )
@@ -34,12 +31,6 @@ def test_role_import_exceptions(ansible_config):
     """" Exceptions should end up in the client facing logs """
 
     config = ansible_config("admin")
-    api_client = get_client(
-        config=config,
-        request_token=False,
-        require_auth=True
-    )
-
     github_user = 'jctanner'
     github_repo = 'busted-role'
     cleanup_social_user(github_user, ansible_config)
@@ -54,7 +45,7 @@ def test_role_import_exceptions(ansible_config):
         ga.delete_user(login=github_user)
     except Exception:
         pass
-    guser = ga.create_user(login=github_user, password='redhat', email='jctanner.foo@bar.com')
+    ga.create_user(login=github_user, password='redhat', email='jctanner.foo@bar.com')
 
     # Login with the user first to create the v1+v3 namespaces
     with SocialGithubClient(config=user_cfg) as client:

--- a/galaxy_ng/tests/integration/community/test_role_import_exceptions.py
+++ b/galaxy_ng/tests/integration/community/test_role_import_exceptions.py
@@ -1,0 +1,83 @@
+"""test_community.py - Tests related to the community featureset.
+"""
+
+import pytest
+
+from ansible.errors import AnsibleError
+
+from ..utils import (
+    ansible_galaxy,
+    get_client,
+    SocialGithubClient,
+    GithubAdminClient,
+)
+from ..utils.legacy import (
+    cleanup_social_user,
+)
+
+pytestmark = pytest.mark.qa  # noqa: F821
+
+
+def extract_default_config(ansible_config):
+    base_cfg = ansible_config('github_user_1')
+    cfg = {}
+    cfg['token'] = None
+    cfg['url'] = base_cfg.get('url')
+    cfg['auth_url'] = base_cfg.get('auth_url')
+    cfg['github_url'] = base_cfg.get('github_url')
+    cfg['github_api_url'] = base_cfg.get('github_api_url')
+    return cfg
+
+
+@pytest.mark.deployment_community
+def test_role_import_exceptions(ansible_config):
+    """" Exceptions should end up in the client facing logs """
+
+    config = ansible_config("admin")
+    api_client = get_client(
+        config=config,
+        request_token=False,
+        require_auth=True
+    )
+
+    github_user = 'jctanner'
+    github_repo = 'busted-role'
+    cleanup_social_user(github_user, ansible_config)
+
+    user_cfg = extract_default_config(ansible_config)
+    user_cfg['username'] = github_user
+    user_cfg['password'] = 'redhat'
+
+    # delete and recreate the github user ...
+    ga = GithubAdminClient()
+    try:
+        ga.delete_user(login=github_user)
+    except Exception:
+        pass
+    guser = ga.create_user(login=github_user, password='redhat', email='jctanner.foo@bar.com')
+
+    # Login with the user first to create the v1+v3 namespaces
+    with SocialGithubClient(config=user_cfg) as client:
+        me = client.get('_ui/v1/me/')
+        assert me.json()['username'] == github_user
+
+    # Run the import
+    import_pid = ansible_galaxy(
+        f"role import {github_user} {github_repo}",
+        ansible_config=config,
+        token=None,
+        force_token=False,
+        cleanup=False,
+        check_retcode=False
+    )
+
+    # core always exits zero...
+    # https://github.com/ansible/ansible/issues/82175
+    assert import_pid.returncode == 0
+
+    stdout = import_pid.stdout.decode('utf-8')
+    assert 'Traceback (most recent call last):' in stdout
+    assert 'galaxy_importer.exceptions.LegacyRoleSchemaError' in stdout
+
+    # cleanup
+    cleanup_social_user(github_user, ansible_config)


### PR DESCRIPTION
Exception caused by current code ...

```
  File "/venv/lib64/python3.11/site-packages/pulpcore/tasking/tasks.py", line 66, in _execute_task
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/app/galaxy_ng/app/api/v1/tasks.py", line 412, in legacy_role_import
    logger.exception(e)
  File "/usr/lib64/python3.11/logging/__init__.py", line 1524, in exception
    self.error(msg, *args, exc_info=exc_info, **kwargs)
  File "/usr/lib64/python3.11/logging/__init__.py", line 1518, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/usr/lib64/python3.11/logging/__init__.py", line 1634, in _log
    self.handle(record)
  File "/usr/lib64/python3.11/logging/__init__.py", line 1644, in handle
    self.callHandlers(record)
  File "/usr/lib64/python3.11/logging/__init__.py", line 1706, in callHandlers
    hdlr.handle(record)
  File "/usr/lib64/python3.11/logging/__init__.py", line 978, in handle
    self.emit(record)
  File "/app/galaxy_ng/app/api/v1/logutils.py", line 34, in emit
    legacyrole_import.save()
  File "/venv/lib64/python3.11/site-packages/django/db/models/base.py", line 814, in save
    self.save_base(
  File "/venv/lib64/python3.11/site-packages/django/db/models/base.py", line 877, in save_base
    updated = self._save_table(
              ^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/db/models/base.py", line 990, in _save_table
    updated = self._do_update(
              ^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/db/models/base.py", line 1054, in _do_update
    return filtered._update(values) > 0
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/db/models/query.py", line 1231, in _update
    return query.get_compiler(self.db).execute_sql(CURSOR)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/db/models/sql/compiler.py", line 1984, in execute_sql
    cursor = super().execute_sql(result_type)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/db/models/sql/compiler.py", line 1562, in execute_sql
    cursor.execute(sql, params)
  File "/venv/lib64/python3.11/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/psycopg/cursor.py", line 719, in execute
    self._conn.wait(
  File "/venv/lib64/python3.11/site-packages/psycopg/connection.py", line 957, in wait
    return waiting.wait(gen, self.pgconn.socket, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "psycopg_binary/_psycopg/waiting.pyx", line 176, in psycopg_binary._psycopg.wait_c
  File "/venv/lib64/python3.11/site-packages/psycopg/cursor.py", line 195, in _execute_gen
    pgq = self._convert_query(query, params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/psycopg/client_cursor.py", line 79, in _convert_query
    pgq.convert(query, params)
  File "/venv/lib64/python3.11/site-packages/psycopg/_queries.py", line 129, in convert
    self.dump(vars)
  File "/venv/lib64/python3.11/site-packages/psycopg/_queries.py", line 139, in dump
    self.params = tuple(
                  ^^^^^^
  File "/venv/lib64/python3.11/site-packages/psycopg/_queries.py", line 140, in <genexpr>
    self._tx.as_literal(p) if p is not None else b"NULL" for p in params
    ^^^^^^^^^^^^^^^^^^^^^^
  File "psycopg_binary/_psycopg/transform.pyx", line 206, in psycopg_binary._psycopg.Transformer.as_literal
  File "psycopg_binary/_psycopg/transform.pyx", line 215, in psycopg_binary._psycopg.Transformer.as_literal
  File "/venv/lib64/python3.11/site-packages/psycopg/adapt.py", line 58, in quote
    value = self.dump(obj)
            ^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/psycopg/types/json.py", line 135, in dump
    return dumps(obj).encode()
           ^^^^^^^^^^
  File "/usr/lib64/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '

Object of type LegacyRoleSchemaError is not JSON serializable
```

New import output ...

```
(venv) [jtanner@p1 galaxy_ng.role_exception_logging]$ ansible-galaxy role import nephelaiio ansible-role-packetbeat
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
Successfully submitted import request 2054526162614225967054263524602829492
Starting import: task_id=2054526162614225967054263524602829492, pulp_id=018baff5-e521-74ef-aa66-95efc7925ab4

==== PARAMETERS ====
importer username: admin
matched user: admin id:1
github_user: nephelaiio
github_repo: ansible-role-packetbeat
github_reference: None
alternate_role_name: packetbeat

==== CHECK FOR MATCHING ROLE(S) ====
user:nephelaiio repo:ansible-role-packetbeat did not match any existing roles

===== CLONING REPO =====
cloning https://github.com/nephelaiio/ansible-role-packetbeat ...

===== GIT ATTRIBUTES =====
github_reference(branch): master
github_commit: b4563952c93f37f2c5324c088114b842339d4493
github_commit_message: Fix service task evaluation conditions (#4)

github_commit_date: 2023-11-08T10:42:47-06:00

===== LOADING ROLE =====
Importing with galaxy-importer 0.4.16

Role loading failed! dependency must include 'role' keyword.

Traceback (most recent call last):
  File "/src/galaxy_ng/galaxy_ng/app/api/v1/tasks.py", line 411, in legacy_role_import
    result = import_legacy_role(checkout_path, namespace.name, importer_config, logger)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/galaxy_importer/legacy_role.py", line 51, in import_legacy_role
    return _import_legacy_role(dirname, namespace, cfg, logger)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/galaxy_importer/legacy_role.py", line 57, in _import_legacy_role
    data = LegacyRoleLoader(dirname, namespace, cfg, logger).load()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/galaxy_importer/loaders/legacy_role.py", line 41, in load
    self.metadata = self._load_metadata()
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/galaxy_importer/loaders/legacy_role.py", line 77, in _load_metadata
    return schema.LegacyMetadata.parse(meta_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/galaxy_importer/schema.py", line 536, in parse
    return cls(galaxy_info, dependencies)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<attrs generated init galaxy_importer.schema.LegacyMetadata>", line 10, in __init__
    __attr_validator_dependencies(self, __attr_dependencies, self.dependencies)
  File "/usr/local/lib/python3.11/site-packages/galaxy_importer/schema.py", line 553, in _validate_dependencies
    raise exc.LegacyRoleSchemaError("dependency must include 'role' keyword.")
galaxy_importer.exceptions.LegacyRoleSchemaError: dependency must include 'role' keyword.

```