### PR TITLE
Set some defaults on the new roledefs from their pulp counterparts.

### DIFF
--- a/galaxy_ng/app/migrations/_dab_rbac.py
+++ b/galaxy_ng/app/migrations/_dab_rbac.py
@@ -54,7 +54,13 @@ def copy_roles_to_role_definitions(apps, schema_editor):
                 dab_perms.append(dabperm)
 
         if dab_perms:
-            roledef, created = RoleDefinition.objects.get_or_create(name=corerole.name)
+            roledef, created = RoleDefinition.objects.get_or_create(
+                name=corerole.name,
+                defaults={
+                    'description': corerole.description,
+                    'managed': corerole.locked,
+                }
+            )
             if created:
                 print(f'CREATED RoleDefinition from {corerole} {corerole.name}')
                 roledef.permissions.set(dab_perms)

--- a/galaxy_ng/app/migrations/_dab_rbac.py
+++ b/galaxy_ng/app/migrations/_dab_rbac.py
@@ -57,7 +57,7 @@ def copy_roles_to_role_definitions(apps, schema_editor):
             roledef, created = RoleDefinition.objects.get_or_create(
                 name=corerole.name,
                 defaults={
-                    'description': corerole.description,
+                    'description': corerole.description or corerole.name,
                     'managed': corerole.locked,
                 }
             )

--- a/galaxy_ng/app/signals/handlers.py
+++ b/galaxy_ng/app/signals/handlers.py
@@ -206,7 +206,11 @@ def copy_role_to_role_definition(sender, instance, created, **kwargs):
     with pulp_rbac_signals():
         rd = RoleDefinition.objects.filter(name=instance.name).first()
         if not rd:
-            RoleDefinition.objects.create(name=instance.name)
+            RoleDefinition.objects.create(
+                name=instance.name,
+                managed=instance.locked,
+                description=instance.description
+            )
         # TODO: other fields? like description
 
 

--- a/galaxy_ng/app/signals/handlers.py
+++ b/galaxy_ng/app/signals/handlers.py
@@ -209,7 +209,7 @@ def copy_role_to_role_definition(sender, instance, created, **kwargs):
             RoleDefinition.objects.create(
                 name=instance.name,
                 managed=instance.locked,
-                description=instance.description
+                description=instance.description or instance.name,
             )
         # TODO: other fields? like description
 

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac.py
@@ -102,10 +102,10 @@ def test_dab_rbac_namespace_owner_by_user(
 
 
 @pytest.mark.deployment_standalone
-# @pytest.mark.skipif(
-#    not os.getenv("ENABLE_DAB_TESTS"),
-#    reason="Skipping test because ENABLE_DAB_TESTS is not set"
-# )
+@pytest.mark.skip(reason=(
+    "the galaxy.collection_namespace_owner role is global"
+    " and does not allow object assignment"
+))
 def test_dab_rbac_namespace_owner_by_team(
     settings,
     galaxy_client,


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-3364


After stack startup ...
```
$ curl -s -k -u admin:admin http://localhost:55001/api/galaxy/_ui/v2/role_definitions/  | jq '.results[].managed' | grep false | wc -l
0
$ curl -s -k -u admin:admin http://localhost:55001/api/galaxy/_ui/v2/role_definitions/  | jq '.results[].managed' | grep true | wc -l
35
```