### PR TITLE
fix: Fresh installs must get the correct URL for rh-certified

### DIFF
--- a/galaxy_ng/app/migrations/0017_populate_repos_and_remotes.py
+++ b/galaxy_ng/app/migrations/0017_populate_repos_and_remotes.py
@@ -31,7 +31,7 @@ REPOSITORIES = [
         "next_version": 1,
         "remote": {
             "name": "rh-certified",
-            "url": "https://console.redhat.com/api/automation-hub/",
+            "url": "https://console.redhat.com/api/automation-hub/content/published/",
             "requirements_file": None,
             "token": None,
             "auth_url": (


### PR DESCRIPTION
Add /content/published to the default URL when setting up the default remotes.

This has been fix on #2032 but that PR not backported.

This PR changes the original migration, so fresh installs gets the new URL and existing systems are not affected

This must be backported to 4.9.z

No-Issue
Related: AAH-2836
