### PR TITLE
edit logo test: add a sleep after the initial namespace create.

### DIFF
--- a/galaxy_ng/tests/integration/api/test_namespace_management.py
+++ b/galaxy_ng/tests/integration/api/test_namespace_management.py
@@ -154,6 +154,8 @@ def test_namespace_edit_logo(galaxy_client):
     }
     my_namespace = gc.post("_ui/v1/my-namespaces/", body=payload)
     assert my_namespace["avatar_url"] == ''
+    sleep(60)
+    wait_for_all_tasks_gk(gc)
 
     namespaces = gc.get('_ui/v1/my-namespaces/')
     name = my_namespace["name"]


### PR DESCRIPTION
The initial create fires off multiple async but the test isn't waiting for all of them to finish before moving on with altering the namespace.