### PR TITLE
Add communication details

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,29 +8,41 @@ This is a brand new take on Ansible Galaxy, so it will look and feel a bit diffe
 
 Our mission is to help organizations share Ansible automation and promote a culture of collaboration around Ansible automation development. We'll be providing features that make it easy to create, discover, use and distribute Ansible automation content.
 
-To see what we're currently working on, [view the Roadmap](/ROADMAP.rst). 
+To see what we're currently working on, [view the Roadmap](/ROADMAP.rst).
 
 To learn more about Pulp, [view the Pulp project page](https://pulpproject.org/).
 
 ## Documentation
 
-Project documentation is hosted on [Read The Docs](http://galaxy-ng.readthedocs.io/).
+Project documentation is hosted on [Read The Docs](https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/).
 
 ## OpenAPI Spec
 
-View the latest version of the spec at https://galaxy.ansible.com/api/v3/swagger-ui/. *(Directlink to [JSON](https://galaxy.ansible.com/api/v3/openapi.json) or [YAML](https://galaxy.ansible.com/api/v3/openapi.yaml))*
+View the latest version of the spec at <https://galaxy.ansible.com/api/v3/swagger-ui/>. *(Directlink to [JSON](https://galaxy.ansible.com/api/v3/openapi.json) or [YAML](https://galaxy.ansible.com/api/v3/openapi.yaml))*
+
+## Communication
+
+Refer to the [Communication](https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/overview/#communication)
+section of the Contributor Guide to find out how to get in touch with us.
+
+You can also find more information in the
+[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
 
 ## Contributing
 
 * If you're interested in jumping in and helping out, [view the contributing guide](https://github.com/ansible/galaxy_ng/wiki#contributing-to-galaxyng).
 * To setup your development environment, [view the development setup guide](https://github.com/ansible/galaxy_ng/wiki/Development-Setup).
-* Chat with us on irc.libera.chat: #ansible-galaxy
 * Found a bug or have a feature idea? Please [open an issue](https://issues.redhat.com/projects/AAH/issues).
+
+## Code of Conduct
+
+Please see the official
+[Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
 ## Installation
 
 To install and run a local GalaxyNG server [view the End User Installation guide](https://github.com/ansible/galaxy_ng/wiki/End-User-Installation).
 
-# License
+## License
 
 GNU General Public License v2. View [LICENSE](/LICENSE) for full text.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can also find more information in the
 ## Code of Conduct
 
 Please see the official
-[Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
+[Ansible Community Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html).
 
 ## Installation
 

--- a/docs/community/api_v3.md
+++ b/docs/community/api_v3.md
@@ -1,7 +1,8 @@
 # Galaxy V3 API 
 
 The following sections describe the API endpoints that are relevant to the Galaxy NG API.
-if you have questions or looking for help please post to the Matrix Channel `#galaxy:ansible.com` or IRC `#ansible-galaxy`
+if you have questions or looking for help please post to the [Ansible forum](https://forum.ansible.com/c/help/6)
+with the appropriate tags; for example, `ansible-galaxy` or `galaxy-ng`.
 
 ## Authentication
 

--- a/docs/community/devstack.md
+++ b/docs/community/devstack.md
@@ -6,7 +6,7 @@ As noted in the overview, GalaxyNG is considered a [pulp plugin](https://docs.pu
 
 Governance of the various projects has increasingly leaned towards writing less code in the galaxy_ng repository and more in the pulp_ansible repository. The code in the pulp_ansible repository is sufficiently generic to be usable for not only GalaxyNG but also as components in the Red Hat Satellite product. GalaxyNG is slowly turning into more of an "integration project" than a project with unique features. This pattern of where to write code has slightly diverged in the case of the api/v1 codebase because of differences in pulp_ansible's implementation that are incompatible with many of the roles indexed by [galaxy](https://galaxy.ansible.com).
 
-As a hopeful contributor, you may need to first figure out where to write code for a new feature or a bugfix. General guidance is to start any new enhancements for api/v3 in the pulp_ansible project. Anything for api/v1 is in the galaxy_ng project. If you aren't sure or can't figure out where the code should be, please reach out on the IRC channels and we'll help guide you.
+As a hopeful contributor, you may need to first figure out where to write code for a new feature or a bugfix. General guidance is to start any new enhancements for api/v3 in the pulp_ansible project. Anything for api/v1 is in the galaxy_ng project. If you aren't sure or can't figure out where the code should be, please reach out on the Ansible forum and we'll help guide you.
 
 
 ### Services

--- a/docs/community/devstack.md
+++ b/docs/community/devstack.md
@@ -6,7 +6,7 @@ As noted in the overview, GalaxyNG is considered a [pulp plugin](https://docs.pu
 
 Governance of the various projects has increasingly leaned towards writing less code in the galaxy_ng repository and more in the pulp_ansible repository. The code in the pulp_ansible repository is sufficiently generic to be usable for not only GalaxyNG but also as components in the Red Hat Satellite product. GalaxyNG is slowly turning into more of an "integration project" than a project with unique features. This pattern of where to write code has slightly diverged in the case of the api/v1 codebase because of differences in pulp_ansible's implementation that are incompatible with many of the roles indexed by [galaxy](https://galaxy.ansible.com).
 
-As a hopeful contributor, you may need to first figure out where to write code for a new feature or a bugfix. General guidance is to start any new enhancements for api/v3 in the pulp_ansible project. Anything for api/v1 is in the galaxy_ng project. If you aren't sure or can't figure out where the code should be, please reach out on the Ansible forum and we'll help guide you.
+As a hopeful contributor, you may need to first figure out where to write code for a new feature or a bugfix. General guidance is to start any new enhancements for api/v3 in the pulp_ansible project. Anything for api/v1 is in the galaxy_ng project. If you aren't sure or can't figure out where the code should be, please reach out on the [Ansible forum](https://docs.ansible.com/ansible/devel/community/communication.html) and we'll help guide you.
 
 
 ### Services

--- a/docs/community/overview.md
+++ b/docs/community/overview.md
@@ -47,24 +47,32 @@ the galaxy codebase and cooperatively plan to rehost https://galaxy.ansible.com 
 
 We do not yet have a timeline for the migration or the cut over. 
 
+## Communication
 
-## Communication and Feedback.
+Join the Ansible forum to ask questions, get help, and interact with the community.
 
-The galaxy dev team, contributors and community can mostly be found on libera.chat's #ansible-galaxy irc channel.
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions, for example the
+  `ansible-galaxy` or `galaxy-ng` tags.
+- [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
+  fellow enthusiasts.
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+  announcements including social events.
 
-For bug reports and feature requests, see "Filing Issues".
-
+To get release announcements and important changes from the community, see the
+[Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
 
 ## Filing Issues
 
-1. Go to https://issues.redhat.com/browse/AAH (can browse without login)
-2. Register for red hat account
-3. Click blue “Create” button at top of screen to get a dialog box for AAH project
-4. Set “Issue Type” to Bug or Task
-5. Set “Summary” (give it a title) & “Description”, and mention community
-6. Click “Create” at bottom of dialog box
+To submit bug reports and feature requests, do the following:
 
+1. Go to <https://issues.redhat.com/browse/AAH>.
+2. Register for a Red Hat account.
+3. Click the blue “Create” button to open a dialog box for the AAH project.
+4. Set the “Issue Type” to Bug or Task.
+5. Set “Summary” (give it a title) & “Description” and mention community.
+6. Click “Create” in the dialog box.
 
-## Creating PullRequests
+## Creating Pull Requests
 
 See the Community Development documentation.

--- a/docs/usage_guide/execution_environments.md
+++ b/docs/usage_guide/execution_environments.md
@@ -1,6 +1,6 @@
 # Execution Environments
 
-For information on how to use execution environments, please check out the [awx documentation](https://docs.ansible.com/automation-controller/latest/html/userguide/execution_environments.html).
+For information on how to use execution environments, please check out [Getting started with execution environments](https://docs.ansible.com/ansible/latest/getting_started_ee/index.html).
 
 Galaxy NG provides a container registry for pushing container images. It functions just like any other container registry and can be accessed with all the standardized container tools.
 


### PR DESCRIPTION
#### What is this PR doing:
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thanks!

Issue: AAP-27579

#### Reviewers must know:
n/a
