### PR TITLE
v1/sync, v1/import: return pulp task id along with numeric ids

### DIFF
--- a/galaxy_ng/app/api/v1/viewsets/roles.py
+++ b/galaxy_ng/app/api/v1/viewsets/roles.py
@@ -275,11 +275,12 @@ class LegacyRoleImportsViewSet(viewsets.ModelViewSet, LegacyTasksMixin):
         role_name = kwargs.get('alternate_role_name') or \
             kwargs['github_repo'].replace('ansible-role-', '')
 
-        task_id = self.legacy_dispatch(legacy_role_import, kwargs=kwargs)
+        task_id, pulp_id = self.legacy_dispatch(legacy_role_import, kwargs=kwargs)
 
         return Response({
             'results': [{
                 'id': task_id,
+                'pulp_id': pulp_id,
                 'github_user': kwargs['github_user'],
                 'github_repo': kwargs['github_repo'],
                 'github_reference': kwargs.get('github_reference'),

--- a/galaxy_ng/app/api/v1/viewsets/sync.py
+++ b/galaxy_ng/app/api/v1/viewsets/sync.py
@@ -40,5 +40,8 @@ class LegacyRolesSyncViewSet(viewsets.GenericViewSet, mixins.CreateModelMixin, L
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         kwargs = dict(serializer.validated_data)
-        task_id = self.legacy_dispatch(legacy_sync_from_upstream, kwargs=kwargs)
-        return Response({'task': task_id})
+        task_id, pulp_id = self.legacy_dispatch(legacy_sync_from_upstream, kwargs=kwargs)
+        return Response({
+            'task': task_id,
+            'pulp_id': pulp_id,
+        })

--- a/galaxy_ng/app/api/v1/viewsets/tasks.py
+++ b/galaxy_ng/app/api/v1/viewsets/tasks.py
@@ -40,7 +40,7 @@ class LegacyTasksMixin:
         """Dispatch wrapper for legacy tasks."""
         task = dispatch(function, kwargs=kwargs)
         legacy_id = uuid_to_int(str(task.pulp_id))
-        return legacy_id
+        return legacy_id, str(task.pulp_id)
 
     @extend_schema(
         parameters=[],

--- a/galaxy_ng/tests/integration/api/test_community.py
+++ b/galaxy_ng/tests/integration/api/test_community.py
@@ -457,6 +457,7 @@ def test_v1_sync_with_user_and_limit(ansible_config):
     resp = api_client('/api/v1/sync/', method='POST', args=pargs)
     assert isinstance(resp, dict)
     assert resp.get('task') is not None
+    assert resp.get('pulp_id') is not None
     wait_for_v1_task(resp=resp, api_client=api_client)
 
     # verify filtering in the way that the CLI does it

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -850,6 +850,7 @@ def test_api_ui_v1_tags_roles(ansible_config):
         resp = api_admin_client('/api/v1/sync/', method='POST', args=pargs)
         assert isinstance(resp, dict)
         assert resp.get('task') is not None
+        assert resp.get('pulp_id') is not None
         wait_for_v1_task(resp=resp, api_client=api_admin_client)
 
     def _populate_tags_cmd():

--- a/galaxy_ng/tests/integration/community/test_community_namespace_rbac.py
+++ b/galaxy_ng/tests/integration/community/test_community_namespace_rbac.py
@@ -53,6 +53,7 @@ def test_admin_can_import_legacy_roles(ansible_config):
         'github_user': github_user,
     }
     resp = admin_client('/api/v1/imports/', method='POST', args=payload)
+    assert resp['results'][0]['pulp_id'] is not None, resp
     task_id = resp['results'][0]['id']
     res = wait_for_v1_task(task_id=task_id, api_client=admin_client, check=False)
 
@@ -90,6 +91,7 @@ def test_admin_can_import_legacy_roles(ansible_config):
 
     # try to import again ...
     resp = admin_client('/api/v1/imports/', method='POST', args=payload)
+    assert resp['results'][0]['pulp_id'] is not None, resp
     task_id = resp['results'][0]['id']
     res = wait_for_v1_task(task_id=task_id, api_client=admin_client, check=False)
     assert res['results'][0]['state'] == 'SUCCESS', res


### PR DESCRIPTION
The UI needs uuids to wait for tasks, bigints lose precision - js treats them as floats ([MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER), 53 < 128).

Making `legacy_dispatch` return a tuple of `task_id, pulp_id` (numeric, uuid),
and adding a `pulp_id` field along the existing `task`/`id` fields,
both to `v1/import`, to show an "Import started" task alert in the UI,
and to `v1/sync`, purely for symmetry. (Does it make sense there?)

Meant to support https://github.com/ansible/ansible-hub-ui/pull/4508,
@jctanner does something like this make sense? :)