### PR TITLE
remove prefix substitution

### DIFF
--- a/galaxy_ng/tests/integration/api/test_collection_delete.py
+++ b/galaxy_ng/tests/integration/api/test_collection_delete.py
@@ -11,7 +11,7 @@ from ..utils import (
     get_all_collections_by_repo,
     get_all_repository_collection_versions,
 )
-from ..utils.iqe_utils import is_stage_environment, fix_prefix_workaround
+from ..utils.iqe_utils import is_stage_environment
 
 pytestmark = pytest.mark.qa  # noqa: F821
 
@@ -71,8 +71,6 @@ def test_delete_collection_version(galaxy_client, uncertifiedv2):
                 matches.append(k)
         for rcv in matches:
             rcv_url = cv_before[rcv]['href']
-            # workaround
-            rcv_url = fix_prefix_workaround(rcv_url)
             resp = gc.delete(rcv_url)
             wait_for_task(gc, resp, timeout=10000)
 
@@ -119,8 +117,6 @@ def test_delete_default_repos(galaxy_client, uncertifiedv2):
         assert distro["repository"] is not None
 
         try:
-            # workaround
-            distro["pulp_href"] = fix_prefix_workaround(distro["pulp_href"])
             gc.delete(distro["pulp_href"])
             # This API call should fail
             assert False
@@ -128,8 +124,6 @@ def test_delete_default_repos(galaxy_client, uncertifiedv2):
             assert ge.response.status_code == 403
 
         try:
-            # workaround
-            distro["repository"] = fix_prefix_workaround(distro["repository"])
             gc.delete(distro["repository"])
             # This API call should fail
             assert False

--- a/galaxy_ng/tests/integration/api/test_container_delete.py
+++ b/galaxy_ng/tests/integration/api/test_container_delete.py
@@ -5,7 +5,7 @@ import pytest
 from galaxykit.containers import get_container_distribution, delete_container
 from galaxykit.utils import wait_for_task, GalaxyClientError
 
-from ..utils.iqe_utils import pull_and_tag_test_image, fix_prefix_workaround
+from ..utils.iqe_utils import pull_and_tag_test_image
 
 
 # this is to be enabled when https://github.com/ansible/galaxy_ng/pull/1627
@@ -44,8 +44,6 @@ def test_delete_ee_and_content(ansible_config, galaxy_client):
     assert distro_response["results"][0]["base_path"] == 'alpine'
 
     # Grab the repository href from the json and make get request
-    distro_response["results"][0]["repository"] = (
-        fix_prefix_workaround(distro_response["results"][0]["repository"]))
     repo_response = gc.get(distro_response["results"][0]["repository"])
 
     # Grab <latest_version_href> field from this Container Push Repo Instance
@@ -68,7 +66,6 @@ def test_delete_ee_and_content(ansible_config, galaxy_client):
     for item in content_hrefs:
         failed = None
         try:
-            item = fix_prefix_workaround(item)
             gc.get(item)
             failed = False
         except GalaxyClientError as ge:
@@ -118,11 +115,6 @@ def test_shared_content_is_not_deleted(ansible_config, galaxy_client):
     assert distro_response2["results"][0]["base_path"] == 'alpine2'
 
     # Grab the repository href from the json and make get request
-    distro_response1["results"][0]["repository"] = (
-        fix_prefix_workaround(distro_response1["results"][0]["repository"]))
-    distro_response2["results"][0]["repository"] = (
-        fix_prefix_workaround(distro_response2["results"][0]["repository"]))
-
     repo_response_1 = gc.get(distro_response1["results"][0]["repository"])
     repo_response_2 = gc.get(distro_response2["results"][0]["repository"])
 
@@ -150,7 +142,6 @@ def test_shared_content_is_not_deleted(ansible_config, galaxy_client):
     for item in content_hrefs:
         success = None
         try:
-            item = fix_prefix_workaround(item)
             gc.get(item)
             success = True
         except GalaxyClientError as ge:

--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -13,7 +13,7 @@ from galaxykit.utils import wait_for_task, wait_for_url
 from ..conftest import is_hub_4_5
 from ..constants import USERNAME_PUBLISHER
 from ..utils import set_certification
-from ..utils.iqe_utils import is_ocp_env, fix_prefix_workaround
+from ..utils.iqe_utils import is_ocp_env
 
 pytestmark = pytest.mark.qa  # noqa: F821
 
@@ -36,7 +36,6 @@ def test_move_collection_version(ansible_config, galaxy_client):
         for repo in collections.keys():
             next_page = f'_ui/v1/collection-versions/?repository={repo}'
             while next_page:
-                next_page = fix_prefix_workaround(next_page)
                 resp = gc_admin.get(next_page)
                 for _collection in resp['data']:
                     key = (_collection['namespace'], _collection['name'], _collection['version'])
@@ -119,7 +118,6 @@ def test_copy_collection_version(ansible_config, galaxy_client):
         for repo in collections.keys():
             next_page = f'_ui/v1/collection-versions/?repository={repo}'
             while next_page:
