### PR TITLE
Bump galaxy-importer cap to v0.4.24

### DIFF
--- a/CHANGES/3302.bugfix
+++ b/CHANGES/3302.bugfix
@@ -1,0 +1,1 @@
+Updated galaxy-importer dependency cap to v0.4.24. 

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ django_ansible_base_dependency = (
 )
 
 requirements = [
-    "galaxy-importer>=0.4.21,<0.5.0",
+    "galaxy-importer>=0.4.24,<0.5.0",
     "pulpcore>=3.49.0,<3.50.0",
     "pulp_ansible>=0.21.0,<0.22.0",
     "pulp-container>=2.19.2,<2.20.0",


### PR DESCRIPTION
Issue: AAH-3302

#### What is this PR doing:
Upgrades galaxy-importer version to 0.4.24.

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAH-3302

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
