### PR TITLE
Bump all pulp_* dependencies

### DIFF
--- a/.github/workflows/ci_automation_hub_collection.yml
+++ b/.github/workflows/ci_automation_hub_collection.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
+
+      - name: install ansible
+        run: pip3 install ansible
 
       - name: Checkout the galaxy collection
         uses: actions/checkout@v4

--- a/CHANGES/3064.misc
+++ b/CHANGES/3064.misc
@@ -1,0 +1,1 @@
+Bump pulp* versions

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-# This file contains dev requirements to be installed on dev host only 
+# This file contains dev requirements to be installed on dev host only
 # to add requirements to dev container see requirements/requirements-dev.txt
 
 coverage
@@ -15,3 +15,5 @@ check-manifest
 
 darker
 isort
+
+pip-tools

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -8,22 +8,24 @@ aiodns==3.1.1
     # via pulpcore
 aiofiles==23.2.1
     # via pulpcore
-aiohttp==3.9.1
+aiohttp==3.9.3
     # via pulpcore
 aiosignal==1.3.1
     # via aiohttp
-ansible-builder==3.0.0
+ansible-builder==3.0.1
     # via galaxy-importer
-ansible-core==2.16.3
+ansible-core==2.16.4
     # via
     #   ansible-lint
     #   galaxy-importer
 ansible-lint==6.14.3
     # via galaxy-importer
-asgiref==3.7.2
+asgiref==3.8.0
     # via django
 async-lru==2.0.4
     # via pulp-ansible
+async-timeout==4.0.3
+    # via redis
 asyncio-throttle==1.0.2
     # via pulpcore
 attrs==22.2.0
@@ -31,23 +33,20 @@ attrs==22.2.0
     #   aiohttp
     #   galaxy-importer
     #   jsonschema
+    #   referencing
 backoff==2.2.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-    #   pulpcore
+    # via pulpcore
 bindep==2.11.0
     # via ansible-builder
-black==24.2.0
+black==24.3.0
     # via ansible-lint
 bleach==3.3.1
     # via galaxy-importer
 bleach-allowlist==1.0.3
     # via galaxy-importer
-boto3==1.34.46
+boto3==1.34.67
     # via galaxy-ng (setup.py)
-botocore==1.34.46
+botocore==1.34.67
     # via
     #   boto3
     #   s3transfer
@@ -65,12 +64,13 @@ click==8.1.7
     # via
     #   black
     #   pulpcore
-cryptography==42.0.0
+cryptography==42.0.5
     # via
     #   ansible-core
     #   django-ansible-base
     #   pulpcore
     #   pyjwt
+    #   pyopenssl
     #   social-auth-core
 defusedxml==0.8.0rc2
     # via
@@ -88,7 +88,7 @@ distro==1.9.0
     # via
     #   bindep
     #   galaxy-ng (setup.py)
-django==4.2.10
+django==4.2.11
     # via
     #   django-ansible-base
     #   django-auth-ldap
@@ -104,7 +104,7 @@ django==4.2.10
     #   insights-analytics-collector
     #   pulpcore
     #   social-auth-app-django
