### PR TITLE
fix(performance):Improve performance of /settings/ endpoint

### DIFF
--- a/galaxy_ng/app/api/ui/views/settings.py
+++ b/galaxy_ng/app/api/ui/views/settings.py
@@ -27,5 +27,6 @@ class SettingsView(api_base.APIView):
             "GALAXY_LDAP_DISABLE_REFERRALS",
             "KEYCLOAK_URL",
         ]
-        data = {key: settings.as_dict().get(key, None) for key in keyset}
+        settings_dict = settings.as_dict()
+        data = {key: settings_dict.get(key, None) for key in keyset}
         return Response(data)


### PR DESCRIPTION
No-Issue

## Before

```console
$ time curl -s http://localhost:5001/api/galaxy/_ui/v1/settings/ 2>&1 > /dev/null

real	0m0.132s
user	0m0.012s
sys	0m0.005s

```

## After

```console
$ time curl -s http://localhost:5001/api/galaxy/_ui/v1/settings/ 2>&1 > /dev/null

real	0m0.023s
user	0m0.000s
sys	0m0.005s

```
