### PR TITLE
More test GW skipping

### DIFF
--- a/galaxy_ng/tests/integration/api/test_auth.py
+++ b/galaxy_ng/tests/integration/api/test_auth.py
@@ -132,6 +132,7 @@ def test_gateway_token_auth(galaxy_client):
 
 @pytest.mark.deployment_standalone
 @pytest.mark.skip_in_gw
+@pytest.mark.skipif(not aap_gateway(), reason="This test can't run if AAP Gateway is deployed")
 def test_ui_login_csrftoken(galaxy_client):
     if is_keycloak():
         pytest.skip("This test is not valid for keycloak")

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -639,7 +639,7 @@ def test_group_sync_from_pulp_to_dab(galaxy_client, assert_user_in_group, user_a
     gc.patch(f"_ui/v2/users/{user['id']}/", body={"groups": old_groups})
     assert_user_in_group(user["id"], group["id"], expected=False)
 
-
+@pytest.mark.skip(reason="FIXME - skip until resource management is decided")
 def test_team_member_sync_from_dab_to_pulp(galaxy_client, assert_user_in_group, user_and_group):
     gc = galaxy_client("admin")
     user, group = user_and_group

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -639,6 +639,7 @@ def test_group_sync_from_pulp_to_dab(galaxy_client, assert_user_in_group, user_a
     gc.patch(f"_ui/v2/users/{user['id']}/", body={"groups": old_groups})
     assert_user_in_group(user["id"], group["id"], expected=False)
 
+
 @pytest.mark.skip(reason="FIXME - skip until resource management is decided")
 def test_team_member_sync_from_dab_to_pulp(galaxy_client, assert_user_in_group, user_and_group):
     gc = galaxy_client("admin")

--- a/galaxy_ng/tests/integration/dab/test_ui_v2.py
+++ b/galaxy_ng/tests/integration/dab/test_ui_v2.py
@@ -228,7 +228,7 @@ def test_ui_v2_teams(
     assert team["name"] == team_name
 
     # Check that associated group exists
-    group = client.get(f"_ui/v1/groups/{team['group']['id']}")
+    group = client.get(f"_ui/v1/groups/{team['group']['id']}", relogin=False)
     assert group["id"] == team["group"]["id"]
     assert group["name"] == f"Default::{team_name}"
 

--- a/galaxy_ng/tests/integration/dab/test_ui_v2.py
+++ b/galaxy_ng/tests/integration/dab/test_ui_v2.py
@@ -228,7 +228,7 @@ def test_ui_v2_teams(
     assert team["name"] == team_name
 
     # Check that associated group exists
-    group = client.get(f"_ui/v1/groups/{team['group']['id']}", relogin=False)
+    group = client.get(f"_ui/v1/groups/{team['group']['id']}/")
     assert group["id"] == team["group"]["id"]
     assert group["name"] == f"Default::{team_name}"
 
@@ -243,7 +243,7 @@ def test_ui_v2_teams(
 
     # Check that associated group does not exist
     with pytest.raises(GalaxyClientError) as ctx:
-        client.get(f"_ui/v1/groups/{team['group']['id']}")
+        client.get(f"_ui/v1/groups/{team['group']['id']}/")
     assert ctx.value.response.status_code == HTTPStatus.NOT_FOUND
 
 


### PR DESCRIPTION
No-Issue

Skip in GW:
- `test_ui_login_csrftoken`: [AAP-29887](https://issues.redhat.com/browse/AAP-29887)
- `test_team_member_sync_from_dab_to_pulp` 

Fix:
- `requests.exceptions.HTTPError: 401 Client Error: Unauthorized` for `test_ui_v2_teams`