### PR TITLE
Workaround for broken pulp ci container builds

### DIFF
--- a/dev/playbooks/docker/BUILD.sh
+++ b/dev/playbooks/docker/BUILD.sh
@@ -15,7 +15,7 @@ chmod +x pulp-oci-images/images/assets/switch_python
 cd pulp-oci-images
 git apply ../py311.patch
 git apply ../rootless.patch
-git apply ../xz.patch
+git apply ../packages.patch
 
 docker build --file images/Containerfile.core.base --tag pulp/base:latest .
 docker build --file images/pulp_ci_centos/Containerfile --tag pulp/pulp-ci-centos9:latest .

--- a/dev/playbooks/docker/BUILD.sh
+++ b/dev/playbooks/docker/BUILD.sh
@@ -9,11 +9,15 @@ cd pulp-oci-images
 git reset --hard
 cd ..
 
+# exit 1
+
 cp -f switch_python pulp-oci-images/images/assets/.
 chmod +x pulp-oci-images/images/assets/switch_python
 
 cd pulp-oci-images
 git apply ../py311.patch
+git apply ../rootless.patch
+git apply ../xz.patch
 
 docker build --file images/Containerfile.core.base --tag pulp/base:latest .
 docker build --file images/pulp_ci_centos/Containerfile --tag pulp/pulp-ci-centos9:latest .

--- a/dev/playbooks/docker/BUILD.sh
+++ b/dev/playbooks/docker/BUILD.sh
@@ -9,8 +9,6 @@ cd pulp-oci-images
 git reset --hard
 cd ..
 
-# exit 1
-
 cp -f switch_python pulp-oci-images/images/assets/.
 chmod +x pulp-oci-images/images/assets/switch_python
 

--- a/dev/playbooks/docker/packages.patch
+++ b/dev/playbooks/docker/packages.patch
@@ -6,7 +6,7 @@ index 559ad3f..621ca6b 100644
  ARG FROM_TAG="latest"
  FROM pulp/base:${FROM_TAG}
  # https://ryandaniels.ca/blog/docker-dockerfile-arg-from-arg-trouble/
-+RUN dnf -y install xz
++RUN dnf -y install xz which gettext jq sudo
  
  RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-x86_64.tar.xz | tar xvJ -C /
  RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-noarch.tar.xz | tar xvJ -C /

--- a/dev/playbooks/docker/rootless.patch
+++ b/dev/playbooks/docker/rootless.patch
@@ -1,0 +1,13 @@
+diff --git a/images/Containerfile.core.base b/images/Containerfile.core.base
+index e85a8ab..4c0e9b5 100644
+--- a/images/Containerfile.core.base
++++ b/images/Containerfile.core.base
+@@ -79,7 +79,7 @@ RUN useradd -d /var/lib/pulp --system -u 700 -g pulp pulp
+ 
+ # Rootless podman inside rootless podman/docker
+ # https://www.redhat.com/sysadmin/podman-inside-container
+-RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
++# RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
+ # We modified the example so that we have a UID range of upto 65535.
+ # Because, for example, the image docker.io/library/busybox actually uses the user nobody(65534) for
+ # /home rather than the traditional nobody/nfsnbody usage (not an owner on a permanent filesystem.)

--- a/dev/playbooks/docker/xz.patch
+++ b/dev/playbooks/docker/xz.patch
@@ -1,0 +1,12 @@
+diff --git a/images/pulp_ci_centos/Containerfile b/images/pulp_ci_centos/Containerfile
+index 559ad3f..621ca6b 100644
+--- a/images/pulp_ci_centos/Containerfile
++++ b/images/pulp_ci_centos/Containerfile
+@@ -1,6 +1,7 @@
+ ARG FROM_TAG="latest"
+ FROM pulp/base:${FROM_TAG}
+ # https://ryandaniels.ca/blog/docker-dockerfile-arg-from-arg-trouble/
++RUN dnf -y install xz
+ 
+ RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-x86_64.tar.xz | tar xvJ -C /
+ RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-noarch.tar.xz | tar xvJ -C /


### PR DESCRIPTION
The pulp oci containerfiles are broken for various reasons.