### PR TITLE
disable resource registry on crc hub

### DIFF
--- a/openshift/clowder/clowd-app.yaml
+++ b/openshift/clowder/clowd-app.yaml
@@ -179,6 +179,8 @@ objects:
             value: ${GALAXY_FEATURE_FLAGS_DISPLAY_SIGNATURES}
           - name: PULP_GALAXY_FEATURE_FLAGS__execution_environments
             value: 'false'
+          - name: PULP_GALAXY_FEATURE_FLAGS__dab_resource_registry
+            value: 'false'
           - name: PULP_ANSIBLE_COLLECT_DOWNLOAD_LOG
             value: ${ANSIBLE_COLLECT_DOWNLOAD_LOG}
           - name: PULP_ANSIBLE_COLLECT_DOWNLOAD_COUNT


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
This PR disables the resource registry for console.redhat.com Automation Hub

<!-- Add Jira issue link or replace with No-Issue -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
