### PR TITLE
Add more settings to the settings endpoint.

### DIFF
--- a/galaxy_ng/app/api/ui/views/settings.py
+++ b/galaxy_ng/app/api/ui/views/settings.py
@@ -39,4 +39,10 @@ class SettingsView(api_base.APIView):
         ]
         settings_dict = settings.as_dict()
         data = {key: settings_dict.get(key, None) for key in keyset}
+
+        # these might not be strings ...
+        if data.get("DYNACONF_AFTER_GET_HOOKS") is not None:
+            data["DYNACONF_AFTER_GET_HOOKS"] = \
+                [str(func) for func in settings_dict["DYNACONF_AFTER_GET_HOOKS"]]
+
         return Response(data)

--- a/galaxy_ng/app/api/ui/views/settings.py
+++ b/galaxy_ng/app/api/ui/views/settings.py
@@ -26,7 +26,16 @@ class SettingsView(api_base.APIView):
             "GALAXY_LDAP_MIRROR_ONLY_EXISTING_GROUPS",
             "GALAXY_LDAP_DISABLE_REFERRALS",
             "KEYCLOAK_URL",
+            "ANSIBLE_BASE_JWT_VALIDATE_CERT",
+            "ANSIBLE_BASE_JWT_KEY",
             "ALLOW_LOCAL_RESOURCE_MANAGEMENT",
+            "ANSIBLE_BASE_ROLES_REQUIRE_VIEW",
+            "DYNACONF_AFTER_GET_HOOKS",
+            "ANSIBLE_API_HOSTNAME",
+            "ANSIBLE_CONTENT_HOSTNAME",
+            "CONTENT_ORIGIN",
+            "TOKEN_SERVER",
+            "TOKEN_AUTH_DISABLED",
         ]
         settings_dict = settings.as_dict()
         data = {key: settings_dict.get(key, None) for key in keyset}

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -784,6 +784,15 @@ def test_api_ui_v1_settings(ansible_config):
         assert ds['GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD'] is False
         assert ds['GALAXY_REQUIRE_CONTENT_APPROVAL'] is True
 
+        assert ds["ALLOW_LOCAL_RESOURCE_MANAGEMENT"] in [True, False]
+        assert ds["ANSIBLE_BASE_ROLES_REQUIRE_VIEW"] in [True, False]
+        assert ds["TOKEN_AUTH_DISABLED"] in [True, False]
+        assert "ANSIBLE_API_HOSTNAME" in ds
+        assert "ANSIBLE_CONTENT_HOSTNAME" in ds
+        assert "CONTENT_ORIGIN" in ds
+        assert "TOKEN_SERVER" in ds
+        assert "DYNACONF_AFTER_GET_HOOKS" in ds
+
 
 # /api/automation-hub/_ui/v1/synclists/
 # /api/automation-hub/_ui/v1/synclists/{id}/


### PR DESCRIPTION
```
{
  "GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS": false,
  "GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD": false,
  "GALAXY_FEATURE_FLAGS": {
    "legacy_roles": false,
    "external_authentication": true,
    "display_repositories": true,
    "execution_environments": true,
    "ai_deny_index": false,
    "dab_resource_registry": true
  },
  "GALAXY_TOKEN_EXPIRATION": null,
  "GALAXY_REQUIRE_CONTENT_APPROVAL": true,
  "GALAXY_COLLECTION_SIGNING_SERVICE": "ansible-default",
  "GALAXY_AUTO_SIGN_COLLECTIONS": true,
  "GALAXY_SIGNATURE_UPLOAD_ENABLED": false,
  "GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL": false,
  "GALAXY_MINIMUM_PASSWORD_LENGTH": null,
  "GALAXY_AUTH_LDAP_ENABLED": null,
  "GALAXY_CONTAINER_SIGNING_SERVICE": "container-default",
  "GALAXY_LDAP_MIRROR_ONLY_EXISTING_GROUPS": false,
  "GALAXY_LDAP_DISABLE_REFERRALS": null,
  "KEYCLOAK_URL": null,
  "ANSIBLE_BASE_JWT_VALIDATE_CERT": false,
  "ANSIBLE_BASE_JWT_KEY": "http://jwtproxy:8080",
  "ALLOW_LOCAL_RESOURCE_MANAGEMENT": false,
  "ANSIBLE_BASE_ROLES_REQUIRE_VIEW": false,
  "DYNACONF_AFTER_GET_HOOKS": [
    "read_settings_from_cache_or_db",
    "alter_hostname_settings"
  ],
  "ANSIBLE_API_HOSTNAME": "http://jwtproxy:8080",
  "ANSIBLE_CONTENT_HOSTNAME": "http://jwtproxy:8080",
  "CONTENT_ORIGIN": "http://jwtproxy:8080",
  "TOKEN_SERVER": "http://jwtproxy:8080/token/",
  "TOKEN_AUTH_DISABLED": false
}
```