### PR TITLE
Migrate group user list to role assignments

### DIFF
--- a/galaxy_ng/app/migrations/_dab_rbac.py
+++ b/galaxy_ng/app/migrations/_dab_rbac.py
@@ -89,10 +89,13 @@ def copy_roles_to_role_definitions(apps, schema_editor):
 def migrate_role_assignments(apps, schema_editor):
     UserRole = apps.get_model('core', 'UserRole')
     GroupRole = apps.get_model('core', 'GroupRole')
+    Group = apps.get_model('auth', 'Group')
+    Team = apps.get_model('galaxy', 'Team')
     RoleDefinition = apps.get_model('dab_rbac', 'RoleDefinition')
     RoleUserAssignment = apps.get_model('dab_rbac', 'RoleUserAssignment')
     RoleTeamAssignment = apps.get_model('dab_rbac', 'RoleTeamAssignment')
 
+    # Migrate user role assignments
     for user_role in UserRole.objects.all():
         rd = RoleDefinition.objects.filter(name=user_role.role.name).first()
         if not rd:
@@ -103,6 +106,7 @@ def migrate_role_assignments(apps, schema_editor):
         else:
             give_permissions(apps, rd, users=[user_role.user], object_id=user_role.object_id, content_type_id=user_role.content_type_id)
 
+    # Migrate team/group role assignments
     for group_role in GroupRole.objects.all():
         rd = RoleDefinition.objects.filter(name=group_role.role.name).first()
         if not rd:
@@ -117,3 +121,16 @@ def migrate_role_assignments(apps, schema_editor):
             RoleTeamAssignment.objects.create(role_definition=rd, team=actor)
         else:
             give_permissions(apps, rd, teams=[actor], object_id=group_role.object_id, content_type_id=group_role.content_type_id)
+
+    # In DAB RBAC, team users are saved as a role assignment
+    # Migrate the pulp group users (relationship) to role assignment
+    member_rd = RoleDefinition.objects.get(name='Galaxy Team Member')
+    for group in Group.objects.prefetch_related('user_set').all():
+        user_list = list(group.user_set.all())
+        team = Team.objects.filter(group=group).first()
+        if not team:
+            logger.warning(f'Data migration could not find team by name {group.name}')
+            continue
+
+        if user_list:
+            give_permissions(apps, member_rd, users=user_list, object_id=team.id, content_type_id=member_rd.content_type_id)

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -656,11 +656,6 @@ def test_group_sync_from_pulp_to_dab(galaxy_client, assert_user_in_group, user_a
     assert_user_in_group(user["id"], group["id"], expected=False)
 
 
-@pytest.mark.skip(reason=(
-    "Cannot be fixed until "
-    + "https://github.com/ansible/django-ansible-base/pull/562"
-    + " stops it giving a 400"
-))
 def test_team_member_sync_from_dab_to_pulp(galaxy_client, assert_user_in_group, user_and_group):
     gc = galaxy_client("admin")
     user, group = user_and_group
@@ -687,3 +682,12 @@ def test_team_member_sync_from_dab_to_pulp(galaxy_client, assert_user_in_group, 
     )
 
     assert_user_in_group(user["id"], group["id"], expected=True)
+
+
+def test_team_members_are_migrated(galaxy_client, assert_user_in_group):
+    "Make sure any existing team memberships are correct"
+    gc = galaxy_client("admin")
+
+    team_assignments = gc.get("_ui/v2/role_user_assignments/", params={"role_definition__name": "Galaxy Team Member"})
+    for assignment in team_assignments["results"]:
+        assert_user_in_group(assignment["user"], int(assignment["object_id"]))

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -688,6 +688,8 @@ def test_team_members_are_migrated(galaxy_client, assert_user_in_group):
     "Make sure any existing team memberships are correct"
     gc = galaxy_client("admin")
 
-    team_assignments = gc.get("_ui/v2/role_user_assignments/", params={"role_definition__name": "Galaxy Team Member"})
+    team_assignments = gc.get("_ui/v2/role_user_assignments/", params={
+        "role_definition__name": "Galaxy Team Member"
+    })
     for assignment in team_assignments["results"]:
         assert_user_in_group(assignment["user"], int(assignment["object_id"]))


### PR DESCRIPTION
No-Issue

#### What is this PR doing:
The data migration was not fully complete before.

Since the only shared roles we're truly supporting are the team member role, this should take care of that.

#### Reviewers must know:
The integration tests aren't working for me anymore. I tested this with a custom script piped to `django-admin shell`

```python
from uuid import uuid4

from django.apps import apps
from django.db.models.signals import post_migrate

from galaxy_ng.app.migrations._dab_rbac import migrate_role_assignments
from galaxy_ng.app.models import Organization, Team, User
from galaxy_ng.app.signals.handlers import dab_rbac_signals

from ansible_base.rbac.models import RoleUserAssignment


test_string = f'gateway_member_{str(uuid4())}'

org = Organization.objects.create(name=test_string)
team = Team.objects.create(name=test_string, organization=org)
user = User.objects.create(username=test_string)

with dab_rbac_signals():
    team.group.user_set.add(user)

# Sanity, the assignment in the new system should not yet exist
assert not RoleUserAssignment.objects.filter(
    role_definition__name__icontains='Team Member',
    object_id=team.id,
    user=user
).exists(), 1


migrate_role_assignments(apps, None)


# This will mean the migration did its job
assert RoleUserAssignment.objects.filter(
    role_definition__name='Galaxy Team Member',
    object_id=team.id,
    user=user
).exists(), 2

# Not the right one
assert not RoleUserAssignment.objects.filter(
    role_definition__name='Team Member',
    object_id=team.id,
    user=user
).exists(), 3

# force the RBAC rebuilding logic (for evaluations) run
for app_config in apps.get_app_configs():
    post_migrate.send(sender=app_config, app_config=app_config, verbosity=1, interactive=False, apps=apps)


# overkill now
assert user.has_obj_perm(team, 'member'), 5
```

Basically I got that to passing and that's the extent of the work I've done on this.

Requires, kind of, but maybe not, the DAB patch https://github.com/ansible/django-ansible-base/pull/584