### PR TITLE
Skip 2.5 tests in 2.4 pipelines

### DIFF
--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -765,7 +765,7 @@ def test_api_ui_v1_collection_detail_view(ansible_config, published):
 # /api/automation-hub/_ui/v1/settings/
 @pytest.mark.deployment_standalone
 @pytest.mark.api_ui
-@pytest.mark.min_hub_version("4.6dev")
+@pytest.mark.min_hub_version("4.10dev")
 @pytest.mark.skip_in_gw
 def test_api_ui_v1_settings(ansible_config):
 

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac.py
@@ -295,6 +295,7 @@ def test_dab_rbac_namespace_owner_by_user_or_team(
     os.environ.get('JWT_PROXY') is not None,
     reason="Skipped because jwt proxy is in use"
 )
+@pytest.mark.min_hub_version("4.10dev")
 def test_dab_user_platform_auditor_bidirectional_sync(
     settings,
     galaxy_client,
@@ -387,6 +388,7 @@ def test_dab_user_platform_auditor_bidirectional_sync(
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 def test_dab_team_platform_auditor_bidirectional_sync(
     settings,
     galaxy_client,
@@ -489,6 +491,7 @@ def test_dab_team_platform_auditor_bidirectional_sync(
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 def test_dab_user_assignment_filtering_as_user(
     settings,
     galaxy_client,

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -11,6 +11,7 @@ GALAXY_API_PATH_PREFIX = "/api/galaxy"  # cant import from settings on integrati
 
 # This tests the basic DAB RBAC contract using custom roles to do things.
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 def test_list_namespace_permissions(galaxy_client):
     gc = galaxy_client("admin")
     r = gc.get("_ui/v2/role_metadata/")
@@ -30,6 +31,7 @@ def test_list_namespace_permissions(galaxy_client):
 
 # look for the content_type choices
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 def test_role_definition_options(galaxy_client):
     gc = galaxy_client("admin")
     # TODO: add support for options in GalaxyClient in galaxykit
@@ -220,6 +222,7 @@ def check_system_role_user_assignments(client: GalaxyClient, user: dict, role: d
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 @pytest.mark.parametrize("by_api", ["dab", "pulp"])
 def test_create_custom_namespace_system_admin_role(custom_role_factory, galaxy_client, by_api):
     if by_api == "dab":
@@ -242,6 +245,7 @@ def test_create_custom_namespace_system_admin_role(custom_role_factory, galaxy_c
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 def test_give_user_custom_role_system(galaxy_client, custom_role_factory, namespace):
     # TODO: verify that assignment is seen in pulp API (HOW?)
     # Step 0: Setup test.
@@ -306,6 +310,7 @@ def test_give_user_custom_role_system(galaxy_client, custom_role_factory, namesp
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 def test_give_team_custom_role_system(
     settings,
     galaxy_client,
@@ -378,6 +383,7 @@ def test_give_team_custom_role_system(
 
 # TODO: We need another version of it for a team
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 @pytest.mark.parametrize("by_role_api", ["dab", "pulp"])
 @pytest.mark.parametrize("by_assignment_api", ["dab", "pulp"])
 def test_give_user_custom_role_object(
@@ -554,6 +560,7 @@ def test_give_team_custom_role_object(
     assert ctx.value.response.status_code == HTTPStatus.FORBIDDEN
 
 
+@pytest.mark.min_hub_version("4.10dev")
 def test_object_role_permission_validation(galaxy_client, custom_role_factory, namespace):
     gc = galaxy_client("admin")
 
@@ -629,6 +636,7 @@ def user_and_group(request, galaxy_client):
     return (user, group)
 
 
+@pytest.mark.min_hub_version("4.10dev")
 def test_group_sync_from_pulp_to_dab(galaxy_client, assert_user_in_group, user_and_group):
     gc = galaxy_client("admin")
     user, group = user_and_group

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_pagination.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_pagination.py
@@ -5,6 +5,7 @@ pytestmark = pytest.mark.qa  # noqa: F821
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 def test_dab_rbac_pagination(galaxy_client):
     gc = galaxy_client("admin", ignore_cache=True)
     roledefs = gc.get('_ui/v2/role_definitions/?page_size=1')

--- a/galaxy_ng/tests/integration/dab/test_ui_v2.py
+++ b/galaxy_ng/tests/integration/dab/test_ui_v2.py
@@ -11,6 +11,7 @@ pytestmark = pytest.mark.qa  # noqa: F821
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 @pytest.mark.parametrize("user_payload", [
     {},
     {"email": "foobar@foobar.com"},
@@ -61,6 +62,7 @@ def test_ui_v2_user_create(
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 @pytest.mark.parametrize("user_payload", [
     {"groups": [{"name": "$RANDOM"}]},
     {"teams": [{"name": "$RANDOM", "organization": "$RANDOM"}]},
@@ -170,6 +172,7 @@ def test_ui_v2_user_create_with_groups_and_teams_and_orgs(
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 @pytest.mark.parametrize("invalid_payload", [
     ({"email": "invalidemail"}, "Enter a valid email address."),
     ({"email": "@whoops"}, "Enter a valid email address."),
@@ -214,6 +217,7 @@ def test_ui_v2_user_create_invalid_data(
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 def test_ui_v2_user_edit(
     settings,
     galaxy_client,
@@ -256,6 +260,7 @@ def test_ui_v2_user_edit(
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.min_hub_version("4.10dev")
 @pytest.mark.parametrize("invalid_payload", [
     ({"email": "invalidemail"}, "Enter a valid email address."),
     ({"email": "@whoops"}, "Enter a valid email address."),


### PR DESCRIPTION
No-Issue

Skip 2.5 GW and DAB tests.
 List of failing tests in [2.4 jenkins pipeline](https://main-jenkins-csb-aap.apps.ocp-c1.prod.psi.redhat.com/blue/organizations/jenkins/AAPQA%2FRPM_Gating%2Fansible-automation-platform-2.4-rhel-9%2Fgeneric%2Finteg-aap-2.4_public-tls/detail/integ-aap-2.4_public-tls/91/tests/): 

```
test_api_ui_v1_settings
test_dab_user_platform_auditor_bidirectional_sync 
test_dab_team_platform_auditor_bidirectional_sync 
test_dab_user_assignment_filtering_as_user 
test_list_namespace_permissions 
test_role_definition_options 
test_create_custom_namespace_system_admin_role[dab] 
test_create_custom_namespace_system_admin_role[pulp] 
test_give_user_custom_role_system 
test_give_team_custom_role_system 
test_give_user_custom_role_object[dab-dab] 
test_give_user_custom_role_object[pulp-dab] 
test_give_user_custom_role_object[pulp-pulp] 
test_object_role_permission_validation 
test_group_sync_from_pulp_to_dab 
test_dab_rbac_pagination
test_ui_v2_user_create[user_payload0] 
test_ui_v2_user_create[user_payload1] 
test_ui_v2_user_create[user_payload2] 
test_ui_v2_user_create_with_groups_and_teams_and_orgs[user_payload0] 
test_ui_v2_user_create_with_groups_and_teams_and_orgs[user_payload1]
test_ui_v2_user_create_with_groups_and_teams_and_orgs[user_payload2]
test_ui_v2_user_create_invalid_data[invalid_payload0]
test_ui_v2_user_create_invalid_data[invalid_payload1] 
test_ui_v2_user_create_invalid_data[invalid_payload2] 
test_ui_v2_user_create_invalid_data[invalid_payload3] 
test_ui_v2_user_create_invalid_data[invalid_payload4] 
test_ui_v2_user_create_invalid_data[invalid_payload5] 
test_ui_v2_user_create_invalid_data[invalid_payload6] 
test_ui_v2_user_create_invalid_data[invalid_payload7] 
test_ui_v2_user_edit 
test_ui_v2_user_edit_invalid_data[invalid_payload0] 
test_ui_v2_user_edit_invalid_data[invalid_payload1] 
test_ui_v2_user_edit_invalid_data[invalid_payload2] 
test_ui_v2_user_edit_invalid_data[invalid_payload3] 
test_ui_v2_user_edit_invalid_data[invalid_payload4] 
test_ui_v2_user_edit_invalid_data[invalid_payload5] 
test_ui_v2_user_edit_invalid_data[invalid_payload6] 
test_ui_v2_user_edit_invalid_data[invalid_payload7] 
```