### PR TITLE
Use a more recent version of ansible-core in testing.

### DIFF
--- a/galaxy_ng/tests/integration/community/test_role_import_exceptions.py
+++ b/galaxy_ng/tests/integration/community/test_role_import_exceptions.py
@@ -62,9 +62,8 @@ def test_role_import_exceptions(ansible_config):
         check_retcode=False
     )
 
-    # core always exits zero...
-    # https://github.com/ansible/ansible/issues/82175
-    assert import_pid.returncode == 0
+    # should have exited non-zero ...
+    assert import_pid.returncode == 1
 
     stdout = import_pid.stdout.decode('utf-8')
     assert 'Traceback (most recent call last):' in stdout

--- a/integration_requirements.txt
+++ b/integration_requirements.txt
@@ -1,7 +1,7 @@
 epdb
 requests
 # pulp requires compatibility with python 3.8
-ansible-core<2.13.0
+ansible-core<2.17.0
 pytest
 orionutils
 openapi-spec-validator


### PR DESCRIPTION
AAP 2.5 is going to ship with core 2.16.x ... so it's probably long past due that we test with >2.12