### PR TITLE
Use pytest-subtest on the rbac integration tests for more granular output

### DIFF
--- a/galaxy_ng/tests/integration/api/test_rbac_roles.py
+++ b/galaxy_ng/tests/integration/api/test_rbac_roles.py
@@ -652,7 +652,7 @@ def _get_reusable_extras(gc):
 
 @pytest.mark.rbac_roles
 @pytest.mark.parametrize("role", ROLES_TO_TEST)
-def test_global_role_actions(role, galaxy_client):
+def test_global_role_actions(role, subtests, galaxy_client):
     USERNAME = f"{NAMESPACE}_user_{gen_string()}"
 
     user = create_user(USERNAME, PASSWORD)
@@ -663,25 +663,20 @@ def test_global_role_actions(role, galaxy_client):
     gc = galaxy_client("admin", ignore_cache=True)
     extra = _get_reusable_extras(gc)
 
-    failures = []
     # Test global actions
     for action in GLOBAL_ACTIONS:
-        expect_pass = action in expected_allows or action in ACTIONS_FOR_ALL_USERS
-        try:
+        with subtests.test(action=action):
+            expect_pass = action in expected_allows or action in ACTIONS_FOR_ALL_USERS
             action(user, PASSWORD, expect_pass, extra)
-        except AssertionError:
-            failures.append(action.__name__)
 
     # cleanup user, group
     requests.delete(f"{API_ROOT}_ui/v1/users/{user['id']}/", auth=ADMIN_CREDENTIALS)
     requests.delete(f"{API_ROOT}_ui/v1/groups/{group_id}/", auth=ADMIN_CREDENTIALS)
 
-    assert failures == []
-
 
 @pytest.mark.rbac_roles
 @pytest.mark.parametrize("role", OBJECT_ROLES_TO_TEST)
-def test_object_role_actions(role, galaxy_client):
+def test_object_role_actions(role, subtests, galaxy_client):
     USERNAME = f"{NAMESPACE}_user_{gen_string()}"
 
     gc = galaxy_client("admin", ignore_cache=True)
@@ -714,7 +709,6 @@ def test_object_role_actions(role, galaxy_client):
             add_group_role(group["pulp_href"], role, repo_href)
             add_group_role(group["pulp_href"], role, private_repo_href)
 
-    failures = []
     expected_allows = OBJECT_ROLES_TO_TEST[role]
 
     # since we're also applying the namespace owner role to test if the user can
@@ -727,36 +721,27 @@ def test_object_role_actions(role, galaxy_client):
 
     # Test global actions
     for action in OBJECT_ACTIONS:
-        # re apply roles in case they get reset
-        _apply_roles()
-        expect_pass = action in expected_allows or action in ACTIONS_FOR_ALL_USERS
-        try:
+        with subtests.test(action=action):
+            # re apply roles in case they get reset
+            _apply_roles()
+            expect_pass = action in expected_allows or action in ACTIONS_FOR_ALL_USERS
             action(user, PASSWORD, expect_pass, extra)
-        except AssertionError:
-            failures.append(action.__name__)
 
     # cleanup user, group
     requests.delete(f"{API_ROOT}_ui/v1/users/{user['id']}/", auth=ADMIN_CREDENTIALS)
     requests.delete(f"{API_ROOT}_ui/v1/groups/{group_id}/", auth=ADMIN_CREDENTIALS)
 
-    assert failures == []
-
 
 @pytest.mark.rbac_roles
-def test_role_actions_for_admin(galaxy_client):
+def test_role_actions_for_admin(subtests, galaxy_client):
     gc = galaxy_client("admin", ignore_cache=True)
     extra = _get_reusable_extras(gc)
-    failures = []
 
     # Test global actions
     for action in GLOBAL_ACTIONS:
-        expect_pass = action not in DENIED_FOR_ALL_USERS
-        try:
+        with subtests.test(action=action):
+            expect_pass = action not in DENIED_FOR_ALL_USERS
             action({'username': ADMIN_USER}, ADMIN_PASSWORD, expect_pass, extra)
-        except AssertionError:
-            failures.append(action.__name__)
-
-    assert failures == []
 
 
 @pytest.mark.rbac_roles

--- a/integration_requirements.txt
+++ b/integration_requirements.txt
@@ -10,3 +10,4 @@ hvac
 importlib_resources
 galaxykit @ git+https://github.com/ansible/galaxykit
 pyyaml
+pytest-subtests


### PR DESCRIPTION
These tests take a long time and iterate through a lot of "parameters" without reporting anything.