### PR TITLE
Use the upstream x-forwarded-proto header if possible.

### DIFF
--- a/galaxy_ng/app/webserver_snippets/nginx.conf
+++ b/galaxy_ng/app/webserver_snippets/nginx.conf
@@ -11,7 +11,7 @@ location /ui/ {
 
 location /api/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $x_forwarded_proto_header;
     proxy_set_header Host $http_host;
     # we don't want nginx trying to do something clever with
     # redirects, we set the Host: header above already.

--- a/profiles/base/nginx/nginx.conf.j2
+++ b/profiles/base/nginx/nginx.conf.j2
@@ -29,6 +29,11 @@ http {
          server 127.0.0.1:24817;
     }
 
+    map $http_x_forwarded_proto $x_forwarded_proto_header {
+        default $http_x_forwarded_proto;
+        ""      $scheme;  # If the header is empty or not present, use the current scheme
+    }
+
     server {
         # Gunicorn docs suggest the use of the "deferred" directive on Linux.
         {% if https | default(false) -%}


### PR DESCRIPTION
This will allow us to determine the true proto + host + port the client called into.