### PR TITLE
add load data and verify data stages

### DIFF
--- a/.ci/aap_upgrade.groovy
+++ b/.ci/aap_upgrade.groovy
@@ -178,6 +178,17 @@ pipeline {
                 }
             }
 
+            stage('Hub Load Data') {
+                steps {
+                    container('aapqa-ansible') {
+                        script {
+                            stepsFactory.aapqaAutomationHubSteps.setup(installInfo)
+                            stepsFactory.aapqaAutomationHubSteps.runAutomationHubLoadDataTests(installInfo)
+                            stepsFactory.commonSteps.saveXUnitResultsToJenkins(xunitFile: 'ah-results-load.xml')
+                        }
+                    }
+                }
+            }
 
             stage('Upgrade AAP 2.4') {
                 steps {
@@ -281,6 +292,19 @@ pipeline {
                                     """
                                 }
                             }
+                        }
+                    }
+                }
+            }
+
+            stage('Hub Verify Data Tests') {
+                steps {
+                    container('aapqa-ansible') {
+                        script {
+                            upgradeFlags.add('input/install/flags/upgrade_from_aap_23.yml')
+                            stepsFactory.aapqaAutomationHubSteps.setup(installInfo)
+                            stepsFactory.aapqaAutomationHubSteps.runAutomationHubVerifyDataTests(installInfo + [upgradeVarFiles: upgradeFlags])
+                            stepsFactory.commonSteps.saveXUnitResultsToJenkins(xunitFile: 'ah-results-verify.xml')
                         }
                     }
                 }


### PR DESCRIPTION
Add two new stages to the AAP installation and upgrade pipeline, to check that the data loaded before the upgrade remains consistent after it
No-Issue

