### PR TITLE
Rename local RESOURCE_MANAGEMENT settings flag

### DIFF
--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -573,8 +573,8 @@ class AccessPolicyBase(AccessPolicyFromDB):
                 })
         return True
 
-    def is_direct_shared_resource_management_disabled(self, request, view, action):
-        return not settings.DIRECT_SHARED_RESOURCE_MANAGEMENT_ENABLED
+    def is_local_resource_management_disabled(self, request, view, action):
+        return not settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT
 
     def user_is_superuser(self, request, view, action):
         if getattr(self, "swagger_fake_view", False):

--- a/galaxy_ng/app/access_control/statements/pulp.py
+++ b/galaxy_ng/app/access_control/statements/pulp.py
@@ -589,7 +589,7 @@ PULP_CORE_VIEWSETS = {
             "action": ["create", "destroy"],
             "principal": "*",
             "effect": "deny",
-            "condition": "is_direct_shared_resource_management_disabled"
+            "condition": "is_local_resource_management_disabled"
         },
     ]},
     "users": {"statements": _user_statements},

--- a/galaxy_ng/app/access_control/statements/standalone.py
+++ b/galaxy_ng/app/access_control/statements/standalone.py
@@ -113,7 +113,7 @@ _group_statements = _group_role_statements + [
         "action": ["create", "destroy", "update", "partial_update"],
         "principal": "*",
         "effect": "deny",
-        "condition": "is_direct_shared_resource_management_disabled"
+        "condition": "is_local_resource_management_disabled"
     },
 ]
 
@@ -164,7 +164,7 @@ _user_statements = [
         "action": ["create", "destroy", "update", "partial_update"],
         "principal": "*",
         "effect": "deny",
-        "condition": "is_direct_shared_resource_management_disabled"
+        "condition": "is_local_resource_management_disabled"
     },
 ]
 _deny_all = [
@@ -270,7 +270,7 @@ STANDALONE_STATEMENTS = {
             "action": ["create", "destroy", "update", "partial_update"],
             "principal": "*",
             "effect": "deny",
-            "condition": "is_direct_shared_resource_management_disabled"
+            "condition": "is_local_resource_management_disabled"
         },
     ],
     #  disable synclists for on prem installations

--- a/galaxy_ng/app/api/ui/serializers/user.py
+++ b/galaxy_ng/app/api/ui/serializers/user.py
@@ -175,7 +175,7 @@ class CurrentUserSerializer(UserSerializer):
     @extend_schema_field(OpenApiTypes.OBJECT)
     def get_model_permissions(self, obj):
         permissions = {}
-        allow_group_user_edits = settings.get("DIRECT_SHARED_RESOURCE_MANAGEMENT_ENABLED", True)
+        allow_group_user_edits = settings.get("ALLOW_LOCAL_RESOURCE_MANAGEMENT", True)
         for i, j in PERMISSIONS.items():
             permissions[i] = j
             permissions[i]["has_model_permission"] = obj.has_perm(i)

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -310,4 +310,4 @@ ANSIBLE_BASE_JWT_KEY = "https://localhost"
 DEFAULT_ORGANIZATION_NAME = "Default"
 
 # Disables editing and managing users and groups.
-DIRECT_SHARED_RESOURCE_MANAGEMENT_ENABLED = True
+ALLOW_LOCAL_RESOURCE_MANAGEMENT = True

--- a/profiles/dab/pulp_config.env
+++ b/profiles/dab/pulp_config.env
@@ -21,4 +21,4 @@ PULP_GALAXY_CONTAINER_SIGNING_SERVICE=container-default
 PULP_DYNACONF_AFTER_GET_HOOKS=["read_settings_from_cache_or_db", "alter_hostname_settings"]
 
 # disable user/group modifications
-PULP_DIRECT_SHARED_RESOURCE_MANAGEMENT_ENABLED=false
+PULP_ALLOW_LOCAL_RESOURCE_MANAGEMENT=false

--- a/profiles/dab_jwt/pulp_config.env
+++ b/profiles/dab_jwt/pulp_config.env
@@ -21,4 +21,4 @@ PULP_GALAXY_CONTAINER_SIGNING_SERVICE=container-default
 PULP_DYNACONF_AFTER_GET_HOOKS=["read_settings_from_cache_or_db", "alter_hostname_settings"]
 
 # disable user/group modifications
-PULP_DIRECT_SHARED_RESOURCE_MANAGEMENT_ENABLED=false
+PULP_ALLOW_LOCAL_RESOURCE_MANAGEMENT=false


### PR DESCRIPTION
No-Issue

The name `DIRECT_SHARED_RESOURCE_MANAGEMENT_ENABLED` was considered confusing, so renamed to `ALLOW_LOCAL_RESOURCE_MANAGEMENT`

realted to https://github.com/ansible/django-ansible-base/pull/456