### PR TITLE
Add `exclude_fields` and `fields` filters to `v3/namespaces`

### DIFF
--- a/CHANGES/2858.bugfix
+++ b/CHANGES/2858.bugfix
@@ -1,0 +1,1 @@
+Support ``exclude_fields`` and ``fields`` filters in ``v3/namespaces`` endpoint.

--- a/galaxy_ng/app/api/v3/serializers/namespace.py
+++ b/galaxy_ng/app/api/v3/serializers/namespace.py
@@ -9,7 +9,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework import serializers
 from rest_framework import fields
 
-from pulpcore.plugin.serializers import IdentityField
+from pulpcore.plugin.serializers import IdentityField, ModelSerializer
 
 from galaxy_ng.app import models
 from galaxy_ng.app.tasks import dispatch_create_pulp_namespace_metadata
@@ -75,7 +75,7 @@ class NamespaceLinkSerializer(serializers.ModelSerializer):
         return url
 
 
-class NamespaceSerializer(serializers.ModelSerializer):
+class NamespaceSerializer(ModelSerializer):
     links = NamespaceLinkSerializer(many=True, required=False)
     groups = GroupPermissionField(required=False)
     users = UserPermissionField(required=False)


### PR DESCRIPTION
Issue: AAH-2858

Use pulpcore `ModelSerializer` in namespaces to support filters like `exclude_fields` and `fields`. 

Should we make this change for other endpoints? For example openapi spec for `v3/tasks` shows support of these filters, but they don't work (https://console.redhat.com/api/automation-hub/v3/swagger-ui/#/Tasks/_api_automation-hub_v3_tasks_tasks_list). 