### PR TITLE
add support for rhel8 jenkins node in devshift ci

### DIFF
--- a/dev/ephemeral/smoke_test.sh
+++ b/dev/ephemeral/smoke_test.sh
@@ -48,7 +48,7 @@ else
     #DOCKER_IMAGE="python:3"
     DOCKER_IMAGE="quay.io/fedora/python-310"
     $DOCKERCMD run \
-        -v $(pwd):/app \
+        -v $(pwd):/app:z \
         --env HUB_USE_MOVE_ENDPOINT="${HUB_USE_MOVE_ENDPOINT}" \
         --env HUB_API_ROOT="${HUB_API_ROOT}" \
         --env HUB_AUTH_URL="${HUB_AUTH_URL}" \


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
The devshift ci jenkins nodes have been migrated to rhel 8 and these nodes use podman instead of docker.
This PR Adds the shared label to the volume mount in smoke_test.sh to support the rhel8 jenkins nodes.

No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
