### PR TITLE
Bump galaxy-importer to 0.4.20

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -164,7 +164,7 @@ frozenlist==1.4.0
     #   aiosignal
 future==0.18.3
     # via pyjwkest
-galaxy-importer==0.4.19
+galaxy-importer==0.4.20
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -173,7 +173,7 @@ frozenlist==1.4.0
     #   aiosignal
 future==0.18.3
     # via pyjwkest
-galaxy-importer==0.4.19
+galaxy-importer==0.4.20
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -164,7 +164,7 @@ frozenlist==1.4.0
     #   aiosignal
 future==0.18.3
     # via pyjwkest
-galaxy-importer==0.4.19
+galaxy-importer==0.4.20
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ def _format_pulp_requirement(plugin, specifier=None, ref=None, gh_namespace="pul
 
 
 requirements = [
-    "galaxy-importer>=0.4.19,<0.5.0",
+    "galaxy-importer>=0.4.20,<0.5.0",
     "pulpcore>=3.28.12,<3.29.0",
     "pulp_ansible>=0.20.0,<0.21.0",
     "django-prometheus>=2.0.0",


### PR DESCRIPTION
Upgrading galaxy-importer version. 

Includes:
https://github.com/ansible/galaxy-importer/pull/261
https://github.com/ansible/galaxy-importer/pull/265
https://issues.redhat.com/browse/AAH-3083

