### PR TITLE
Sync to 2 different DAB team member roles

### DIFF
--- a/CHANGES/3358.misc
+++ b/CHANGES/3358.misc
@@ -1,0 +1,1 @@
+sync RBAC assignments from JWT, specific Team Member role, to the pulp group users relationship

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -422,6 +422,8 @@ ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
 # Pass ignore_conflicts=False for bulk_create calls for role evaluations
 ANSIBLE_BASE_EVALUATIONS_IGNORE_CONFLICTS = False
+# The JWT roles should never be assigned to users through the API
+ALLOW_LOCAL_ASSIGNING_JWT_ROLES = False
 # Set up managed role definitions
 ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
     'platform_auditor': {'name': 'Platform Auditor', 'shortname': 'sys_auditor'},

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -594,7 +594,11 @@ def assert_user_in_group(galaxy_client):
 
         assignment_r = gc.get(
             "_ui/v2/role_user_assignments/",
-            params={"user": user['id'], "content_type__model": "team"},
+            params={
+                "user": user['id'],
+                "content_type__model": "team",
+                "role_definition__name": "Galaxy Team Member"
+            },
         )
         group_ids = [assignment["object_id"] for assignment in assignment_r["results"]]
         if expected:


### PR DESCRIPTION
#### What is this PR doing:
Testing for this is problematic. I will share my hacked tests for this. The first blurb is the one that really can't be tested by other means.

```python
from uuid import uuid4

from galaxy_ng.app.models import Team, Organization, User

from ansible_base.rbac.models import RoleDefinition


test_string = f'gateway_member_{str(uuid4())}'


member_rd = RoleDefinition.objects.filter(name='Team Member').first()

assert member_rd

org = Organization.objects.create(name=test_string)
team = Team.objects.create(name=test_string, organization=org)

user = User.objects.create(username=test_string)

member_rd.give_permission(user, team)

assert user in team.group.user_set.all()
```

This test could maybe be an integration test.

```python
from uuid import uuid4

from galaxy_ng.app.models import Team, Organization, User

from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment


test_string = f'gateway_member_{str(uuid4())}'


local_member_rd = RoleDefinition.objects.filter(name='Galaxy Team Member').first()
shared_member_rd = RoleDefinition.objects.filter(name='Team Member').first()

assert local_member_rd, -1
assert shared_member_rd, 0

org = Organization.objects.create(name=test_string)
team = Team.objects.create(name=test_string, organization=org)

user = User.objects.create(username=test_string)


team.group.user_set.add(user)
# team.users.add(user)  # did not connect signals for this

assert user.has_obj_perm(team, 'member'), 0.5

assert not RoleUserAssignment.objects.filter(role_definition=shared_member_rd, object_id=team.id, user=user).exists(), 1
assert RoleUserAssignment.objects.filter(role_definition=local_member_rd, object_id=team.id, user=user).exists(), 2

assert user in team.group.user_set.all(), 3
# assert user in team.users.all(), 4  # TODO: not sure if this should be a thing?
```


Issue: AAH-3358

requires https://github.com/ansible/django-ansible-base/pull/562

#### Reviewers must know:
To run this I had to install from:

```
pip install git+https://github.com/alancoding/django-ansible-base.git@local_management
```

Then I commented out the skip on `test_team_member_sync_from_dab_to_pulp`, and that was passing. So more of the testing from this could/should be absorbed into that.

The "Team Member" role, however, will be set by jwt_consumer, and there is no way to test that other than hacking.
