### PR TITLE
Skip collection signing and validation in related test.

### DIFF
--- a/galaxy_ng/tests/integration/api/test_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_repositories.py
@@ -168,7 +168,7 @@ class TestRepositories:
     @pytest.mark.repositories
     @pytest.mark.deployment_standalone
     @pytest.mark.skipif(is_ocp_env(), reason="Content signing not enabled in AAP Operator")
-    def test_copy_signed_cv_endpoint(self, galaxy_client):
+    def test_copy_signed_cv_endpoint(self, use_collection_signatures, galaxy_client):
         """
         Verifies a signed cv can be copied to a different repo
         """
@@ -190,13 +190,14 @@ class TestRepositories:
         test_repo_name_2 = f"repo-test-{generate_random_string()}"
         repo_pulp_href_2 = create_repo_and_dist(gc_admin, test_repo_name_2)
 
-        sign_collection(gc_admin, content_units[0], repo_pulp_href_1)
+        if use_collection_signatures:
+            sign_collection(gc_admin, content_units[0], repo_pulp_href_1)
 
         copy_content_between_repos(gc_admin, content_units, repo_pulp_href_1, [repo_pulp_href_2])
         matches, results = search_collection_endpoint(gc_admin, name=artifact.name)
         expected = [
-            {"cv_name": artifact.name, "repo_name": test_repo_name_1, "is_signed": True},
-            {"cv_name": artifact.name, "repo_name": test_repo_name_2, "is_signed": True},
+            {"cv_name": artifact.name, "repo_name": test_repo_name_1, "is_signed": use_collection_signatures},
+            {"cv_name": artifact.name, "repo_name": test_repo_name_2, "is_signed": use_collection_signatures},
         ]
         assert verify_repo_data(expected, results)
 

--- a/galaxy_ng/tests/integration/api/test_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_repositories.py
@@ -210,7 +210,7 @@ class TestRepositories:
     @pytest.mark.repositories
     @pytest.mark.deployment_standalone
     @pytest.mark.skipif(is_ocp_env(), reason="Content signing not enabled in AAP Operator")
-    def test_move_signed_cv_endpoint(self, galaxy_client):
+    def test_move_signed_cv_endpoint(self, use_collection_signatures, galaxy_client):
         """
         Verifies a signed cv can be moved to a different repo
         """
@@ -232,11 +232,12 @@ class TestRepositories:
         test_repo_name_2 = f"repo-test-{generate_random_string()}"
         repo_pulp_href_2 = create_repo_and_dist(gc_admin, test_repo_name_2)
 
-        sign_collection(gc_admin, content_units[0], repo_pulp_href_1)
+        if use_collection_signatures:
+            sign_collection(gc_admin, content_units[0], repo_pulp_href_1)
 
         move_content_between_repos(gc_admin, content_units, repo_pulp_href_1, [repo_pulp_href_2])
         _, results = search_collection_endpoint(gc_admin, name=artifact.name)