-                next_page = fix_prefix_workaround(next_page)
                 resp = gc_admin.get(next_page)
                 for _collection in resp['data']:
                     key = (_collection['namespace'], _collection['name'], _collection['version'])

--- a/galaxy_ng/tests/integration/api/test_namespace_management.py
+++ b/galaxy_ng/tests/integration/api/test_namespace_management.py
@@ -11,7 +11,7 @@ from galaxykit.namespaces import get_namespace, get_namespace_collections
 from galaxykit.repositories import search_collection
 from galaxykit.users import get_me
 
-from ..utils.iqe_utils import is_stage_environment, fix_prefix_workaround
+from ..utils.iqe_utils import is_stage_environment
 from ..utils.repo_management_utils import upload_new_artifact
 from ..utils.tasks import wait_for_all_tasks_gk, wait_for_namespace_tasks_gk
 from ..utils.tools import generate_random_string
@@ -189,10 +189,6 @@ def test_namespace_edit_logo(galaxy_client):
     # verify no side effects
     # fields that should NOT change
     for field in ["pulp_href", "name", "company", "email", "description", "resources", "links"]:
-        # FIXME
-        if field == "pulp_href":
-            updated_again_namespace[field] = (
-                fix_prefix_workaround(updated_again_namespace[field]))
         assert my_namespace[field] == updated_again_namespace[field]
 
     # fields that changed

--- a/galaxy_ng/tests/integration/api/test_private_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_private_repositories.py
@@ -2,7 +2,6 @@ import pytest
 
 from galaxykit.utils import wait_for_task
 from ..utils import uuid4
-from ..utils.iqe_utils import fix_prefix_workaround
 
 
 @pytest.fixture
@@ -36,8 +35,6 @@ def distro_factory(galaxy_client):
             }
         )
         task_results = wait_for_task(gc, distro_task)
-        task_results['created_resources'][0] = (
-            fix_prefix_workaround(task_results['created_resources'][0]))
         return gc.get(task_results['created_resources'][0])
 
     return _distro_factory

--- a/galaxy_ng/tests/integration/api/test_remote_sync.py
+++ b/galaxy_ng/tests/integration/api/test_remote_sync.py
@@ -8,7 +8,6 @@ from ..schemas import (
     schema_objectlist,
     schema_task,
 )
-from ..utils.iqe_utils import fix_prefix_workaround
 
 REQUIREMENTS_FILE = "collections:\n  - name: newswangerd.collection_demo\n    version: 1.0.11"
 
@@ -76,7 +75,6 @@ def test_api_ui_v1_remote_sync(galaxy_client):
 def test_sync_community_with_no_requirements_file(galaxy_client):
     gc = galaxy_client("admin")
     remote = gc.get("pulp/api/v3/remotes/ansible/collection/?name=community")["results"][0]
