### PR TITLE
Fix openapi client generation in the playbooks.

### DIFF
--- a/.github/workflows/ci_full.yml
+++ b/.github/workflows/ci_full.yml
@@ -89,13 +89,13 @@ jobs:
         run: pip3 install ansible
 
       - name: run the build container playbook
-        run: cd dev/playbooks; ansible-playbook -i 'localhost,' --forks=1 -v build_container.yaml
+        run: cd dev/playbooks; ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i 'localhost,' --forks=1 -v build_container.yaml
 
       - name: run the start container playbook
-        run: cd dev/playbooks; ansible-playbook -i 'localhost,' --forks=1 -v start_container.yaml
+        run: cd dev/playbooks; ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i 'localhost,' --forks=1 -v start_container.yaml
 
       - name: run the unit test playbook
-        run: cd dev/playbooks; ansible-playbook -i 'localhost,' --forks=1 -v run_unit_tests.yaml
+        run: cd dev/playbooks; ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i 'localhost,' --forks=1 -v run_unit_tests.yaml
 
       - name: run the functional test playbook
-        run: cd dev/playbooks; ansible-playbook -i 'localhost,' --forks=1 -v run_functional_tests.yaml
+        run: cd dev/playbooks; ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i 'localhost,' --forks=1 -v run_functional_tests.yaml

--- a/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/files/generate.sh
+++ b/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/files/generate.sh
@@ -12,7 +12,7 @@ fi
 cd pulp-openapi-generator;
 
 export USE_LOCAL_API_JSON=true;
-export PULP_URL='https://${PULP_IP}/api/galaxy/pulp/api/v3/';
+export PULP_URL="https://${PULP_IP}/api/galaxy/pulp/api/v3/";
 
 curl -L -k -u admin:password -o status.json "https://${PULP_IP}/api/galaxy/pulp/api/v3/status/";
 curl -L -k -u admin:password -o api.json "https://${PULP_IP}/api/galaxy/pulp/api/v3/docs/api.json?bindings&plugin=${PLUGIN}";

--- a/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/files/generate.sh
+++ b/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/files/generate.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -x
+
+set -e
+
+PULP_IP=$1
+PLUGIN=$2
+
+cd ../../..
+if [[ ! -d pulp-openapi-generator ]]; then
+    git clone https://github.com/pulp/pulp-openapi-generator
+fi
+cd pulp-openapi-generator;
+
+export USE_LOCAL_API_JSON=true;
+export PULP_URL='https://${PULP_IP}/api/galaxy/pulp/api/v3/';
+
+curl -L -k -u admin:password -o status.json "https://${PULP_IP}/api/galaxy/pulp/api/v3/status/";
+curl -L -k -u admin:password -o api.json "https://${PULP_IP}/api/galaxy/pulp/api/v3/docs/api.json?bindings&plugin=${PLUGIN}";
+
+if [ "${PLUGIN}" == "galaxy_ng" ]; then
+    cat status.json | head
+    export REPORTED_VERSION=$(jq '.versions[] | select (.component == "galaxy").version' status.json | tr -d '"')
+    echo "REPORTED_VERSION: ${REPORTED_VERSION}"
+    export VERSION="$(echo "$REPORTED_VERSION" | python -c 'from packaging.version import Version; print(Version(input()))')"
+    echo "FINAL_VERSION: ${FINAL_VERSION}"
+else
+    export VERSION=""
+fi;
+
+bash -x generate.sh ${PLUGIN} python ${VERSION}

--- a/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
+++ b/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
@@ -15,8 +15,16 @@
     command: >
        cd ../../../pulp-openapi-generator;
        export USE_LOCAL_API_JSON=true;
+       export PULP_URL='https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/';
+       curl -L -k -u admin:password -o status.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/status/';
        curl -L -k -u admin:password -o api.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/docs/api.json?bindings&plugin={{ item }}';
-       bash -x generate.sh {{ item }} python
+       if [[ "{{ item }}" == "galaxy_ng" ]]; then
+        export REPORTED_VERSION=$(jq '.versions[] | select (.component == "galaxy").version' status.json | tr -d '"')
+        export VERSION="$(echo "$REPORTED_VERSION" | python -c 'from packaging.version import Version; print(Version(input()))')"
+       else
+        export VERSION=""
+       fi;
+       bash -x generate.sh {{ item }} python $VERSION
   connection: local
   loop:
       - galaxy_ng
@@ -25,7 +33,8 @@
       - pulpcore
 
 - name: install the generated client inside the pulp container
-  shell: cd /src/pulp-openapi-generator/{{ item }}-client/; pip3 install -e .
+  #shell: cd /src/pulp-openapi-generator/{{ item }}-client/; pip3 install -e .
+  shell: cd /src/pulp-openapi-generator/{{ item }}-client/; pip3 install .
   loop:
       - galaxy_ng
       - pulp_ansible

--- a/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
+++ b/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
@@ -10,24 +10,41 @@
   connection: local
   register: pulp_ip
 
