### PR TITLE
support legacy role import overrides for namespace and name.

### DIFF
--- a/galaxy_ng/app/api/v1/serializers.py
+++ b/galaxy_ng/app/api/v1/serializers.py
@@ -569,7 +569,9 @@ class LegacyImportSerializer(serializers.Serializer):
 
     github_user = serializers.CharField()
     github_repo = serializers.CharField()
+    alternate_namespace_name = serializers.CharField(required=False)
     alternate_role_name = serializers.CharField(required=False)
+    alternate_clone_url = serializers.CharField(required=False)
     github_reference = serializers.CharField(required=False)
 
     class Meta:
@@ -577,7 +579,9 @@ class LegacyImportSerializer(serializers.Serializer):
         fields = [
             'github_user',
             'github_repo',
+            'alternate_namespace_name',
             'alternate_role_name',
+            'alternate_clone_url',
             'github_reference',
         ]
 

--- a/galaxy_ng/app/api/v1/viewsets/roles.py
+++ b/galaxy_ng/app/api/v1/viewsets/roles.py
@@ -263,17 +263,12 @@ class LegacyRoleImportsViewSet(viewsets.ModelViewSet, LegacyTasksMixin):
         to the pulp tasking system and translating the
         task UUID to an integer to retain v1 compatibility.
         """
-        serializer_class = LegacyImportSerializer
-        serializer = serializer_class(data=request.data)
+        serializer = LegacyImportSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         kwargs = dict(serializer.validated_data)
 
         # tell the defered task who started this job
         kwargs['request_username'] = request.user.username
-
-        # synthetically create the name for the response
-        role_name = kwargs.get('alternate_role_name') or \
-            kwargs['github_repo'].replace('ansible-role-', '')
 
         task_id, pulp_id = self.legacy_dispatch(legacy_role_import, kwargs=kwargs)
 
@@ -284,9 +279,12 @@ class LegacyRoleImportsViewSet(viewsets.ModelViewSet, LegacyTasksMixin):
                 'github_user': kwargs['github_user'],
                 'github_repo': kwargs['github_repo'],
                 'github_reference': kwargs.get('github_reference'),
+                'alternate_namespace_name': kwargs.get('alternate_namespace_name'),
+                'alternate_role_name': kwargs.get('alternate_role_name'),
+                'alternate_clone_url': kwargs.get('alternate_clone_url'),
                 'summary_fields': {
                     'role': {
-                        'name': role_name
+                        'name': None
                     }
                 }
             }]

--- a/galaxy_ng/app/utils/galaxy.py
+++ b/galaxy_ng/app/utils/galaxy.py
@@ -443,12 +443,13 @@ def upstream_role_iterator(
     pagenum = 0
     role_count = 0
     while next_url:
-        logger.info(f'fetch {pagenum} {next_url} role-count:{role_count}')
+        logger.info(f'fetch {pagenum} {next_url} role-count:{role_count} ...')
 
         page = safe_fetch(next_url)
 
         # Some upstream pages return ISEs for whatever reason.
         if page.status_code >= 500:
+            logger.error(f'{next_url} returned 500ISE. incrementing the page manually')
             if 'page=' in next_url:
                 next_url = next_url.replace(f'page={pagenum}', f'page={pagenum+1}')
             else:
@@ -520,9 +521,16 @@ def upstream_role_iterator(
         if ds.get('next'):
             next_url = ds['next']
         elif ds.get('next_link'):
-            next_url = _baseurl + ds['next_link']
+            next_url = ds['next_link']
         else:
             # break if no next page
             break
+
+        api_prefix = '/api/v1'
+        if not next_url.startswith(_baseurl):
+            if not next_url.startswith(api_prefix):
+                next_url = _baseurl + api_prefix + next_url
+            else:
+                next_url = _baseurl + next_url
 
         pagenum += 1

--- a/galaxy_ng/tests/integration/community/test_role_import_overrides.py
+++ b/galaxy_ng/tests/integration/community/test_role_import_overrides.py
@@ -1,0 +1,105 @@
+"""test_community.py - Tests related to the community featureset.
+"""
+
+import pytest
+
+from ..utils import (
+    get_client,
+)
+from ..utils.legacy import (
+    cleanup_social_user,
+    LegacyRoleGitRepoBuilder,
+    wait_for_v1_task
+)
+
+pytestmark = pytest.mark.qa  # noqa: F821
+
+
+@pytest.mark.parametrize(
+    'spec',
+    [
+        {
+            'namespace': 'foo',
+            'name': 'bar',
+            'github_user': 'foo',
+            'github_repo': 'bar',
+            'meta_namespace': None,
+            'meta_name': None,
+            'alternate_namespace_name': 'foo',
+            'alternate_role_name': 'bar',
+        },
+        {
+            'namespace': 'jim32',
+            'name': 'bob32',
+            'github_user': 'jim',
+            'github_repo': 'bob',
+            'meta_namespace': 'jim32',
+            'meta_name': 'bob32',
+            'alternate_namespace_name': None,
+            'alternate_role_name': None,
+        }
+
+    ]
+)
+@pytest.mark.deployment_community
+def test_role_import_overrides(ansible_config, spec):
+    """" Validate setting namespace in meta/main.yml does the right thing """
+
+    admin_config = ansible_config("admin")
+    admin_client = get_client(
+        config=admin_config,
+        request_token=False,
+        require_auth=True
+    )
+
+    # all required namespaces ...
+    ns_names = [
+        spec['namespace'],
+        spec['github_user'],
+        spec['alternate_namespace_name'],
+        spec['meta_namespace']
+    ]
+    ns_names = sorted(set([x for x in ns_names if x]))
+
+    # cleanup
+    for ns_name in ns_names:
+        cleanup_social_user(ns_name, ansible_config)
+        try:
+            admin_client(f'/api/v3/namespaces/{ns_name}/', method='DELETE')
+        except Exception:
+            pass
+
+    # make the namespace(s)
+    for ns_name in ns_names:
+        v1 = admin_client('/api/v1/namespaces/', method='POST', args={'name': ns_name})
+        v3 = admin_client('/api/v3/namespaces/', method='POST', args={'name': ns_name})
+        admin_client(
+            f'/api/v1/namespaces/{v1["id"]}/providers/', method='POST', args={'id': v3['id']}
+        )
+
+    # make a local git repo
+    builder_kwargs = {
+        'namespace': spec['namespace'],
+        'name': spec['name'],
+        'meta_namespace': spec['meta_namespace'],
+        'meta_name': spec['meta_name'],
+    }
+    lr = LegacyRoleGitRepoBuilder(**builder_kwargs)
+
+    # run the import
+    payload = {'alternate_clone_url': lr.role_dir}
+    for key in ['github_user', 'github_repo', 'alternate_namespace_name', 'alternate_role_name']:
+        if spec.get(key):
+            payload[key] = spec[key]
+    resp = admin_client('/api/v1/imports/', method='POST', args=payload)
+    task_id = resp['results'][0]['id']
+    result = wait_for_v1_task(task_id=task_id, api_client=admin_client)
+    assert result['results'][0]['state'] == 'SUCCESS'
+
+    # find the role and check it's attributes ...
+    roles_search = admin_client(f'/api/v1/roles/?namespace={spec["namespace"]}&name={spec["name"]}')
+    assert roles_search['count'] == 1
+    assert roles_search['results'][0]['summary_fields']['namespace']['name'] == spec['namespace']
+    assert roles_search['results'][0]['name'] == spec['name']
+    assert roles_search['results'][0]['github_user'] == spec['github_user']
+    assert roles_search['results'][0]['github_repo'] == spec['github_repo']


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-3002

