### PR TITLE
fix: Bump dynaconf on stable-4.9

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -138,7 +138,7 @@ drf-spectacular==0.26.2
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
-dynaconf==3.1.12
+dynaconf==3.2.4
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -147,7 +147,7 @@ drf-spectacular==0.26.2
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
-dynaconf==3.1.12
+dynaconf==3.2.4
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -138,7 +138,7 @@ drf-spectacular==0.26.2
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
-dynaconf==3.1.12
+dynaconf==3.2.4
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ requirements = [
     "pulp-container>=2.15.0,<2.16.0",
     "social-auth-core>=4.4.2",
     "social-auth-app-django>=5.2.0",
-    "dynaconf>=3.1.12,<3.1.13",
+    "dynaconf>=3.2.2,<3.3",
     "django-auth-ldap==4.0.0",
     "insights_analytics_collector>=0.3.0",
     "boto3",


### PR DESCRIPTION
Requires PR: https://github.com/pulp/pulpcore/pull/4936

AAP 2.4 uses pulpcore 3.28.z and needs
dynaconf to be at least 3.2.4 to include
a fix for boolean parsing.

Previous versions of dynaconf would parse

```bash
export PULP_DEBUG=False
```

as a str `"False"` causing `if settings.DEBUG:` to evaluate to `True`

On 3.2.2, dynaconf [started parsing](https://github.com/dynaconf/dynaconf/pull/983) `False/True` string as booleans from envvars.

No-Issue
