### PR TITLE
skip if ocp

### DIFF
--- a/galaxy_ng/tests/integration/api/test_load_data.py
+++ b/galaxy_ng/tests/integration/api/test_load_data.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from galaxy_ng.tests.integration.conftest import is_hub_4_7_or_higher
-from galaxy_ng.tests.integration.utils.iqe_utils import sign_collection_on_demand
+from galaxy_ng.tests.integration.utils.iqe_utils import sign_collection_on_demand, is_ocp_env
 from galaxy_ng.tests.integration.utils.repo_management_utils import create_repo_and_dist, \
     upload_new_artifact
 from galaxykit.collections import deprecate_collection, \
@@ -98,11 +98,15 @@ class TestLoadData:
                 move_or_copy_collection(gc, artifact.namespace, artifact.name,
                                         artifact.version, "staging",
                                         destination=collection["repository"])
-                if collection["signed"]:
+                if collection["signed"] and not is_ocp_env():
                     logger.debug("Signing collection")
                     sign_collection_on_demand(
                         gc, "ansible-default", collection["repository"],
                         artifact.namespace, artifact.name, artifact.version)
+                if collection["signed"] and is_ocp_env():
+                    # FIXME
+                    logger.debug("Not Signing collection, collection signing not enabled"
+                                 "on ocp environment")
                 if collection["deprecated"]:
                     logger.debug("Deprecating collection")
                     deprecate_collection(gc, collection["namespace"], artifact.name,

--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -288,6 +288,11 @@ def avoid_docker_limit_rate():
     return avoid_limit_rate in ('true', 'True', 1, '1', True)
 
 
+def is_upgrade_from_aap24_hub47():
+    upgrade = os.getenv("UPGRADE_FROM_AAP24_HUB47", False)
+    return upgrade in ('true', 'True', 1, '1', True)
+
+
 def is_upgrade_from_aap23_hub46():
     upgrade = os.getenv("UPGRADE_FROM_AAP23_HUB46", False)
     return upgrade in ('true', 'True', 1, '1', True)


### PR DESCRIPTION
content signing is still not enabled in OCP pipelines. That's the reason why we need to skip signing collections and verifying they have been signed in LOAD DATA and VERIFY DATA stages

No-Issue

