### PR TITLE
Use new entrypoint cmd per guidance from Pulp team

### DIFF
--- a/docker/bin/start-api
+++ b/docker/bin/start-api
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 
 
-readonly GUNICORN=${GUNICORN:-'/venv/bin/gunicorn'}
+readonly ENTRYPOINT=${ENTRYPOINT:-'/venv/bin/pulpcore-api'}
 readonly GUNICORN_FORWARDED_ALLOW_IPS="${GUNICORN_FORWARDED_ALLOW_IPS:-}"
 readonly GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
 readonly GUNICORN_LOGGER_CLASS="${GUNICORN_LOGGER_CLASS:-}"
@@ -12,16 +12,17 @@ readonly GUNICORN_TIMEOUT="${GUNICORN_TIMEOUT:-60}"
 
 readonly BIND_HOST='0.0.0.0'
 readonly BIND_PORT=${GUNICORN_PORT:-8000}
-readonly APP_MODULE='pulpcore.app.wsgi:application'
 
 
 GUNICORN_OPTIONS=(
   --bind "${BIND_HOST}:${BIND_PORT}"
   --workers "${GUNICORN_WORKERS}"
   --access-logfile -
-  --limit-request-field_size 32768
   --timeout "${GUNICORN_TIMEOUT}"
 )
+
+# Note: add back the following option as soon as there is a fix for the pulpcore issue
+#   --limit-request-field-size 32768
 
 if [[ -n "${GUNICORN_FORWARDED_ALLOW_IPS}" ]]; then
     GUNICORN_OPTIONS+=(--forwarded-allow-ips "${GUNICORN_FORWARDED_ALLOW_IPS}")
@@ -31,4 +32,4 @@ if [[ -n "${GUNICORN_LOGGER_CLASS}" ]]; then
     GUNICORN_OPTIONS+=(--logger-class "${GUNICORN_LOGGER_CLASS}")
 fi
 
-exec "${GUNICORN}" "${GUNICORN_OPTIONS[@]}" "${APP_MODULE}"
+exec "${ENTRYPOINT}" "${GUNICORN_OPTIONS[@]}"

--- a/docker/bin/start-api-reload
+++ b/docker/bin/start-api-reload
@@ -5,13 +5,12 @@ set -o errexit
 set -o nounset
 
 
-readonly GUNICORN=${GUNICORN:-'/venv/bin/gunicorn'}
+readonly ENTRYPOINT=${ENTRYPOINT:-'/venv/bin/pulpcore-api'}
 readonly GUNICORN_WORKERS=${GUNICORN_WORKERS:-4}
 readonly GUNICORN_LOGGER_CLASS="${GUNICORN_LOGGER_CLASS:-}"
 
 readonly BIND_HOST='0.0.0.0'
 readonly BIND_PORT=8000
-readonly APP_MODULE='pulpcore.app.wsgi:application'
 
 GUNICORN_OPTIONS=(
   --bind "${BIND_HOST}:${BIND_PORT}"
@@ -27,4 +26,4 @@ if [[ -n "${GUNICORN_LOGGER_CLASS}" ]]; then
     GUNICORN_OPTIONS+=(--logger-class "${GUNICORN_LOGGER_CLASS}")
 fi
 
-exec "${GUNICORN}" "${GUNICORN_OPTIONS[@]}" "${APP_MODULE}"
+exec "${ENTRYPOINT}" "${GUNICORN_OPTIONS[@]}"

--- a/docker/bin/start-content-app
+++ b/docker/bin/start-content-app
@@ -3,17 +3,13 @@
 set -o errexit
 set -o nounset
 
-readonly GUNICORN=${GUNICORN:-'/venv/bin/gunicorn'}
+readonly ENTRYPOINT=${ENTRYPOINT:-'/venv/bin/pulpcore-content'}
 readonly GUNICORN_WORKERS=${GUNICORN_WORKERS:-4}
 
 readonly BIND_HOST='0.0.0.0'
 readonly BIND_PORT="${GUNICORN_PORT:-24816}"
-readonly WORKER_CLASS='aiohttp.GunicornWebWorker'
-readonly APP_MODULE='pulpcore.content:server'
 
-exec "${GUNICORN}" \
+exec "${ENTRYPOINT}" \
   --bind "${BIND_HOST}:${BIND_PORT}" \
-  --worker-class "${WORKER_CLASS}" \
   --workers "${GUNICORN_WORKERS}" \
-  --access-logfile - \
-  "${APP_MODULE}"
+  --access-logfile -


### PR DESCRIPTION
#### What is this PR doing:

In this pulpcore PR, the entrypoint for api and content containers as changed.

* https://github.com/pulp/pulpcore/pull/4249

In the changelog, they advise:

> Starting with this release, it is highly recommended to start the api and content processes by
the newly provided entrypoints (`pulpcore-api` and `pulpcore-content`) instead of calling
`gunicorn` directly.

I have removed the `--worker-class` flag as it is now handled automatically in the entrypoint script ([here](https://github.com/pulp/pulpcore/pull/4249/files#diff-f59f521cb004e091b299f33ba9750b5baf1247ad4c4017d5572d2fb6bfd0da5dR17)).

This PR is a best effort, as I don't know the galaxy_ng project as well.  Please feel free to close and replace with your own PR or request changes.  Thanks!

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
