### PR TITLE
Skip failing DAB tests in GW

### DIFF
--- a/galaxy_ng/tests/integration/api/test_disable_shared_resources.py
+++ b/galaxy_ng/tests/integration/api/test_disable_shared_resources.py
@@ -31,6 +31,7 @@ def test_user(settings, galaxy_client):
     ]
 )
 @pytest.mark.deployment_standalone
+@pytest.mark.skip(reason="FIXME - skip until resource management is decided")
 def test_dab_groups_are_read_only(settings, galaxy_client, url, test_group):
     if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') in [None, True]:
         pytest.skip(reason="ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
@@ -106,6 +107,7 @@ def test_dab_users_are_read_only(settings, galaxy_client, url, test_user):
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.skip(reason="FIXME - skip until resource management is decided")
 def test_dab_cant_modify_group_memberships(settings, galaxy_client, test_user, test_group):
     if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') in [None, True]:
         pytest.skip(reason="ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
@@ -132,6 +134,7 @@ def test_dab_cant_modify_group_memberships(settings, galaxy_client, test_user, t
 
 
 @pytest.mark.deployment_standalone
+@pytest.mark.skip(reason="FIXME - skip until resource management is decided")
 def test_dab_can_modify_roles(settings, galaxy_client, test_user, test_group):
     if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') in [None, True]:
         pytest.skip(reason="ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")


### PR DESCRIPTION
Issue: [AAP-29891](https://issues.redhat.com/browse/AAP-29891)

Skip failing tests in gw:
```
test_dab_groups_are_read_only[_ui/v1/groups/]
test_dab_groups_are_read_only[pulp/api/v3/groups/]
test_dab_cant_modify_group_memberships
test_dab_can_modify_roles
```