### PR TITLE
use galaxykit instead of requests library so that configuration is ta…

### DIFF
--- a/galaxy_ng/tests/integration/api/test_api_base.py
+++ b/galaxy_ng/tests/integration/api/test_api_base.py
@@ -1,19 +1,17 @@
 import pytest
-import requests
 
 from ..utils import get_client
 
 
 @pytest.mark.min_hub_version("4.6dev")
 @pytest.mark.deployment_standalone
-def test_galaxy_api_root_standalone_no_auth_access(ansible_config):
+def test_galaxy_api_root_standalone_no_auth_access(galaxy_client):
     """Test galaxy API root."""
 
-    config = ansible_config("basic_user")
-    api_root = config["url"]
-
+    gc = galaxy_client("basic_user")
+    del gc.headers["Authorization"]
     # verify api root works without authentication
-    response = requests.get(f"{api_root}").json()
+    response = gc.get("")
     assert "v3" in response["available_versions"]
     assert "pulp-v3" in response["available_versions"]
 


### PR DESCRIPTION
https://main-jenkins-csb-aap.apps.ocp-c1.prod.psi.redhat.com/job/AAPQA/job/RPM_Gating/job/ansible-automation-platform-2.4-rhel-8/job/generic/job/integ-aap-2.4_public-tls/69/testReport/

test is failing because it's using requests library and not taking external configuration into consideration (SSL). This PR updates the test so galaxykit is used.
