### PR TITLE
crc: add IMPORTER_JOB_TIMEOUT and increase timeout

### DIFF
--- a/CHANGES/3036.misc
+++ b/CHANGES/3036.misc
@@ -1,0 +1,1 @@
+adds IMPORTER_JOB_TIMEOUT to pulp-worker on crc, and increases the timeout to 1800 seconds

--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -324,6 +324,8 @@ objects:
             value: 500m
           - name: IMPORTER_CPU_LIMIT
             value: 1000m
+          - name: IMPORTER_JOB_TIMEOUT
+            value: "1800"
           - name: PULP_REDIS_SSL
             value: ${REDIS_SSL}
           - name: ENABLE_SIGNING


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
* adds the IMPORTER_JOB_TIMEOUT envvar to the pulp-worker
* increases the importer timeout from the default of 900 seconds to 1800 seconds

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAH-3036
