### PR TITLE
Schedule Sync on Container Entrypoint + Better logs

### DIFF
--- a/galaxy_ng/app/tasks/resource_sync.py
+++ b/galaxy_ng/app/tasks/resource_sync.py
@@ -1,9 +1,22 @@
-from pprint import pprint
+import logging
+from django.conf import settings
+from ansible_base.resource_registry.tasks.sync import SyncExecutor
+
+logger = logging.getLogger(__name__)
 
 
 def run():  # pragma: no cover
     """Start DAB Resource Sync"""
-    from ansible_base.resource_registry.tasks.sync import SyncExecutor
+    if not settings.get("RESOURCE_SERVER"):
+        logger.debug(
+            "Skipping periodic resource_sync, RESOURCE_SERVER not configured"
+        )
+        return
+
     executor = SyncExecutor(retries=3)
     executor.run()
-    pprint(executor.results)
+    for status, resources in executor.results.items():
+        for resource in resources:
+            # prints `updated: {......}`
+            logger.info("%s: %s", status, resource)
+    logger.info("Resource Sync Finished")

--- a/profiles/base/init.sh
+++ b/profiles/base/init.sh
@@ -109,6 +109,15 @@ download_ui() {
     echo "yes" | django-admin collectstatic
 }
 
+schedule_resource_sync_task() {
+    if dynaconf get RESOURCE_SERVER__URL >/dev/null 2>&1; then
+        log_message "Scheduling Resource Sync Task to execute every 15 minutes"
+        django-admin task-scheduler --id dab_sync --interval 15 --path "galaxy_ng.app.tasks.resource_sync.run" || true
+    else
+        log_message "Resource Server is not enabled, skipping sync scheduling"
+    fi
+}
+
 # set_up_test_data() {
 #     cd /src/galaxy_ng
 #     # make docker/loaddata
@@ -140,3 +149,5 @@ fi
 # if [[ "$SETUP_TEST_DATA" -eq "1" ]]; then
 #     set_up_test_data
 # fi
+
+schedule_resource_sync_task


### PR DESCRIPTION
Added a call to 
```bash
django-admin task-scheduler --id dab_sync --interval 15 --path "galaxy_ng.app.tasks.resource_sync.run"
```
on container entrypoint.sh, so the schedule is added on dev environment and also on all the container builds without the need for operators to call it.


No-Issue
