### PR TITLE
Fix flaky `test_namespace_create_and_delete[v3]`

### DIFF
--- a/galaxy_ng/tests/integration/api/test_namespace_management.py
+++ b/galaxy_ng/tests/integration/api/test_namespace_management.py
@@ -13,7 +13,7 @@ from galaxykit.users import get_me
 
 from ..utils.iqe_utils import is_stage_environment
 from ..utils.repo_management_utils import upload_new_artifact
-from ..utils.tasks import wait_for_all_tasks_gk
+from ..utils.tasks import wait_for_all_tasks_gk, wait_for_namespace_tasks_gk
 from ..utils.tools import generate_random_string
 
 pytestmark = pytest.mark.qa  # noqa: F821
@@ -39,6 +39,7 @@ def test_namespace_create_and_delete(api_version, galaxy_client):
     new_namespace = f"ns_test_{generate_random_string()}"
     payload = {'name': new_namespace, 'groups': []}
     resp = gc.post(f"{api_version}/namespaces/", body=payload)
+    wait_for_namespace_tasks_gk(gc)
     assert resp['name'] == new_namespace
     if api_version == "v3":
         get_namespace(gc, new_namespace)

--- a/galaxy_ng/tests/integration/utils/tasks.py
+++ b/galaxy_ng/tests/integration/utils/tasks.py
@@ -89,6 +89,18 @@ def wait_for_task_ui_client(uclient, task):
     assert state == 'completed'
 
 
+def wait_for_namespace_tasks_gk(gc, timeout=300):
+    ready = False
+    wait_until = time.time() + timeout
+    while not ready:
+        if wait_until < time.time():
+            raise TaskWaitingTimeout()
+        running_count = gc.get("pulp/api/v3/tasks/?state=running&name__contains=namespace")["count"]
+        waiting_count = gc.get("pulp/api/v3/tasks/?state=waiting&name__contains=namespace")["count"]
+        ready = running_count == 0 and waiting_count == 0
+        time.sleep(1)
+
+
 class TaskFailed(Exception):
     def __init__(self, message):
         self.message = message


### PR DESCRIPTION
No-Issue

https://github.com/ansible/galaxy_ng/actions/runs/7171839578/job/19529139780?pr=2003#step:8:1344

```
=================================== FAILURES ===================================
_____________________ test_namespace_create_and_delete[v3] _____________________

api_version = 'v3'
galaxy_client = <bound method GalaxyKitClient.gen_authorized_client of <galaxy_ng.tests.integration.utils.iqe_utils.GalaxyKitClient object at 0x7fe17effc490>>

    @pytest.mark.galaxyapi_smoke
    @pytest.mark.namespace
    @pytest.mark.parametrize(
        "api_version",
        [
            'v3',
            '_ui/v1'
        ]
    )
    @pytest.mark.all
    def test_namespace_create_and_delete(api_version, galaxy_client):
        """Tests whether a namespace can be created and deleted"""
    
        # http://192.168.1.119:8002/api/automation-hub/_ui/v1/namespaces/
        # http://192.168.1.119:8002/api/automation-hub/v3/namespaces/
        # {name: "testnamespace1", groups: []}
        gc = galaxy_client("partner_engineer")
        new_namespace = f"ns_test_{generate_random_string()}"
        payload = {'name': new_namespace, 'groups': []}
        resp = gc.post(f"{api_version}/namespaces/", body=payload)
        assert resp['name'] == new_namespace
        if api_version == "v3":
            get_namespace(gc, new_namespace)
            gc.delete(f"{api_version}/namespaces/{new_namespace}/", parse_json=False)
>           with pytest.raises(KeyError):
E           Failed: DID NOT RAISE <class 'KeyError'>

galaxy_ng/tests/integration/api/test_namespace_management.py:46: Failed
```


Fix by waiting for namespace metadata tasks to finish.