-django-ansible-base[jwt_consumer] @ git+https://github.com/ansible/django-ansible-base@devel
+django-ansible-base[jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@devel
     # via galaxy-ng (setup.py)
 django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
@@ -124,7 +124,7 @@ django-picklefield==3.1
     # via galaxy-ng (setup.py)
 django-prometheus==2.3.1
     # via galaxy-ng (setup.py)
-django-split-settings==1.2.0
+django-split-settings==1.3.0
     # via django-ansible-base
 djangorestframework==3.14.0
     # via
@@ -143,7 +143,7 @@ drf-spectacular==0.26.5
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
-dynaconf==3.1.12
+dynaconf==3.2.4
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
@@ -157,8 +157,6 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-future==1.0.0
-    # via pyjwkest
 galaxy-importer==0.4.20
     # via
     #   galaxy-ng (setup.py)
@@ -167,11 +165,11 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.42
     # via pulp-ansible
-googleapis-common-protos==1.62.0
+googleapis-common-protos==1.63.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.60.1
+grpcio==1.62.1
     # via opentelemetry-exporter-otlp-proto-grpc
 gunicorn==21.2.0
     # via pulpcore
@@ -197,14 +195,22 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.17.3
+jq==1.6.0
+    # via pulpcore
+json-stream==2.3.2
+    # via pulpcore
+json-stream-rs-tokenizer==0.4.26
+    # via json-stream
+jsonschema==4.19.2
     # via
     #   ansible-builder
     #   ansible-lint
     #   drf-spectacular
     #   pulp-ansible
     #   pulp-container
-markdown==3.5.2
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+markdown==3.6
     # via galaxy-importer
 markdown-it-py==3.0.0
     # via rich
@@ -212,7 +218,7 @@ markuppy==1.14
     # via tablib
 markupsafe==2.1.5
     # via jinja2
-marshmallow==3.20.2
+marshmallow==3.21.1
     # via galaxy-ng (setup.py)
 mccabe==0.7.0
     # via flake8
@@ -224,8 +230,6 @@ multidict==6.0.5
     #   yarl
 mypy-extensions==1.0.0
     # via black
-naya==1.1.1
-    # via pulpcore
 oauthlib==3.2.2
     # via
     #   requests-oauthlib
@@ -234,7 +238,7 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opentelemetry-api==1.22.0
+opentelemetry-api==1.23.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -243,47 +247,47 @@ opentelemetry-api==1.22.0
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-distro[otlp]==0.43b0
+opentelemetry-distro[otlp]==0.44b0
     # via pulpcore
-opentelemetry-exporter-otlp==1.22.0
+opentelemetry-exporter-otlp==1.23.0
     # via opentelemetry-distro
-opentelemetry-exporter-otlp-proto-common==1.22.0
+opentelemetry-exporter-otlp-proto-common==1.23.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.22.0
+opentelemetry-exporter-otlp-proto-grpc==1.23.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.22.0
+opentelemetry-exporter-otlp-proto-http==1.23.0
     # via
     #   opentelemetry-exporter-otlp
     #   pulpcore
-opentelemetry-instrumentation==0.43b0
+opentelemetry-instrumentation==0.44b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.43b0
+opentelemetry-instrumentation-django==0.44b0
     # via pulpcore
-opentelemetry-instrumentation-wsgi==0.43b0
+opentelemetry-instrumentation-wsgi==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   pulpcore
-opentelemetry-proto==1.22.0
+opentelemetry-proto==1.23.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.22.0
+opentelemetry-sdk==1.23.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.43b0
+opentelemetry-semantic-conventions==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.43b0
+opentelemetry-util-http==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
@@ -306,28 +310,28 @@ pathspec==0.12.1
     #   yamllint
 pbr==6.0.0
     # via bindep
-pillow==10.0.1
+pillow==10.1.0
     # via pulp-ansible
 platformdirs==4.2.0
     # via black
 prometheus-client==0.20.0
     # via django-prometheus
-protobuf==4.25.2
+protobuf==4.25.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   pulpcore
-psycopg[binary]==3.1.17
+psycopg[binary]==3.1.18
     # via pulpcore
-psycopg-binary==3.1.17
+psycopg-binary==3.1.18
     # via psycopg
-pulp-ansible==0.20.3
+pulp-ansible==0.21.3
     # via galaxy-ng (setup.py)
-pulp-container==2.15.5
+pulp-container==2.19.2
     # via galaxy-ng (setup.py)
 pulp-glue==0.23.2
     # via pulpcore
-pulpcore==3.28.23
+pulpcore==3.49.1
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -344,26 +348,24 @@ pycodestyle==2.11.1
     # via flake8
 pycparser==2.21
     # via cffi
-pycryptodomex==3.20.0
-    # via pyjwkest
 pyflakes==3.1.0
     # via flake8
 pygments==2.17.2
     # via rich
 pygtrie==2.5.0
     # via pulpcore
-pyjwkest==1.4.2
-    # via pulp-container
-pyjwt[crypto]==2.7.0
+pyjwt[crypto]==2.8.0
     # via
     #   django-ansible-base
     #   pulp-container
     #   social-auth-core
+pyopenssl==24.1.0
+    # via pulpcore
 pyparsing==3.1.1
-    # via drf-access-policy
-pyrsistent==0.20.0
-    # via jsonschema
-python-dateutil==2.8.2
+    # via
+    #   drf-access-policy
+    #   pulpcore
+python-dateutil==2.9.0.post0
     # via botocore
 python-gnupg==0.5.2
     # via pulpcore
@@ -384,8 +386,12 @@ pyyaml==6.0.1
     #   pulpcore
     #   tablib
     #   yamllint
-redis==5.0.1
+redis==5.0.2
     # via pulpcore
+referencing==0.34.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   django-ansible-base
@@ -393,22 +399,25 @@ requests==2.31.0
     #   insights-analytics-collector
     #   opentelemetry-exporter-otlp-proto-http
     #   pulp-glue
-    #   pyjwkest
     #   requests-oauthlib
     #   social-auth-core
-requests-oauthlib==1.3.1
+requests-oauthlib==1.4.0
     # via social-auth-core
 requirements-parser==0.5.0
     # via ansible-builder
 resolvelib==1.0.1
     # via ansible-core
-rich==13.7.0
+rich==13.7.1
     # via ansible-lint
+rpds-py==0.18.0
+    # via
+    #   jsonschema
+    #   referencing
 ruamel-yaml==0.17.40
     # via ansible-lint
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via boto3
 semantic-version==2.10.0
     # via
@@ -417,7 +426,6 @@ semantic-version==2.10.0
 six==1.16.0
     # via
     #   bleach
-    #   pyjwkest
     #   python-dateutil
     #   url-normalize
 smmap==5.0.1
@@ -434,9 +442,9 @@ subprocess-tee==0.4.1
     # via ansible-lint
 tablib[html,ods,xls,xlsx,yaml]==3.5.0
     # via django-import-export
-types-setuptools==69.1.0.20240217
+types-setuptools==69.2.0.20240317
     # via requirements-parser
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   opentelemetry-sdk
     #   psycopg
@@ -444,7 +452,7 @@ uritemplate==4.1.1
     # via drf-spectacular
 url-normalize==1.4.3
     # via pulpcore
-urllib3==2.0.7
+urllib3==2.2.1
     # via
     #   botocore
     #   requests
@@ -470,7 +478,7 @@ yarl==1.9.4
     # via
     #   aiohttp
     #   pulpcore
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -8,13 +8,13 @@ aiodns==3.1.1
     # via pulpcore
 aiofiles==23.2.1
     # via pulpcore
-aiohttp==3.9.1
+aiohttp==3.9.3
     # via pulpcore
 aiosignal==1.3.1
     # via aiohttp
-ansible-builder==3.0.0
+ansible-builder==3.0.1
     # via galaxy-importer
-ansible-core==2.16.3
+ansible-core==2.16.4
     # via
     #   ansible-lint
     #   galaxy-importer
@@ -22,10 +22,12 @@ ansible-lint==6.14.3
     # via galaxy-importer
 app-common-python==0.2.6
     # via -r requirements/requirements.insights.in
-asgiref==3.7.2
+asgiref==3.8.0
     # via django
 async-lru==2.0.4
     # via pulp-ansible
+async-timeout==4.0.3
+    # via redis
 asyncio-throttle==1.0.2
     # via pulpcore
 attrs==22.2.0
@@ -33,33 +35,30 @@ attrs==22.2.0
     #   aiohttp
     #   galaxy-importer
     #   jsonschema
-azure-core==1.30.0
+    #   referencing
+azure-core==1.30.1
     # via
     #   azure-storage-blob
     #   django-storages
-azure-storage-blob==12.19.0
+azure-storage-blob==12.19.1
     # via django-storages
 backoff==2.2.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-    #   pulpcore
+    # via pulpcore
 bindep==2.11.0
     # via ansible-builder
-black==24.2.0
+black==24.3.0
     # via ansible-lint
 bleach==3.3.1
     # via galaxy-importer
 bleach-allowlist==1.0.3
     # via galaxy-importer
-boto3==1.34.46
+boto3==1.34.67
     # via
     #   -r requirements/requirements.insights.in
     #   django-storages
     #   galaxy-ng (setup.py)
     #   watchtower
-botocore==1.34.46
+botocore==1.34.67
     # via
     #   boto3
     #   s3transfer
@@ -77,13 +76,14 @@ click==8.1.7
     # via
     #   black
     #   pulpcore
-cryptography==42.0.0
+cryptography==42.0.5
     # via
     #   ansible-core
     #   azure-storage-blob
     #   django-ansible-base
     #   pulpcore
     #   pyjwt
+    #   pyopenssl
     #   social-auth-core
 defusedxml==0.8.0rc2
     # via
@@ -101,7 +101,7 @@ distro==1.9.0
     # via
     #   bindep
     #   galaxy-ng (setup.py)
-django==4.2.10
+django==4.2.11
     # via
     #   django-ansible-base
     #   django-auth-ldap
@@ -118,7 +118,7 @@ django==4.2.10
     #   insights-analytics-collector
     #   pulpcore
     #   social-auth-app-django
-django-ansible-base[jwt_consumer] @ git+https://github.com/ansible/django-ansible-base@devel
+django-ansible-base[jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@devel
     # via galaxy-ng (setup.py)
 django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
@@ -138,7 +138,7 @@ django-picklefield==3.1
     # via galaxy-ng (setup.py)
 django-prometheus==2.3.1
     # via galaxy-ng (setup.py)
-django-split-settings==1.2.0
+django-split-settings==1.3.0
     # via django-ansible-base
 django-storages[azure,boto3,s3]==1.14.2
     # via -r requirements/requirements.insights.in
@@ -159,7 +159,7 @@ drf-spectacular==0.26.5
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
-dynaconf==3.1.12
+dynaconf==3.2.4
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
@@ -173,8 +173,6 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-future==1.0.0
-    # via pyjwkest
 galaxy-importer==0.4.20
     # via
     #   galaxy-ng (setup.py)
@@ -183,11 +181,11 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.42
     # via pulp-ansible
-googleapis-common-protos==1.62.0
+googleapis-common-protos==1.63.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.60.1
+grpcio==1.62.1
     # via opentelemetry-exporter-otlp-proto-grpc
 gunicorn==21.2.0
     # via pulpcore
@@ -215,16 +213,24 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.17.3
+jq==1.6.0
+    # via pulpcore
+json-stream==2.3.2
+    # via pulpcore
+json-stream-rs-tokenizer==0.4.26
+    # via json-stream
+jsonschema==4.19.2
     # via
     #   ansible-builder
     #   ansible-lint
     #   drf-spectacular
     #   pulp-ansible
     #   pulp-container
+jsonschema-specifications==2023.12.1
+    # via jsonschema
 logstash-formatter==0.5.17
     # via -r requirements/requirements.insights.in
-markdown==3.5.2
+markdown==3.6
     # via galaxy-importer
 markdown-it-py==3.0.0
     # via rich
@@ -232,7 +238,7 @@ markuppy==1.14
     # via tablib
 markupsafe==2.1.5
     # via jinja2
-marshmallow==3.20.2
+marshmallow==3.21.1
     # via galaxy-ng (setup.py)
 mccabe==0.7.0
     # via flake8
@@ -244,8 +250,6 @@ multidict==6.0.5
     #   yarl
 mypy-extensions==1.0.0
     # via black
-naya==1.1.1
-    # via pulpcore
 oauthlib==3.2.2
     # via
     #   requests-oauthlib
@@ -254,7 +258,7 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opentelemetry-api==1.22.0
+opentelemetry-api==1.23.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -263,47 +267,47 @@ opentelemetry-api==1.22.0
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-distro[otlp]==0.43b0
+opentelemetry-distro[otlp]==0.44b0
     # via pulpcore
-opentelemetry-exporter-otlp==1.22.0
+opentelemetry-exporter-otlp==1.23.0
     # via opentelemetry-distro
-opentelemetry-exporter-otlp-proto-common==1.22.0
+opentelemetry-exporter-otlp-proto-common==1.23.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.22.0
+opentelemetry-exporter-otlp-proto-grpc==1.23.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.22.0
+opentelemetry-exporter-otlp-proto-http==1.23.0
     # via
     #   opentelemetry-exporter-otlp
     #   pulpcore
-opentelemetry-instrumentation==0.43b0
+opentelemetry-instrumentation==0.44b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.43b0
+opentelemetry-instrumentation-django==0.44b0
     # via pulpcore
-opentelemetry-instrumentation-wsgi==0.43b0
+opentelemetry-instrumentation-wsgi==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   pulpcore
-opentelemetry-proto==1.22.0
+opentelemetry-proto==1.23.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.22.0
+opentelemetry-sdk==1.23.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.43b0
+opentelemetry-semantic-conventions==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.43b0
+opentelemetry-util-http==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
@@ -326,28 +330,28 @@ pathspec==0.12.1
     #   yamllint
 pbr==6.0.0
     # via bindep
-pillow==10.0.1
+pillow==10.1.0
     # via pulp-ansible
 platformdirs==4.2.0
     # via black
 prometheus-client==0.20.0
     # via django-prometheus
-protobuf==4.25.2
+protobuf==4.25.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   pulpcore
-psycopg[binary]==3.1.17
+psycopg[binary]==3.1.18
     # via pulpcore
-psycopg-binary==3.1.17
+psycopg-binary==3.1.18
     # via psycopg
-pulp-ansible==0.20.3
+pulp-ansible==0.21.3
     # via galaxy-ng (setup.py)
-pulp-container==2.15.5
+pulp-container==2.19.2
     # via galaxy-ng (setup.py)
 pulp-glue==0.23.2
     # via pulpcore
-pulpcore==3.28.23
+pulpcore==3.49.1
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -364,26 +368,24 @@ pycodestyle==2.11.1
     # via flake8
 pycparser==2.21
     # via cffi
-pycryptodomex==3.20.0
-    # via pyjwkest
 pyflakes==3.1.0
     # via flake8
 pygments==2.17.2
     # via rich
 pygtrie==2.5.0
     # via pulpcore
-pyjwkest==1.4.2
-    # via pulp-container
-pyjwt[crypto]==2.7.0
+pyjwt[crypto]==2.8.0
     # via
     #   django-ansible-base
     #   pulp-container
     #   social-auth-core
+pyopenssl==24.1.0
+    # via pulpcore
 pyparsing==3.1.1
-    # via drf-access-policy
-pyrsistent==0.20.0
-    # via jsonschema
-python-dateutil==2.8.2
+    # via
+    #   drf-access-policy
+    #   pulpcore
+python-dateutil==2.9.0.post0
     # via botocore
 python-gnupg==0.5.2
     # via pulpcore
@@ -404,8 +406,12 @@ pyyaml==6.0.1
     #   pulpcore
     #   tablib
     #   yamllint
-redis==5.0.1
+redis==5.0.2
     # via pulpcore
+referencing==0.34.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   azure-core
@@ -414,22 +420,25 @@ requests==2.31.0
     #   insights-analytics-collector
     #   opentelemetry-exporter-otlp-proto-http
     #   pulp-glue
-    #   pyjwkest
     #   requests-oauthlib
     #   social-auth-core
-requests-oauthlib==1.3.1
+requests-oauthlib==1.4.0
     # via social-auth-core
 requirements-parser==0.5.0
     # via ansible-builder
 resolvelib==1.0.1
     # via ansible-core
-rich==13.7.0
+rich==13.7.1
     # via ansible-lint
+rpds-py==0.18.0
+    # via
+    #   jsonschema
+    #   referencing
 ruamel-yaml==0.17.40
     # via ansible-lint
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via boto3
 semantic-version==2.10.0
     # via
@@ -440,7 +449,6 @@ six==1.16.0
     #   azure-core
     #   bleach
     #   isodate
-    #   pyjwkest
     #   python-dateutil
     #   url-normalize
 smmap==5.0.1
@@ -457,9 +465,9 @@ subprocess-tee==0.4.1
     # via ansible-lint
 tablib[html,ods,xls,xlsx,yaml]==3.5.0
     # via django-import-export
-types-setuptools==69.1.0.20240217
+types-setuptools==69.2.0.20240317
     # via requirements-parser
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   azure-core
     #   azure-storage-blob
@@ -469,13 +477,13 @@ uritemplate==4.1.1
     # via drf-spectacular
 url-normalize==1.4.3
     # via pulpcore
-urllib3==2.0.7
+urllib3==2.2.1
     # via
     #   botocore
     #   requests
 uuid6==2024.1.12
     # via pulpcore
-watchtower==3.0.1
+watchtower==3.1.0
     # via -r requirements/requirements.insights.in
 wcmatch==8.5.1
     # via ansible-lint
@@ -497,7 +505,7 @@ yarl==1.9.4
     # via
     #   aiohttp
     #   pulpcore
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -8,22 +8,24 @@ aiodns==3.1.1
     # via pulpcore
 aiofiles==23.2.1
     # via pulpcore
-aiohttp==3.9.1
+aiohttp==3.9.3
     # via pulpcore
 aiosignal==1.3.1
     # via aiohttp
-ansible-builder==3.0.0
+ansible-builder==3.0.1
     # via galaxy-importer
-ansible-core==2.16.3
+ansible-core==2.16.4
     # via
     #   ansible-lint
     #   galaxy-importer
 ansible-lint==6.14.3
     # via galaxy-importer
-asgiref==3.7.2
+asgiref==3.8.0
     # via django
 async-lru==2.0.4
     # via pulp-ansible
+async-timeout==4.0.3
+    # via redis
 asyncio-throttle==1.0.2
     # via pulpcore
 attrs==22.2.0
@@ -31,23 +33,20 @@ attrs==22.2.0
     #   aiohttp
     #   galaxy-importer
     #   jsonschema
+    #   referencing
 backoff==2.2.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-    #   pulpcore
+    # via pulpcore
 bindep==2.11.0
     # via ansible-builder
-black==24.2.0
+black==24.3.0
     # via ansible-lint
 bleach==3.3.1
     # via galaxy-importer
 bleach-allowlist==1.0.3
     # via galaxy-importer
-boto3==1.34.46
+boto3==1.34.67
     # via galaxy-ng (setup.py)
-botocore==1.34.46
+botocore==1.34.67
     # via
     #   boto3
     #   s3transfer
@@ -65,12 +64,13 @@ click==8.1.7
     # via
     #   black
     #   pulpcore
-cryptography==42.0.0
+cryptography==42.0.5
     # via
     #   ansible-core
     #   django-ansible-base
     #   pulpcore
     #   pyjwt
+    #   pyopenssl
     #   social-auth-core
 defusedxml==0.8.0rc2
     # via
@@ -88,7 +88,7 @@ distro==1.9.0
     # via
     #   bindep
     #   galaxy-ng (setup.py)
-django==4.2.10
+django==4.2.11
     # via
     #   django-ansible-base
     #   django-auth-ldap
@@ -104,7 +104,7 @@ django==4.2.10
     #   insights-analytics-collector
     #   pulpcore
     #   social-auth-app-django
-django-ansible-base[jwt_consumer] @ git+https://github.com/ansible/django-ansible-base@devel
+django-ansible-base[jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@devel
     # via galaxy-ng (setup.py)
 django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
@@ -124,7 +124,7 @@ django-picklefield==3.1
     # via galaxy-ng (setup.py)
 django-prometheus==2.3.1
     # via galaxy-ng (setup.py)
-django-split-settings==1.2.0
+django-split-settings==1.3.0
     # via django-ansible-base
 djangorestframework==3.14.0
     # via
@@ -143,7 +143,7 @@ drf-spectacular==0.26.5
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
-dynaconf==3.1.12
+dynaconf==3.2.4
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
@@ -157,8 +157,6 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-future==1.0.0
-    # via pyjwkest
 galaxy-importer==0.4.20
     # via
     #   galaxy-ng (setup.py)
@@ -167,11 +165,11 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.42
     # via pulp-ansible
-googleapis-common-protos==1.62.0
+googleapis-common-protos==1.63.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.60.1
+grpcio==1.62.1
     # via opentelemetry-exporter-otlp-proto-grpc
 gunicorn==21.2.0
     # via pulpcore
@@ -197,14 +195,22 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.17.3
+jq==1.6.0
+    # via pulpcore
+json-stream==2.3.2
+    # via pulpcore
+json-stream-rs-tokenizer==0.4.26
+    # via json-stream
+jsonschema==4.19.2
     # via
     #   ansible-builder
     #   ansible-lint
     #   drf-spectacular
     #   pulp-ansible
     #   pulp-container
-markdown==3.5.2
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+markdown==3.6
     # via galaxy-importer
 markdown-it-py==3.0.0
     # via rich
@@ -212,7 +218,7 @@ markuppy==1.14
     # via tablib
 markupsafe==2.1.5
     # via jinja2
-marshmallow==3.20.2
+marshmallow==3.21.1
     # via galaxy-ng (setup.py)
 mccabe==0.7.0
     # via flake8
@@ -224,8 +230,6 @@ multidict==6.0.5
     #   yarl
 mypy-extensions==1.0.0
     # via black
-naya==1.1.1
-    # via pulpcore
 oauthlib==3.2.2
     # via
     #   requests-oauthlib
@@ -234,7 +238,7 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opentelemetry-api==1.22.0
+opentelemetry-api==1.23.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -243,47 +247,47 @@ opentelemetry-api==1.22.0
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-distro[otlp]==0.43b0
+opentelemetry-distro[otlp]==0.44b0
     # via pulpcore
-opentelemetry-exporter-otlp==1.22.0
+opentelemetry-exporter-otlp==1.23.0
     # via opentelemetry-distro
-opentelemetry-exporter-otlp-proto-common==1.22.0
+opentelemetry-exporter-otlp-proto-common==1.23.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.22.0
+opentelemetry-exporter-otlp-proto-grpc==1.23.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.22.0
+opentelemetry-exporter-otlp-proto-http==1.23.0
     # via
     #   opentelemetry-exporter-otlp
     #   pulpcore
-opentelemetry-instrumentation==0.43b0
+opentelemetry-instrumentation==0.44b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.43b0
+opentelemetry-instrumentation-django==0.44b0
     # via pulpcore
-opentelemetry-instrumentation-wsgi==0.43b0
+opentelemetry-instrumentation-wsgi==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   pulpcore
-opentelemetry-proto==1.22.0
+opentelemetry-proto==1.23.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.22.0
+opentelemetry-sdk==1.23.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.43b0
+opentelemetry-semantic-conventions==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.43b0
+opentelemetry-util-http==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
@@ -306,28 +310,28 @@ pathspec==0.12.1
     #   yamllint
 pbr==6.0.0
     # via bindep
-pillow==10.0.1
+pillow==10.1.0
     # via pulp-ansible
 platformdirs==4.2.0
     # via black
 prometheus-client==0.20.0
     # via django-prometheus
-protobuf==4.25.2
+protobuf==4.25.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   pulpcore
-psycopg[binary]==3.1.17
+psycopg[binary]==3.1.18
     # via pulpcore
-psycopg-binary==3.1.17
+psycopg-binary==3.1.18
     # via psycopg
-pulp-ansible==0.20.3
+pulp-ansible==0.21.3
     # via galaxy-ng (setup.py)
-pulp-container==2.15.5
+pulp-container==2.19.2
     # via galaxy-ng (setup.py)
 pulp-glue==0.23.2
     # via pulpcore
-pulpcore==3.28.23
+pulpcore==3.49.1
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -344,26 +348,24 @@ pycodestyle==2.11.1
     # via flake8
 pycparser==2.21
     # via cffi
-pycryptodomex==3.20.0
-    # via pyjwkest
 pyflakes==3.1.0
     # via flake8
 pygments==2.17.2
     # via rich
 pygtrie==2.5.0
     # via pulpcore
-pyjwkest==1.4.2
-    # via pulp-container
-pyjwt[crypto]==2.7.0
+pyjwt[crypto]==2.8.0
     # via
     #   django-ansible-base
     #   pulp-container
     #   social-auth-core
+pyopenssl==24.1.0
+    # via pulpcore
 pyparsing==3.1.1
-    # via drf-access-policy
-pyrsistent==0.20.0
-    # via jsonschema
-python-dateutil==2.8.2
+    # via
+    #   drf-access-policy
+    #   pulpcore
+python-dateutil==2.9.0.post0
     # via botocore
 python-gnupg==0.5.2
     # via pulpcore
@@ -384,8 +386,12 @@ pyyaml==6.0.1
     #   pulpcore
     #   tablib
     #   yamllint
-redis==5.0.1
+redis==5.0.2
     # via pulpcore
+referencing==0.34.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   django-ansible-base
@@ -393,22 +399,25 @@ requests==2.31.0
     #   insights-analytics-collector
     #   opentelemetry-exporter-otlp-proto-http
     #   pulp-glue
-    #   pyjwkest
     #   requests-oauthlib
     #   social-auth-core
-requests-oauthlib==1.3.1
+requests-oauthlib==1.4.0
     # via social-auth-core
 requirements-parser==0.5.0
     # via ansible-builder
 resolvelib==1.0.1
     # via ansible-core
-rich==13.7.0
+rich==13.7.1
     # via ansible-lint
+rpds-py==0.18.0
+    # via
+    #   jsonschema
+    #   referencing
 ruamel-yaml==0.17.40
     # via ansible-lint
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via boto3
 semantic-version==2.10.0
     # via
@@ -417,7 +426,6 @@ semantic-version==2.10.0
 six==1.16.0
     # via
     #   bleach
-    #   pyjwkest
     #   python-dateutil
     #   url-normalize
 smmap==5.0.1
@@ -434,9 +442,9 @@ subprocess-tee==0.4.1
     # via ansible-lint
 tablib[html,ods,xls,xlsx,yaml]==3.5.0
     # via django-import-export
-types-setuptools==69.1.0.20240217
+types-setuptools==69.2.0.20240317
     # via requirements-parser
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   opentelemetry-sdk
     #   psycopg
@@ -444,7 +452,7 @@ uritemplate==4.1.1
     # via drf-spectacular
 url-normalize==1.4.3
     # via pulpcore
-urllib3==2.0.7
+urllib3==2.2.1
     # via
     #   botocore
     #   requests
@@ -470,7 +478,7 @@ yarl==1.9.4
     # via
     #   aiohttp
     #   pulpcore
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -112,15 +112,15 @@ def _format_pulp_requirement(plugin, specifier=None, ref=None, gh_namespace="pul
 
 requirements = [
     "galaxy-importer>=0.4.19,<0.5.0",
-    "pulpcore>=3.28.12,<3.29.0",
-    "pulp_ansible>=0.20.0,<0.21.0",
+    "pulpcore>=3.49.0,<3.50.0",
+    "pulp_ansible>=0.21.0,<0.22.0",
+    "pulp-container>=2.19.2,<2.20.0",
     "django-prometheus>=2.0.0",
-    "drf-spectacular",
-    "pulp-container>=2.15.0,<2.16.0",
     "social-auth-core>=4.4.2",
     "social-auth-app-django>=5.2.0",
-    "dynaconf>=3.1.12,<3.1.13",
     "django-auth-ldap==4.0.0",
+    "drf-spectacular",
+    "dynaconf",  # unversioned because pulpcore already sets it
     "insights_analytics_collector>=0.3.0",
     "boto3",
     "distro",


### PR DESCRIPTION
Issue: AAH-3064

```python
pulpcore==3.49.1
pulp-ansible==0.21.3
pulp-container==2.19.2
dynaconf==3.2.4
```

~~I have tried pulp_container 2.19, but there is a circular import happening on it.~~


- [x] Fix galaxy Collection CI to use oci-env deployment (fix already being done by @bmclaughlin on https://github.com/ansible/galaxy_ng/pull/2055)
- [x] Try to bump pulp_container to 2.19 after https://github.com/pulp/pulp_container/issues/1561 is fixed