### PR TITLE
Remove the JWT hook that overrides hostname and content origin.

### DIFF
--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -56,7 +56,6 @@ def post(settings: Dynaconf) -> Dict[str, Any]:
     data.update(configure_api_base_path(settings))
     data.update(configure_legacy_roles(settings))
     data.update(configure_dab_required_settings(settings))
-    data.update(configure_resource_provider(settings))
 
     # This should go last, and it needs to receive the data from the previous configuration
     # functions because this function configures the rest framework auth classes based off
@@ -580,30 +579,6 @@ def configure_legacy_roles(settings: Dynaconf) -> Dict[str, Any]:
     legacy_roles = settings.get("GALAXY_ENABLE_LEGACY_ROLES", False)
     data["GALAXY_FEATURE_FLAGS__legacy_roles"] = legacy_roles
     return data
-
-
-def configure_resource_provider(settings: Dynaconf) -> Dict[str, Any]:
-    # The following variable is either a URL or a key file path.
-    ANSIBLE_BASE_JWT_KEY = settings.get("ANSIBLE_BASE_JWT_KEY")
-    if ANSIBLE_BASE_JWT_KEY is None:
-        return {}
-
-    data = {
-        "ANSIBLE_API_HOSTNAME": settings.get("ANSIBLE_API_HOSTNAME", ""),
-        "ANSIBLE_CONTENT_HOSTNAME": settings.get("ANSIBLE_CONTENT_HOSTNAME", ""),
-    }
-    gw_url = urlparse(ANSIBLE_BASE_JWT_KEY)
-    if gw_url.scheme and gw_url.hostname:
-        for k in data:
-            k_parsed = urlparse(data[k])
-            if gw_url.scheme and gw_url.hostname:
-                k_updated = k_parsed._replace(
-                    scheme=gw_url.scheme,
-                    netloc=gw_url.netloc,
-                )
-                data.update({k: urlunparse(k_updated)})
-        return data
-    return {}
 
 
 def validate(settings: Dynaconf) -> None:

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -18,7 +18,6 @@ import pkg_resources
 import os
 import re
 from typing import Any, Dict, List
-from urllib.parse import urlparse, urlunparse
 from django_auth_ldap.config import LDAPSearch
 from dynaconf import Dynaconf, Validator
 from galaxy_ng.app.dynamic_settings import DYNAMIC_SETTINGS_SCHEMA

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -390,11 +390,11 @@ ANSIBLE_BASE_RESOURCE_CONFIG_MODULE = "galaxy_ng.app.api.resource_api"
 ANSIBLE_BASE_ORGANIZATION_MODEL = "galaxy.Organization"
 ANSIBLE_BASE_JWT_VALIDATE_CERT = False
 
-# WARNING: When set to a url such as https://localhost this will
-# cause a hook configure_resource_provider to set API_HOSTNAME/CONTENT_HOSTNAME
-# scheme and netloc to the same. This variable must be None (or unset)
-# whenever galaxy is running standalone (without a RESOURCE_SERVER proxy)
-# and set to `https://resource_server` when running behind the resource proxy.
+# This is meant to be a url to the resource server
+# which the JWT consumer code can obtain a certificate
+# from for decrypting the JWT. If the hub system can
+# reach the resource server via an internal url,
+# use that here for the best network performance.
 ANSIBLE_BASE_JWT_KEY = None
 
 # NOTE: For the Resource Sync Feature the following are required:


### PR DESCRIPTION
This hook is too broad and conflicts with the intent of the alter_hostname_settings hook ...

https://github.com/ansible/galaxy_ng/blob/master/galaxy_ng/app/dynaconf_hooks.py#L714-L742
