### PR TITLE
Drop support for `stable-4.5` in translations

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         branch:
         - 'master'
-        - 'stable-4.5'
         - 'stable-4.6'
         - 'stable-4.7'
         - 'stable-4.8'


### PR DESCRIPTION
No-Issue

Since 4.5 (AAP 2.2) is EOL, stop adding translations.	
