### PR TITLE
Fix traceback on user serializer with accessing social auth table.

### DIFF
--- a/galaxy_ng/app/api/ui/serializers/user.py
+++ b/galaxy_ng/app/api/ui/serializers/user.py
@@ -44,7 +44,9 @@ class UserSerializer(serializers.ModelSerializer):
         }
 
     def get_auth_provider(self, user):
-        if hasattr(user, 'social_auth') and user.social_auth.all():
+        if hasattr(user, 'social_auth') \
+                and 'social_django' in settings.INSTALLED_APPS \
+                and user.social_auth.all():
             providers = []
             for social in user.social_auth.all():
                 providers.append(social.provider)

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -64,6 +64,10 @@ def configure_dab_resource_registry(settings: Dynaconf) -> Dict[str, Any]:
         data["INSTALLED_APPS"] = ['ansible_base.resource_registry', 'dynaconf_merge']
         data["ANSIBLE_BASE_RESOURCE_CONFIG_MODULE"] = "galaxy_ng.app.api.resource_api"
 
+        # this always needs social_django installed ...
+        if "social_django" not in settings.INSTALLED_APPS:
+            data["INSTALLED_APPS"].append("social_django")
+
     return data
 
 


### PR DESCRIPTION
When the DAB resource registry is enabled and the oci profile doesn't actually "install" social-core, this traceback is thrown ...

```
pulp-1          | Traceback (most recent call last):
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
pulp-1          |     response = get_response(request)
pulp-1          |                ^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
pulp-1          |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
pulp-1          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
pulp-1          |     return view_func(*args, **kwargs)
pulp-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/viewsets.py", line 125, in view
pulp-1          |     return self.dispatch(request, *args, **kwargs)
pulp-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
pulp-1          |     response = self.handle_exception(exc)
pulp-1          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
pulp-1          |     self.raise_uncaught_exception(exc)
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
pulp-1          |     raise exc
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
pulp-1          |     response = handler(request, *args, **kwargs)
pulp-1          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/mixins.py", line 56, in retrieve
pulp-1          |     return Response(serializer.data)
pulp-1          |                     ^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 555, in data
pulp-1          |     ret = super().data
pulp-1          |           ^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 253, in data
pulp-1          |     self._data = self.to_representation(self.instance)
pulp-1          |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/user.py", line 134, in to_representation
pulp-1          |     representation = super().to_representation(instance)
pulp-1          |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 522, in to_representation
pulp-1          |     ret[field.field_name] = field.to_representation(attribute)
pulp-1          |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/rest_framework/fields.py", line 1838, in to_representation
pulp-1          |     return method(value)
pulp-1          |            ^^^^^^^^^^^^^
pulp-1          |   File "/src/galaxy_ng/galaxy_ng/app/api/ui/serializers/user.py", line 47, in get_auth_provider
pulp-1          |     if hasattr(user, 'social_auth') and user.social_auth.all():
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 412, in __bool__
pulp-1          |     self._fetch_all()
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 1881, in _fetch_all
pulp-1          |     self._result_cache = list(self._iterable_class(self))
pulp-1          |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 91, in __iter__
pulp-1          |     results = compiler.execute_sql(
pulp-1          |               ^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1562, in execute_sql
pulp-1          |     cursor.execute(sql, params)
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 102, in execute
pulp-1          |     return super().execute(sql, params)
pulp-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 67, in execute
pulp-1          |     return self._execute_with_wrappers(
pulp-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
pulp-1          |     return executor(sql, params, many, context)
pulp-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 84, in _execute
pulp-1          |     with self.db.wrap_database_errors:
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
pulp-1          |     raise dj_exc_value.with_traceback(traceback) from exc_value
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 89, in _execute
pulp-1          |     return self.cursor.execute(sql, params)
pulp-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pulp-1          |   File "/usr/local/lib/python3.11/site-packages/psycopg/cursor.py", line 732, in execute
pulp-1          |     raise ex.with_traceback(None)
pulp-1          | django.db.utils.ProgrammingError: relation "social_auth_usersocialauth" does not exist
pulp-1          | LINE 1: ...ed", "social_auth_usersocialauth"."modified" FROM "social_au...
pulp-1          |                                                              ^
pulp-1          | ('pulp [56d724dcde884ac7b22d48ef03558f32]: ::ffff:127.0.0.1 - admin [08/Apr/2024:18:06:03 +0000] "GET /api/galaxy/_ui/v1/me/ HTTP/1.0" 500 222348 "-" "curl/8.0.1"',)
```