### PR TITLE
Add CI upload junit xml test results

### DIFF
--- a/.github/workflows/ci_full.yml
+++ b/.github/workflows/ci_full.yml
@@ -101,6 +101,7 @@ jobs:
         run: cd dev/playbooks; ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i 'localhost,' --forks=1 -v run_unit_tests.yaml
 
       - name: upload jUnit XML test results
+        if: github.event_name == 'push' && github.repository == 'ansible/galaxy_ng' && github.ref_name == 'master'
         continue-on-error: true
         run: >-
           curl -v --user "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"

--- a/.github/workflows/ci_full.yml
+++ b/.github/workflows/ci_full.yml
@@ -104,12 +104,12 @@ jobs:
         if: github.event_name == 'push' && github.repository == 'ansible/galaxy_ng' && github.ref_name == 'master'
         continue-on-error: true
         run: >-
-          curl -v --user "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"
+          docker exec pulp /bin/bash -c 'curl -v --user "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"
           --form "xunit_xml=@/tmp/galaxy_ng-test-results.xml"
           --form "component_name=hub"
           --form "git_commit_sha=${{ github.sha }}"
           --form "git_repository_url=https://github.com/${{ github.repository }}"
-          "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}/api/results/upload/"
+          "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}/api/results/upload/"'
 
 
       # FIXME: do we really care about these anymore ... ?

--- a/.github/workflows/ci_full.yml
+++ b/.github/workflows/ci_full.yml
@@ -100,6 +100,17 @@ jobs:
       - name: run the unit test playbook
         run: cd dev/playbooks; ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i 'localhost,' --forks=1 -v run_unit_tests.yaml
 
+      - name: upload jUnit XML test results
+        continue-on-error: true
+        run: >-
+          curl -v --user "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"
+          --form "xunit_xml=@/tmp/galaxy_ng-test-results.xml"
+          --form "component_name=hub"
+          --form "git_commit_sha=${{ github.sha }}"
+          --form "git_repository_url=https://github.com/${{ github.repository }}"
+          "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}/api/results/upload/"
+
+
       # FIXME: do we really care about these anymore ... ?
       #- name: run the functional test playbook
       #  run: cd dev/playbooks; ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i 'localhost,' --forks=1 -v run_functional_tests.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+galaxy_ng-test-results.xml
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-galaxy_ng-test-results.xml
 
 # Translations
 *.mo

--- a/dev/playbooks/files/run_units.sh
+++ b/dev/playbooks/files/run_units.sh
@@ -21,6 +21,7 @@ PYTEST_FLAGS=""
 PYTEST_FLAGS="$PYTEST_FLAGS --cov-report term-missing:skip-covered --cov=galaxy_ng"
 PYTEST_FLAGS="$PYTEST_FLAGS -v -r sx --color=yes"
 PYTEST_FLAGS="$PYTEST_FLAGS -p no:pulpcore"
+PYTEST_FLAGS="$PYTEST_FLAGS --junit-xml=/tmp/galaxy_ng-test-results.xml"
 
 # This command will run all unit tests in galaxy_ng/tests/unit.
 # If you need to run a single test, include '-k <substring>' in the PYTEST_FLAGS variable


### PR DESCRIPTION
This PR adds storing Hub unit test results in jUnit XML file when the test are running and then uploading them to the platform readiness dashboard.

Issue: [issues.redhat.com/browse/AAP-29787](https://issues.redhat.com/browse/AAP-29787)

Documentation: [handbook.eng.ansible.com/docs/Testing/xunit-junit](https://handbook.eng.ansible.com/docs/Testing/xunit-junit)

copy-pasted from https://github.com/ansible/aap-gateway/pull/527 