The old API supported a request parameter for `alternate-role-name` for a period of time, but was ultimately removed in https://github.com/ansible/galaxy/commit/1d1519f6cdf3098983c817421ee940db98be0d11

We added support in the galaxy-importer legacy role schema for the namespace name per https://github.com/ansible/galaxy-importer/commit/98e0931139219c61e13279d5a8a0a740e1b65fd7

"role_name" was added to the initial legacy role schema per https://github.com/ansible/galaxy-importer/commit/1927cd6b44d0a4a4713de3b34183f3b06e7856c9

This PR adds a few things ....

1) The `namespace` and `role_name` in meta/main.yml now causes the role import code to attempt to put the role by the given name into the given namespace name. RBAC still requires the github_user to map to some known namespace name that the request user is an owner of.

2) The import API endpoint now accepts `alternate_namespace_name` and `alternate_role_name` with both overriding any values found in the role's metadata. The ansible-galaxy CLI only supports alternate_role_name but I envision these new parametes to be primarily used by the galaxy UI for UX driven imports. I'd expect CLI users to use the meta/main.yml definitions instead.

The "magic" role finding code that attempts to map a non-matching github_user to an old role with a non-matching namespace name will remain in place for now. I think after we establish this new path as the standard way of doing things, we can do away with the "magic" and make the code predicatable.