### PR TITLE
Whitespace edits to copy docker run cmd to terminal

### DIFF
--- a/docs/usage_guide/installation.md
+++ b/docs/usage_guide/installation.md
@@ -103,12 +103,12 @@ Understanding every setting in the file is beyond the scope of this document, bu
 
 Start the container with these docker args ...
 ```
-docker run \                                                        
+docker run \
     --name=galaxy_ng \
-    -v $(pwd)/galaxy-importer.cfg:/etc/galaxy-importer/galaxy-importer.cfg
+    -v $(pwd)/galaxy-importer.cfg:/etc/galaxy-importer/galaxy-importer.cfg \
     --env-file=pulp_settings.env \
-    -p 8080:80 \                                                    
-    quay.io/pulp/galaxy:4.9.0 
+    -p 8080:80 \
+    quay.io/pulp/galaxy:latest
 ```
 
 The container uses the s6 init system to spin up postgresql, gunicorn, nginx and various pulp services all in the same container. Once migrations have finished and the log entries settle and end with a "New worker XXXXXX discovered", the system is ready to use.


### PR DESCRIPTION
#### What is this PR doing:
I followed the docs link in the README.md https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/ and then went to User Guides -> Installation

Pasted this in terminal:

```
docker run \                                                        
    --name=galaxy_ng \
    -v $(pwd)/galaxy-importer.cfg:/etc/galaxy-importer/galaxy-importer.cfg
    --env-file=pulp_settings.env \
    -p 8080:80 \                                                    
    quay.io/pulp/galaxy:4.9.0 
```

This didn't run because of whitespace/wrapping problems, and I believe this fixes it.

No-Issue

#### Reviewers must know:
I changed the tag as well, because `PULP_GALAXY_AUTHENTICATION_CLASSES` in that same file is outdated and causes a traceback because it references a class that doesn't exist in 4.9.0. The latest is on 4.9.2 which still doesn't work, but `:latest` seems more honest because it will at least _eventually_ work.

