### PR TITLE
Fix `github_user` and `github_repo` filters in `LegacyRoleImportFilter`

### DIFF
--- a/galaxy_ng/app/api/v1/filtersets.py
+++ b/galaxy_ng/app/api/v1/filtersets.py
@@ -186,8 +186,8 @@ class LegacyRoleImportFilter(filterset.FilterSet):
     role_name = filters.NumberFilter(field_name='role__name')
     namespace_id = filters.NumberFilter(field_name='role__namespace_id')
     namespace_name = filters.NumberFilter(field_name='role__namespace_name')
-    github_user = filters.CharFilter(method='github_user_filter')
-    github_repo = filters.CharFilter(method='github_repo_filter')
+    github_user = filters.CharFilter(field_name='task__kwargs__github_user')
+    github_repo = filters.CharFilter(field_name='task__kwargs__github_repo')
     state = filters.CharFilter(method='state_filter')
 
     class Meta:


### PR DESCRIPTION
No-Issue

```
AttributeError at /api/galaxy/v3/openapi.json
type object 'LegacyRoleImportFilter' has no attribute 'github_user_filter'
```

In https://github.com/ansible/galaxy_ng/blob/master/galaxy_ng/app/api/v1/filtersets.py#L189 `github_user_filter` and `github_repo_filter` are missing filter methods.

![Screenshot from 2023-11-14 16-43-09](https://github.com/ansible/galaxy_ng/assets/19647757/00d2f963-19ed-458d-b7fd-ed8a6d62fed2)
