### PR TITLE
enable middleware to log traceback on timeout

### DIFF
--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -99,6 +99,7 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',
     'django_guid.middleware.guid_middleware',
     'pulpcore.middleware.DomainMiddleware',
+    'ansible_base.lib.middleware.logging.log_request.LogTracebackMiddleware',
     # END: Pulp standard middleware
     'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]


### PR DESCRIPTION

#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
gunicorn sends a signal 6 when it is about to timeout a request This middleware handles that request and logs a traceback.

this aids in debugging infrastructure issues that may be causing requests to timeout.


<!-- Add Jira issue link or replace with No-Issue -->
Issue: https://issues.redhat.com/browse/AAP-29982 (caused by https://issues.redhat.com/browse/AAP-27692 )
#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->
To test manually, change gunicorn timeout to much lower value and add sleep in a view
See django-ansible-base notes https://github.com/ansible/django-ansible-base/blob/2af5f34dd4887eeba65f48e01e488745e90f8f04/docs/logging.md?plain=1#L56-L70


**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
