### PR TITLE
The urls for ephemeral environments have changed.

### DIFF
--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -238,9 +238,10 @@ def is_standalone():
 
 
 def is_ephemeral_env():
-    return "c-rh-c-eph" in os.getenv(
+    api_root = os.getenv(
         "HUB_API_ROOT", "http://localhost:5001/api/automation-hub/"
     )
+    return "c-rh-c-eph" in api_root or "crc-eph" in api_root
 
 
 def is_galaxy_stage():


### PR DESCRIPTION
The ephemeral URL structure has changed, which then causes the is_ephemeral function in tests/integration/iqe_utils.py to return False and then cause the the rest of the code to assume it could do a token grant which then obviously blew up because ephemeral keycloak can only do password grants.

```
17:12:18 Running pytest ...
17:12:18 + echo 'Running pytest ...'
17:12:18 + /tmp/gvenv/bin/pytest --capture=no -m 'deployment_cloud or all' -v galaxy_ng/tests/integration
17:12:18 /tmp/gvenv/lib64/python3.10/site-packages/urllib3/connectionpool.py:1103: InsecureRequestWarning: Unverified HTTPS request is being made to host 'ee-0olmrio4-auth.apps.crc-eph.r9lp.p1.openshiftapps.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
17:12:18   warnings.warn(
17:12:18 INTERNALERROR> Traceback (most recent call last):
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/_pytest/main.py", line 271, in wrap_session
17:12:18 INTERNALERROR>     config.hook.pytest_sessionstart(session=session)
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/pluggy/_hooks.py", line 501, in __call__
17:12:18 INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/pluggy/_manager.py", line 119, in _hookexec
17:12:18 INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/pluggy/_callers.py", line 138, in _multicall
17:12:18 INTERNALERROR>     raise exception.with_traceback(exception.__traceback__)
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
17:12:18 INTERNALERROR>     teardown.throw(exception)  # type: ignore[union-attr]
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/_pytest/logging.py", line 775, in pytest_sessionstart
17:12:18 INTERNALERROR>     return (yield)
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/pluggy/_callers.py", line 102, in _multicall
17:12:18 INTERNALERROR>     res = hook_impl.function(*args)
17:12:18 INTERNALERROR>   File "/app/galaxy_ng/tests/integration/conftest.py", line 301, in pytest_sessionstart
17:12:18 INTERNALERROR>     hub_version = get_hub_version(ansible_config)
17:12:18 INTERNALERROR>   File "/app/galaxy_ng/tests/integration/utils/iqe_utils.py", line 649, in get_hub_version
17:12:18 INTERNALERROR>     gc = GalaxyKitClient(ansible_config).gen_authorized_client(role)
17:12:18 INTERNALERROR>   File "/app/galaxy_ng/tests/integration/utils/iqe_utils.py", line 176, in gen_authorized_client
17:12:18 INTERNALERROR>     g_client = GalaxyClient(
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/galaxykit/client.py", line 129, in __init__
17:12:18 INTERNALERROR>     self._refresh_jwt_token()
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/galaxykit/client.py", line 186, in _refresh_jwt_token
17:12:18 INTERNALERROR>     json = self._http(
17:12:18 INTERNALERROR>   File "/tmp/gvenv/lib64/python3.10/site-packages/galaxykit/client.py", line 240, in _http
17:12:18 INTERNALERROR>     raise GalaxyClientError(resp, resp.status_code)
17:12:18 INTERNALERROR> galaxykit.utils.GalaxyClientError: 400
```