-    remote["pulp_href"] = fix_prefix_workaround(remote["pulp_href"])
     resp = gc.patch(
         remote["pulp_href"],
         body={
@@ -87,7 +85,6 @@ def test_sync_community_with_no_requirements_file(galaxy_client):
     wait_for_task(gc, resp)
 
     repo = gc.get("pulp/api/v3/repositories/ansible/ansible/?name=community")["results"][0]
-    repo["pulp_href"] = fix_prefix_workaround(repo["pulp_href"])
     try:
         gc.post(f'{repo["pulp_href"]}sync/', body={})
         # This API call should fail

--- a/galaxy_ng/tests/integration/api/test_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_repositories.py
@@ -2,7 +2,7 @@ import pytest
 import logging
 import time
 
-from galaxy_ng.tests.integration.utils.iqe_utils import is_ocp_env, fix_prefix_workaround
+from galaxy_ng.tests.integration.utils.iqe_utils import is_ocp_env
 from galaxy_ng.tests.integration.utils.rbac_utils import upload_test_artifact
 
 from galaxy_ng.tests.integration.utils.repo_management_utils import (
@@ -108,8 +108,6 @@ class TestRepositories:
         collection_resp = gc_admin.get(
             f"pulp/api/v3/content/ansible/collection_versions/?name={artifact.name}"
         )
-        collection_resp["results"][0]["pulp_href"] = fix_prefix_workaround(
-            collection_resp["results"][0]["pulp_href"])
         content_units = [collection_resp["results"][0]["pulp_href"]]
         add_content_units(gc_admin, content_units, repo_pulp_href_1)
 

--- a/galaxy_ng/tests/integration/api/test_x_repo_search.py
+++ b/galaxy_ng/tests/integration/api/test_x_repo_search.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from galaxy_ng.tests.integration.utils.iqe_utils import is_ocp_env, fix_prefix_workaround
+from galaxy_ng.tests.integration.utils.iqe_utils import is_ocp_env
 from galaxy_ng.tests.integration.utils.rbac_utils import add_new_user_to_new_group
 
 from galaxy_ng.tests.integration.utils.repo_management_utils import (
@@ -577,11 +577,6 @@ class TestXRepoSearch:
         collection_resp_2 = gc.get(
             f"pulp/api/v3/content/ansible/collection_versions/?name={artifact_2.name}"
         )
-
-        collection_resp_1["results"][0]["pulp_href"] = fix_prefix_workaround(
-            collection_resp_1["results"][0]["pulp_href"])
-        collection_resp_2["results"][0]["pulp_href"] = fix_prefix_workaround(
-            collection_resp_2["results"][0]["pulp_href"])
         content_units = [
             collection_resp_1["results"][0]["pulp_href"],
             collection_resp_2["results"][0]["pulp_href"],

--- a/galaxy_ng/tests/integration/utils/collections.py
+++ b/galaxy_ng/tests/integration/utils/collections.py
@@ -27,7 +27,7 @@ from .tasks import wait_for_task as gng_wait_for_task
 from galaxykit.utils import wait_for_url, wait_for_task, GalaxyClientError
 
 from .tools import iterate_all, iterate_all_gk
-from .iqe_utils import get_ansible_config, get_galaxy_client, fix_prefix_workaround
+from .iqe_utils import get_ansible_config, get_galaxy_client
 
 try:
     import importlib.resources as pkg_resources
@@ -532,8 +532,6 @@ def get_all_collections_by_repo(gc):
     for repo in collections.keys():
         next_page = f'{gc.galaxy_root}_ui/v1/collection-versions/?repository={repo}'
         while next_page:
-            # workaround
-            next_page = fix_prefix_workaround(next_page)
             resp = gc.get(next_page)
             for _collection in resp['data']:
                 key = (
@@ -563,8 +561,6 @@ def get_all_repository_collection_versions(gc):
         next_page = (f'{gc.galaxy_root}content/{repo}/'
                      f'v3/plugin/ansible/content/{repo}/collections/index/')
         while next_page:
-            # workaround
-            next_page = fix_prefix_workaround(next_page)
             resp = gc.get(next_page)
             collections.extend(resp['data'])
             next_page = resp.get('links', {}).get('next')
@@ -573,7 +569,6 @@ def get_all_repository_collection_versions(gc):
     for collection in collections:
         next_page = collection['versions_url']
         while next_page:
-            next_page = fix_prefix_workaround(next_page)
             resp = gc.get(next_page)
             for cv in resp['data']:
                 cv['namespace'] = collection['namespace']

--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -744,13 +744,6 @@ def galaxy_auto_sign_collections():
     return settings.get("GALAXY_AUTO_SIGN_COLLECTIONS")
 
 
-def fix_prefix_workaround(url):
-    if aap_gateway():
-        return url.replace("/api/galaxy/", "/api/hub/")
-    else:
-        return url
-
-
 def get_paginated(client, relative_url: str = None) -> list:
     """Iterate through all results in a paginated queryset"""
     ds = client.get(relative_url)
@@ -764,7 +757,6 @@ def get_paginated(client, relative_url: str = None) -> list:
 
     next_url = ds['links']['next']
     while next_url:
-        next_url = fix_prefix_workaround(next_url)
         _ds = client.get(next_url)
 
         results.extend(_ds[key])

--- a/galaxy_ng/tests/integration/utils/namespaces.py
+++ b/galaxy_ng/tests/integration/utils/namespaces.py
@@ -6,7 +6,6 @@ import string
 
 from .collections import delete_all_collections_in_namespace, \
     delete_all_collections_in_namespace_gk
-from .iqe_utils import fix_prefix_workaround
 
 logger = logging.getLogger(__name__)
 
@@ -52,8 +51,6 @@ def get_all_namespaces(gc=None, api_version='v3'):
     namespaces = []
     next_page = f'{api_version}/namespaces/'
     while next_page:
-        # workaround
-        next_page = fix_prefix_workaround(next_page)
         resp = gc.get(next_page)
         namespaces.extend(resp['data'])
         next_page = resp.get('links', {}).get('next')

--- a/galaxy_ng/tests/integration/utils/tools.py
+++ b/galaxy_ng/tests/integration/utils/tools.py
@@ -6,8 +6,6 @@ from random import randint
 import random
 import string
 
-from galaxy_ng.tests.integration.utils.iqe_utils import fix_prefix_workaround
-
 
 def is_docker_installed():
     return shutil.which("docker") is not None
@@ -28,10 +26,8 @@ def iterate_all(api_client, url, gc=None):
     key = "data"
     while next is not None:
         if gc:
-            next = fix_prefix_workaround(next)
             r = gc.get(next)
         else:
-            next = fix_prefix_workaround(next)
             r = api_client(next)
         # pulp uses "results"
         if "data" not in r:


### PR DESCRIPTION
until now there have been two prefixes /api/hub and /api/galaxy. That's why the tests needed to implement a method to make everything homogeneous. Now this is not needed anymore since /api/galaxy prefix is defined everywhere