+#- name: run the generate script
+#  galaxy_ng.tools.local_run:
+#    command: >
+#       cd ../../../pulp-openapi-generator;
+#       export USE_LOCAL_API_JSON=true;
+#       export PULP_URL='https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/';
+#       curl -L -k -u admin:password -o status.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/status/';
+#       curl -L -k -u admin:password -o api.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/docs/api.json?bindings&plugin={{ item }}';
+#       if [ "{{ item }}" == "galaxy_ng" ]; then
+#        cat status.json | head
+#        export REPORTED_VERSION=$(jq '.versions[] | select (.component == "galaxy").version' status.json | tr -d '"')
+#        echo "REPORTED_VERSION: ${REPORTED_VERSION}"
+#        export VERSION="$(echo "$REPORTED_VERSION" | python -c 'from packaging.version import Version; print(Version(input()))')"
+#        echo "FINAL_VERSION: ${FINAL_VERSION}"
+#       else
+#        export VERSION=""
+#       fi;
+#       bash -x generate.sh {{ item }} python $VERSION
+#  connection: local
+#  loop:
+#      - galaxy_ng
+#      - pulp_ansible
+#      - pulp_container
+#      - pulpcore
+
+- name: copy the generate script to a tmp location
+  copy:
+    src: generate.sh
+    dest: /tmp/generate.sh
+    mode: '0777'
+  connection: local
+
 - name: run the generate script
   galaxy_ng.tools.local_run:
-    command: >
-       cd ../../../pulp-openapi-generator;
-       export USE_LOCAL_API_JSON=true;
-       export PULP_URL='https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/';
-       curl -L -k -u admin:password -o status.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/status/';
-       curl -L -k -u admin:password -o api.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/docs/api.json?bindings&plugin={{ item }}';
-       if [ "{{ item }}" == "galaxy_ng" ]; then
-        cat status.json | head
-        export REPORTED_VERSION=$(jq '.versions[] | select (.component == "galaxy").version' status.json | tr -d '"')
-        echo "REPORTED_VERSION: ${REPORTED_VERSION}"
-        export VERSION="$(echo "$REPORTED_VERSION" | python -c 'from packaging.version import Version; print(Version(input()))')"
-        echo "FINAL_VERSION: ${FINAL_VERSION}"
-       else
-        export VERSION=""
-       fi;
-       bash -x generate.sh {{ item }} python $VERSION
+    command: /tmp/generate.sh {{ pulp_ip.stdout }} {{ item }} 
   connection: local
   loop:
       - galaxy_ng

--- a/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
+++ b/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
@@ -19,8 +19,11 @@
        curl -L -k -u admin:password -o status.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/status/';
        curl -L -k -u admin:password -o api.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/docs/api.json?bindings&plugin={{ item }}';
        if [[ "{{ item }}" == "galaxy_ng" ]]; then
+        cat status.json | head
         export REPORTED_VERSION=$(jq '.versions[] | select (.component == "galaxy").version' status.json | tr -d '"')
+        echo "REPORTED_VERSION: ${REPORTED_VERSION}"
         export VERSION="$(echo "$REPORTED_VERSION" | python -c 'from packaging.version import Version; print(Version(input()))')"
+        echo "FINAL_VERSION: ${FINAL_VERSION}"
        else
         export VERSION=""
        fi;
@@ -33,8 +36,7 @@
       - pulpcore
 
 - name: install the generated client inside the pulp container
-  #shell: cd /src/pulp-openapi-generator/{{ item }}-client/; pip3 install -e .
-  shell: cd /src/pulp-openapi-generator/{{ item }}-client/; pip3 install .
+  shell: cd /src/pulp-openapi-generator/{{ item }}-client/; pip3 install -e .
   loop:
       - galaxy_ng
       - pulp_ansible

--- a/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
+++ b/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
@@ -18,7 +18,7 @@
        export PULP_URL='https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/';
        curl -L -k -u admin:password -o status.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/status/';
        curl -L -k -u admin:password -o api.json 'https://{{ pulp_ip.stdout }}/api/galaxy/pulp/api/v3/docs/api.json?bindings&plugin={{ item }}';
-       if [[ "{{ item }}" == "galaxy_ng" ]]; then
+       if [ "{{ item }}" == "galaxy_ng" ]; then
         cat status.json | head
         export REPORTED_VERSION=$(jq '.versions[] | select (.component == "galaxy").version' status.json | tr -d '"')
         echo "REPORTED_VERSION: ${REPORTED_VERSION}"

--- a/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
+++ b/dev/playbooks/collections/ansible_collections/galaxy_ng/tools/roles/pulp_client/tasks/main.yml
@@ -53,9 +53,12 @@
       - pulpcore
 
 - name: install the generated client inside the pulp container
-  shell: cd /src/pulp-openapi-generator/{{ item }}-client/; pip3 install -e .
+  shell: cd /src/pulp-openapi-generator/{{ item }}-client/; pip3 install .
   loop:
       - galaxy_ng
       - pulp_ansible
       - pulp_container
       - pulpcore
+
+- name: show what we eneded up with
+  shell: pip3 list | grep -e galaxy -e pulp -e ansible


### PR DESCRIPTION
Functional tests were failing because the VERSION string for the generated clients was an empty string which in turn causes pip to fail the install.