### PR TITLE
fix: Accept SVG as avatar_url

### DIFF
--- a/CHANGES/2836.bugfix
+++ b/CHANGES/2836.bugfix
@@ -1,0 +1,1 @@
+Support SVG avatar image on namespaces

--- a/galaxy_ng/app/management/commands/download-namespace-logos.py
+++ b/galaxy_ng/app/management/commands/download-namespace-logos.py
@@ -24,15 +24,51 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--namespace", help="find and sync only this namespace name")
+        parser.add_argument(
+            "--sha-report",
+            default=False,
+            action="store_true",
+            required=False,
+            help="report the number of namespaces with avatar_url but missing avatar_sha256",
+            dest="sha_report",
+        )
+        parser.add_argument(
+            "--only-missing-sha",
+            default=False,
+            action="store_true",
+            required=False,
+            help="When set it will limit the logo download only to those namespaces missing sha",
+            dest="only_missing_sha",
+        )
 
     def echo(self, message, style=None):
         style = style or self.style.SUCCESS
         self.stdout.write(style(message))
 
     def handle(self, *args, **options):
+        # all namespaces having avatar_url must have avatar_sha256 set
+        # query for namespaces missing avatar_sha256
+        ns_missing_avatar_sha = Namespace.objects.filter(
+            _avatar_url__isnull=False,
+            last_created_pulp_metadata__avatar_sha256__isnull=True
+        )
+        if ns_missing_avatar_sha:
+            self.echo(
+                f"{ns_missing_avatar_sha.count()} Namespaces missing avatar_sha256",
+                self.style.ERROR
+            )
+            self.echo(", ".join(ns_missing_avatar_sha.values_list("name", flat=True)))
+        else:
+            self.echo("There are no namespaces missing avatar_sha256!")
+
+        if options["sha_report"]:  # --sha-report indicated only report was requested
+            return
+
+        self.echo("Proceeding with namespace logo downloads")
 
         kwargs = {
             'namespace_name': options['namespace'],
+            'only_missing_sha': options['only_missing_sha'],
         }
 
         task = dispatch(
@@ -52,11 +88,23 @@ class Command(BaseCommand):
             sys.exit(1)
 
 
-def download_all_logos(namespace_name=None):
+def download_all_logos(namespace_name=None, only_missing_sha=False):
+    """Force logo downloads.
+    namespace: limit to specified namespace (or list of namespaces)
+    only_missing_sha: Limit to namespaces having avatar_url but missing avatar_sha256
+    """
     if namespace_name:
-        qs = Namespace.objects.filter(name=namespace_name)
+        namespaces = namespace_name.split(",")
+        qs = Namespace.objects.filter(name__in=namespaces)
     else:
         qs = Namespace.objects.all()
+
+    if only_missing_sha:
+        qs = qs.filter(
+            _avatar_url__isnull=False,
+            last_created_pulp_metadata__avatar_sha256__isnull=True
+        )
+
     for namespace in qs:
         download_logo = False
         if namespace._avatar_url:

--- a/galaxy_ng/tests/integration/api/test_namespace_management.py
+++ b/galaxy_ng/tests/integration/api/test_namespace_management.py
@@ -177,6 +177,7 @@ def test_namespace_edit_logo(galaxy_client):
     wait_for_all_tasks_gk(gc)
     updated_again_namespace = gc.get(f"_ui/v1/my-namespaces/{name}/")
     assert updated_namespace["avatar_url"] != updated_again_namespace["avatar_url"]
+    assert updated_namespace["avatar_sha256"] is not None
 
     # verify no additional namespaces are created
     resp = gc.get("_ui/v1/my-namespaces/")


### PR DESCRIPTION
Make download_avatar task to accept .svg up to 3MB

```console
# pulpcore-manager download-namespace-logos --only-missing-sha
1 Namespaces missing avatar_sha256
nokia
Proceeding with namespace logo downloads
Process completed

# pulpcore-manager download-namespace-logos --sha-report
There are no namespaces missing avatar_sha256!
```

Also it will now fail the task if logo iamge is > 3MB or provided url is an invalid logo.
![2024-02-28_17-25](https://github.com/ansible/galaxy_ng/assets/458654/54350eae-4762-49d7-8877-05b514dbb3a1)



Issue: AAH-2836
