### PR TITLE
node: update minimum version to 18+

### DIFF
--- a/docs/community/devstack.md
+++ b/docs/community/devstack.md
@@ -95,7 +95,7 @@ To connect to the UI, the default address is http://localhost:8002. If social au
 For development work on the UI, it's easiest to launch the webpack dev server outside the compose stack. The npm start scripts and configuration will have it redirect api calls to http://localhost:5001 by default, so no hacking is necessary to make it work locally.
 
 1. Install [NVM](https://github.com/nvm-sh/nvm) to easily manage node.js versions.
-2. Use NVM to install and set the version to 16: `nvm install 16`,
+2. Use NVM to install and set the version to 18: `nvm install 18`,
 3. Clone the [ansible-hub-ui](https://github.com/ansible/ansible-hub-ui) repo to the desired location.
 4. From the checkout, run `npm install`.
 5. From the checkout, run `npm run start-community`.

--- a/docs/dev/docker_environment.md
+++ b/docs/dev/docker_environment.md
@@ -158,7 +158,7 @@ COMPOSE_PROFILE=standalone-keycloak
     This option is only relevant to Red Hat employees. Community contributors should skip this.
 
 1. In your `.compose.env` file set `COMPOSE_PROFILE=insights` and comment out `ANSIBLE_HUB_UI_PATH` (if its set).
-2. Install node. Node v16+ is known to work. Older versions may work as well.
+2. Install node. Node v18+ is known to work. Older versions may work as well.
 3. Switch to your `ansible-hub-ui` checkout and run the following
 
     ```bash


### PR DESCRIPTION
Node 16 is no longer maintained, update docs to mention node 18 instead.

UI: ansible/ansible-hub-ui#4582

https://nodejs.org/en/about/previous-releases