-        expected = [{"cv_name": artifact.name, "repo_name": test_repo_name_2, "is_signed": True}]
+        expected = [{"cv_name": artifact.name, "repo_name": test_repo_name_2, "is_signed": use_collection_signatures}]
         assert verify_repo_data(expected, results)
         matches, _ = search_collection_endpoint(
             gc_admin, name=artifact.name, repository_name=test_repo_name_1

--- a/galaxy_ng/tests/integration/api/test_repositories.py
+++ b/galaxy_ng/tests/integration/api/test_repositories.py
@@ -196,8 +196,16 @@ class TestRepositories:
         copy_content_between_repos(gc_admin, content_units, repo_pulp_href_1, [repo_pulp_href_2])
         matches, results = search_collection_endpoint(gc_admin, name=artifact.name)
         expected = [
-            {"cv_name": artifact.name, "repo_name": test_repo_name_1, "is_signed": use_collection_signatures},
-            {"cv_name": artifact.name, "repo_name": test_repo_name_2, "is_signed": use_collection_signatures},
+            {
+                "cv_name": artifact.name,
+                "repo_name": test_repo_name_1,
+                "is_signed": use_collection_signatures
+            },
+            {
+                "cv_name": artifact.name,
+                "repo_name": test_repo_name_2,
+                "is_signed": use_collection_signatures
+            },
         ]
         assert verify_repo_data(expected, results)
 
@@ -237,7 +245,11 @@ class TestRepositories:
 
         move_content_between_repos(gc_admin, content_units, repo_pulp_href_1, [repo_pulp_href_2])
         _, results = search_collection_endpoint(gc_admin, name=artifact.name)
-        expected = [{"cv_name": artifact.name, "repo_name": test_repo_name_2, "is_signed": use_collection_signatures}]
+        expected = [{
+            "cv_name": artifact.name,
+            "repo_name": test_repo_name_2,
+            "is_signed": use_collection_signatures
+        }]
         assert verify_repo_data(expected, results)
         matches, _ = search_collection_endpoint(
             gc_admin, name=artifact.name, repository_name=test_repo_name_1

--- a/galaxy_ng/tests/integration/api/test_x_repo_search.py
+++ b/galaxy_ng/tests/integration/api/test_x_repo_search.py
@@ -560,10 +560,22 @@ class TestXRepoSearch:
     @pytest.mark.parametrize("is_signed", [True, False])
     @pytest.mark.x_repo_search
     @pytest.mark.skipif(is_ocp_env(), reason="Content signing not enabled in AAP Operator")
-    def test_search_by_is_signed_true_false(self, galaxy_client, is_signed):
+    def test_search_by_is_signed_true_false(
+        self,
+        use_collection_signatures,
+        galaxy_client,
+        is_signed
+    ):
         """
         Verifies that search endpoint can search by is_signed
         """
+
+        # we shouldn't be here if the system doesn't have signatures
+        # enabled and a valid signing service, but we have pipelines
+        # that seem to have issues using the correct marks.
+        if not use_collection_signatures:
+            pytest.skip("signatures are required for this test")
+
         test_repo_name = f"repo-test-1-{generate_random_string()}"
         gc = galaxy_client("iqe_admin")
         repo_pulp_href = create_repo_and_dist(gc, test_repo_name)

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -386,6 +386,23 @@ def settings(galaxy_client):
     return gc.get("_ui/v1/settings/")
 
 
+@pytest.fixture(scope="function")
+def use_collection_signatures(settings):
+    """A shortcut to know if a test should attempt to work with signatures."""
+    service = settings["GALAXY_COLLECTION_SIGNING_SERVICE"]
+    required = settings["GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL"]
+    if service is not None and required:
+        return True
+    return False
+
+
+@pytest.fixture(scope="function")
+def autohubtest2(galaxy_client):
+    """A carry over pre-created namespace from the original IQE tests."""
+    gc = galaxy_client("admin")
+    return create_namespace("autohubtest2", gc=gc)
+
+
 def set_test_data(ansible_config, hub_version):
     role = "admin"
     gc = GalaxyKitClient(ansible_config).gen_authorized_client(role)

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -400,7 +400,8 @@ def use_collection_signatures(settings):
 def autohubtest2(galaxy_client):
     """A carry over pre-created namespace from the original IQE tests."""
     gc = galaxy_client("admin")
-    return create_namespace("autohubtest2", gc=gc)
+    create_namespace(gc, "autohubtest2", "")
+    return {"name": "autohubtest2"}
 
 
 def set_test_data(ansible_config, hub_version):

--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -664,15 +664,11 @@ def has_old_credentials():
 @lru_cache()
 def get_hub_version(ansible_config):
     if aap_gateway():
-        # Why would we do this? ...
-        # username = ansible_config("admin").PROFILES.get("admin").get("username")
-        # password = ansible_config("admin").PROFILES.get("admin").get("password")
-
         cfg = ansible_config("admin")
         username = cfg.get('username')
         password = cfg.get('password')
+        gw_root_url = cfg.get("gw_root_url")
 
-        gw_root_url = ansible_config("admin").get("gw_root_url")
         gc = GalaxyClient(galaxy_root="foo", auth={"username": username, "password": password},
                           gw_auth=True, https_verify=False, gw_root_url=gw_root_url)
         galaxy_ng_version = gc.get_server_version()

--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -534,9 +534,13 @@ class AnsibleConfigFixture(dict):
                 return None
 
         elif key == "username":
+            if self.profile == 'admin' and os.environ.get('HUB_ADMIN_USER'):
+                return os.environ.get('HUB_ADMIN_USER')
             return self.PROFILES[self.profile]["username"]
 
         elif key == "password":
+            if self.profile == 'admin' and os.environ.get('HUB_ADMIN_PASS'):
+                return os.environ.get('HUB_ADMIN_PASS')
             return self.PROFILES[self.profile]["password"]
 
         elif key == 'use_move_endpoint':
@@ -660,8 +664,14 @@ def has_old_credentials():
 @lru_cache()
 def get_hub_version(ansible_config):
     if aap_gateway():
-        username = ansible_config("admin").PROFILES.get("admin").get("username")
-        password = ansible_config("admin").PROFILES.get("admin").get("password")
+        # Why would we do this? ...
+        # username = ansible_config("admin").PROFILES.get("admin").get("username")
+        # password = ansible_config("admin").PROFILES.get("admin").get("password")
+
+        cfg = ansible_config("admin")
+        username = cfg.get('username')
+        password = cfg.get('password')
+
         gw_root_url = ansible_config("admin").get("gw_root_url")
         gc = GalaxyClient(galaxy_root="foo", auth={"username": username, "password": password},
                           gw_auth=True, https_verify=False, gw_root_url=gw_root_url)

--- a/galaxy_ng/tests/integration/utils/namespaces.py
+++ b/galaxy_ng/tests/integration/utils/namespaces.py
@@ -4,6 +4,8 @@ import logging
 import random
 import string
 
+from galaxykit.utils import GalaxyClientError
+
 from .collections import delete_all_collections_in_namespace, \
     delete_all_collections_in_namespace_gk
 
@@ -116,3 +118,18 @@ def cleanup_namespace_gk(name, gc_admin):
 
         resp = gc_admin.get(f'v3/namespaces/?name={name}')
         assert resp['meta']['count'] == 0
+
+
+def create_namespace(namespace_name, gc=None):
+    """ Make a namespace for testing if it does not exist."""
+    assert gc is not None, "api_client is a required param"
+    # check if it already exists ...
+    try:
+        resp = gc.get(f"_ui/v1/namespaces/{namespace_name}/")
+        return resp
+    except GalaxyClientError:
+        pass
+
+    # create it
+    payload = {"name": namespace_name, "groups": []}
+    return gc.post("v3/namespaces/", body=payload)


### PR DESCRIPTION
```
Error
IndexError: list index out of range
Stacktrace
ansible_config = <class 'galaxy_ng.tests.integration.utils.iqe_utils.AnsibleConfigFixture'>
galaxy_client = <bound method GalaxyKitClient.gen_authorized_client of <galaxy_ng.tests.integration.utils.iqe_utils.GalaxyKitClient object at 0x7f87dc835a30>>
    @pytest.mark.deployment_standalone
    @pytest.mark.min_hub_version("4.7dev")
    @pytest.mark.skipif(is_ocp_env(), reason="Content signing not enabled in AAP Operator")
    def test_copy_associated_content(ansible_config, galaxy_client):
        """Tests whether a collection and associated content is copied from repo to repo"""
    
        # TODO: add check for ansible namespace metadata
    
        artifact = build_collection(
            "skeleton",
            config={
                "namespace": USERNAME_PUBLISHER,
                "tags": ["tools", "copytest"],
            }
        )
    
        # import and wait ...
        gc_admin = galaxy_client("admin")
        resp = upload_artifact(None, gc_admin, artifact)
        wait_for_task(gc_admin, resp)
    
        # get staging repo version
        pulp_href = get_repository_href(gc_admin, "staging")
    
        collection_version = gc_admin.get(
            f'pulp/api/v3/content/ansible/collection_versions/'
            f'?namespace={artifact.namespace}&name={artifact.name}&version={artifact.version}'
        )["results"][0]
    
        cv_href = collection_version["pulp_href"]
    
        collection = (f'content/staging/v3/plugin/ansible/content/staging/collections/index/'
                      f'{artifact.namespace}/{artifact.name}/')
    
        collection_version = f'{collection}versions/{artifact.version}/'
        collection_mark = (
            f'pulp/api/v3/content/ansible/collection_marks/'
            f'?marked_collection={cv_href}'
        )
    
        col_deprecation = gc_admin.get(collection)["deprecated"]
        assert col_deprecation is False
    
        col_signature = gc_admin.get(collection_version)["signatures"]
        assert len(col_signature) == 0
    
        col_marked = gc_admin.get(collection_mark)["results"]
        assert len(col_marked) == 0
    
>       sign_collection(gc_admin, cv_href, pulp_href)
galaxy_ng/tests/integration/api/test_move.py:226: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
client = <galaxykit.client.GalaxyClient object at 0x7f87dca9fa00>
cv_href = '/api/galaxy/pulp/api/v3/content/ansible/collection_versions/0190dc16-4cb0-7bda-9da7-3cb11ddbb62c/'
repo_pulp_href = '/api/galaxy/pulp/api/v3/repositories/ansible/ansible/0190dbcd-2ef6-7591-8827-3f2797c42f85/'
    def sign_collection(client, cv_href, repo_pulp_href):
        results = client.get("pulp/api/v3/signing-services/?name=ansible-default")
>       signing_service = results["results"][0]
E       IndexError: list index out of range
```