### PR TITLE
api/v1/imports: change task.kwargs to enc_kwargs

### DIFF
--- a/galaxy_ng/app/api/v1/serializers.py
+++ b/galaxy_ng/app/api/v1/serializers.py
@@ -627,12 +627,13 @@ class LegacyImportListSerializer(serializers.Serializer):
         return state
 
     def get_summary_fields(self, obj):
+        kwargs = obj.task.enc_kwargs or {}
         return {
-            'request_username': obj.task.kwargs.get('request_username'),
-            'github_user': obj.task.kwargs.get('github_user'),
-            'github_repo': obj.task.kwargs.get('github_repo'),
-            'github_reference': obj.task.kwargs.get('github_reference'),
-            'alternate_role_name': obj.task.kwargs.get('alternate_role_name'),
+            'request_username': kwargs.get('request_username'),
+            'github_user': kwargs.get('github_user'),
+            'github_repo': kwargs.get('github_repo'),
+            'github_reference': kwargs.get('github_reference'),
+            'alternate_role_name': kwargs.get('alternate_role_name'),
         }
 
 
@@ -765,12 +766,13 @@ class LegacyRoleImportDetailSerializer(serializers.Serializer):
             }
             task_messages.append(msg)
 
+        kwargs = task.enc_kwargs or {}
         return {
-            'request_username': task.kwargs.get('request_username'),
-            'github_user': task.kwargs.get('github_user'),
-            'github_repo': task.kwargs.get('github_repo'),
-            'github_reference': task.kwargs.get('github_reference'),
-            'alternate_role_name': task.kwargs.get('alternate_role_name'),
+            'request_username': kwargs.get('request_username'),
+            'github_user': kwargs.get('github_user'),
+            'github_repo': kwargs.get('github_repo'),
+            'github_reference': kwargs.get('github_reference'),
+            'alternate_role_name': kwargs.get('alternate_role_name'),
             'task_messages': task_messages
         }
 


### PR DESCRIPTION
pulpcore changed Task kwargs to enc_kwargs, updating v1 serializers

(follows #2099)

Fixes:

```
pulp_1          | AttributeError: 'Task' object has no attribute 'kwargs'
pulp_1          | pulp [f8ef146e15464fab96da675ac0d5b750]: django.request:ERROR: Internal Server Error: /api/automation-hub/v1/imports/
pulp_1          | Traceback (most recent call last):
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
pulp_1          |     response = get_response(request)
pulp_1          |                ^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
pulp_1          |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
pulp_1          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
pulp_1          |     return view_func(*args, **kwargs)
pulp_1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/viewsets.py", line 125, in view
pulp_1          |     return self.dispatch(request, *args, **kwargs)
pulp_1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
pulp_1          |     response = self.handle_exception(exc)
pulp_1          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
pulp_1          |     self.raise_uncaught_exception(exc)
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
pulp_1          |     raise exc
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
pulp_1          |     response = handler(request, *args, **kwargs)
pulp_1          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/src/galaxy_ng/galaxy_ng/app/api/v1/viewsets/roles.py", line 250, in list
pulp_1          |     return super(LegacyRoleImportsViewSet, self).list(request, *args, **kwargs)
pulp_1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/mixins.py", line 43, in list
pulp_1          |     return self.get_paginated_response(serializer.data)
pulp_1          |                                        ^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 768, in data
pulp_1          |     ret = super().data
pulp_1          |           ^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 253, in data
pulp_1          |     self._data = self.to_representation(self.instance)
pulp_1          |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 686, in to_representation
pulp_1          |     return [
pulp_1          |            ^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 687, in <listcomp>
pulp_1          |     self.child.to_representation(item) for item in iterable
pulp_1          |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 522, in to_representation
pulp_1          |     ret[field.field_name] = field.to_representation(attribute)
pulp_1          |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp_1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/fields.py", line 1838, in to_representation
pulp_1          |     return method(value)
pulp_1          |            ^^^^^^^^^^^^^
pulp_1          |   File "/src/galaxy_ng/galaxy_ng/app/api/v1/serializers.py", line 769, in get_summary_fields
pulp_1          |     'request_username': task.kwargs.get('request_username'),
pulp_1          |                         ^^^^^^^^^^^
pulp_1          | AttributeError: 'Task' object has no attribute 'kwargs'
```

during `GET /api/v1/imports/`

(for some reason, despite https://github.com/pulp/pulpcore/blob/3.49/pulpcore/app/migrations/0114_remove_task_args_remove_task_kwargs.py running, `enc_kwargs` is `None` for previously created tasks, but new tasks work as expected)