### PR TITLE
Fix test_artifact_upload.py::test_ansible_lint_exception_AAH_2606

### DIFF
--- a/galaxy_ng/tests/integration/api/test_artifact_upload.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_upload.py
@@ -382,7 +382,6 @@ def test_ansible_lint_exception(galaxy_client, hub_version):
 @pytest.mark.stage_health
 @pytest.mark.importer
 @pytest.mark.all
-@pytest.mark.skip(reason="needs refactoring for new lint version")
 def test_ansible_lint_exception_AAH_2606(galaxy_client, hub_version):
     """
     https://issues.redhat.com/browse/AAH-2609

--- a/galaxy_ng/tests/integration/api/test_artifact_upload.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_upload.py
@@ -402,11 +402,6 @@ def test_ansible_lint_exception_AAH_2606(galaxy_client, hub_version):
             "meta/runtime.yml:1: yaml[new-line-at-end-of-file]:"
             + " No new line character at the end of file"
         ),
-        (
-            "tests/sanity/ignore-2.10.txt:1: sanity[cannot-ignore]:"
-            + " Ignore file contains validate-modules:use-run-command-not-popen at line 1,"
-            + " which is not a permitted ignore."
-        )
     ]
 
     artifact = bc(


### PR DESCRIPTION
ansible-lint no longer returns a warning on one of the warnings being tested against.

No-Issue
