### PR TITLE
Use ANSIBLE_BASE_JWT_KEY to make Galaxy aware of Envoy

### DIFF
--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -5,6 +5,7 @@ import pkg_resources
 import os
 import re
 from typing import Any, Dict, List
+from urllib.parse import urlparse, urlunparse
 from django_auth_ldap.config import LDAPSearch
 from dynaconf import Dynaconf, Validator
 from galaxy_ng.app.dynamic_settings import DYNAMIC_SETTINGS_SCHEMA
@@ -41,6 +42,7 @@ def post(settings: Dynaconf) -> Dict[str, Any]:
     data.update(configure_api_base_path(settings))
     data.update(configure_legacy_roles(settings))
     data.update(configure_dab_resource_registry(settings))
+    data.update(configure_resource_provider(settings))
 
     # This should go last, and it needs to receive the data from the previous configuration
     # functions because this function configures the rest framework auth classes based off
@@ -580,6 +582,28 @@ def configure_legacy_roles(settings: Dynaconf) -> Dict[str, Any]:
     legacy_roles = settings.get("GALAXY_ENABLE_LEGACY_ROLES", False)
     data["GALAXY_FEATURE_FLAGS__legacy_roles"] = legacy_roles
     return data
+
+
+def configure_resource_provider(settings: Dynaconf) -> Dict[str, Any]:
+    # The following variable is either a URL or a key file path.
+    ANSIBLE_BASE_JWT_KEY = settings.get("ANSIBLE_BASE_JWT_KEY")
+    if ANSIBLE_BASE_JWT_KEY:
+        data = {
+            "ANSIBLE_API_HOSTNAME": settings.get("ANSIBLE_API_HOSTNAME"),
+            "ANSIBLE_CONTENT_HOSTNAME": settings.get("ANSIBLE_CONTENT_HOSTNAME"),
+        }
+        gw_url = urlparse(ANSIBLE_BASE_JWT_KEY)
+        if gw_url.scheme and gw_url.hostname:
+            for k in data:
+                k_parsed = urlparse(data[k])
+                if gw_url.scheme and gw_url.hostname:
+                    k_updated = k_parsed._replace(
+                        scheme=gw_url.scheme,
+                        netloc=gw_url.netloc,
+                    )
+                    data.update({k: urlunparse(k_updated)})
+            return data
+    return {}
 
 
 def validate(settings: Dynaconf) -> None:


### PR DESCRIPTION
Specifically in the case of downloading collections. 

Before:
```
$ ansible-galaxy collection download -p . awx.awx -s https://localhost/api/hub/content/community/ --api-key=<INSERT_KEY_HERE> --ignore-certs --no-cache
Process download dependency map
Starting collection download process to '/home/bmclaugh/Downloads/_tmp'
Downloading http://localhost:5001/api/hub/v3/plugin/ansible/content/community/collections/artifacts/awx-awx-24.0.0.tar.gz to /home/bmclaugh/.ansible/tmp/ansible-local-3030078ycyczlke/tmpzw38d1oq/awx-awx-24.0.0-if08m8a7
Downloading collection 'awx.awx:24.0.0' to '/home/bmclaugh/Downloads/'
ERROR! Failed to download collection tar from 'cmd_arg' due to the following unforeseen error: HTTP Error 404: Not Found. HTTP Error 404: Not Found
```

After:
```
$ ansible-galaxy collection download -p . awx.awx -s https://localhost/api/hub/content/community/ --api-key=<INSERT_KEY_HERE> --ignore-certs --no-cache
Process download dependency map
Starting collection download process to '/home/bmclaugh/Downloads'
Downloading https://localhost/api/hub/v3/plugin/ansible/content/community/collections/artifacts/awx-awx-24.0.0.tar.gz to /home/bmclaugh/.ansible/tmp/ansible-local-2970413jpwpnnso/tmpbpkvb8my/awx-awx-24.0.0-nb1v7e1z
Downloading collection 'awx.awx:24.0.0' to '/home/bmclaugh/Downloads'
Collection 'awx.awx:24.0.0' was downloaded successfully
Writing requirements.yml file of downloaded collections to '/home/bmclaugh/Downloads/requirements.yml'
```

AAP-20998
No-Issue
