### PR TITLE
[stable-4.5] Linter: `E721 do not compare types`

### DIFF
--- a/galaxy_ng/app/api/ui/views/index_execution_environments.py
+++ b/galaxy_ng/app/api/ui/views/index_execution_environments.py
@@ -39,6 +39,7 @@ class IndexRegistryEEView(api_base.APIView):
         serializable_meta = {}
         for key in self.request.META:
             val = self.request.META[key]
+            # E721 do not compare types
             if type(val) == str:
                 serializable_meta[key] = val
 


### PR DESCRIPTION
No-Issue

```
/galaxy_ng/app/api/ui/views/index_execution_environments.py:43:16: 
E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```