### PR TITLE
Add back service-mesh network to have reverse sync work

### DIFF
--- a/aap_compose_dev.yaml
+++ b/aap_compose_dev.yaml
@@ -148,6 +148,9 @@ services:
       <<: *common-env
     extra_hosts:
       localhost: "host-gateway"
+    networks:
+      - default
+      - service-mesh
     command: |
       bash -c "
         while [[ ! -f /var/lib/pulp/.migrated ]]; do
@@ -171,6 +174,9 @@ services:
       <<: *common-env
     extra_hosts:
       localhost: "host-gateway"
+    networks:
+      - default
+      - service-mesh
     command: |
       bash -c "
         while [[ ! -f /var/lib/pulp/.migrated ]]; do
@@ -220,7 +226,6 @@ volumes:
   etc_pulp_certs:
     name: etc_pulp_certs 
 
-#networks:
-#  dbnet:
-#  service-mesh:
-#    name: service-mesh
+networks:
+  service-mesh:
+    name: service-mesh


### PR DESCRIPTION
#### What is this PR doing:
Changes error:

```
$ docker exec -it galaxy_ng-api-1 django-admin resource_sync
----- RESOURCE SYNC STARTED -----

>>> shared.organization
2024-09-24 20:06:58,145 INFO ansible_base.resources_api.rest_client: Making get request to https://aap-gw-proxy-1:9080/api/gateway/v1/service-index/metadata/.
Traceback (most recent call last):
  File "/venv/lib64/python3.11/site-packages/urllib3/connection.py", line 196, in _new_conn
    sock = connection.create_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/urllib3/util/connection.py", line 60, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/socket.py", line 962, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno -2] Name or service not known

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/venv/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 789, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 490, in _make_request
    raise new_e
  File "/venv/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 466, in _make_request
    self._validate_conn(conn)
  File "/venv/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 1095, in _validate_conn
    conn.connect()
  File "/venv/lib64/python3.11/site-packages/urllib3/connection.py", line 615, in connect
    self.sock = sock = self._new_conn()
                       ^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/urllib3/connection.py", line 203, in _new_conn
    raise NameResolutionError(self.host, self, e) from e
urllib3.exceptions.NameResolutionError: <urllib3.connection.HTTPSConnection object at 0x7fd02df49950>: Failed to resolve 'aap-gw-proxy-1' ([Errno -2] Name or service not known)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/venv/lib64/python3.11/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 843, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/urllib3/util/retry.py", line 519, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='aap-gw-proxy-1', port=9080): Max retries exceeded with url: /api/gateway/v1/service-index/metadata/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7fd02df49950>: Failed to resolve 'aap-gw-proxy-1' ([Errno -2] Name or service not known)"))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/venv/bin/django-admin", line 8, in <module>
    sys.exit(execute_from_command_line())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/venv/lib64/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/venv/lib64/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/venv/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/management/commands/resource_sync.py", line 80, in handle
    executor.run()
  File "/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/tasks/sync.py", line 373, in run
    manifest_list = fetch_manifest(resource_type_name, api_client=self.api_client)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/tasks/sync.py", line 85, in fetch_manifest
    resp_metadata = api_client.get_service_metadata()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/rest_client.py", line 133, in get_service_metadata
    return self._make_request("get", "metadata/")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/rest_client.py", line 110, in _make_request
    resp = requests.request(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/requests/adapters.py", line 519, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='aap-gw-proxy-1', port=9080): Max retries exceeded with url: /api/gateway/v1/service-index/metadata/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7fd02df49950>: Failed to resolve 'aap-gw-proxy-1' ([Errno -2] Name or service not known)"))
```

to this error which is closer to functioning.

```
$ docker exec -it galaxy_ng-api-1 django-admin resource_sync
----- RESOURCE SYNC STARTED -----

>>> shared.organization
2024-09-24 20:24:09,154 INFO ansible_base.resources_api.rest_client: Making get request to https://aap-gw-proxy-1:9080/api/gateway/v1/service-index/metadata/.
Traceback (most recent call last):
  File "/venv/bin/django-admin", line 8, in <module>
    sys.exit(execute_from_command_line())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/venv/lib64/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/venv/lib64/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/venv/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/management/commands/resource_sync.py", line 80, in handle
    executor.run()
  File "/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/tasks/sync.py", line 373, in run
    manifest_list = fetch_manifest(resource_type_name, api_client=self.api_client)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/ansible_base/resource_registry/tasks/sync.py", line 86, in fetch_manifest
    resp_metadata.raise_for_status()
  File "/venv/lib64/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://aap-gw-proxy-1:9080/api/gateway/v1/service-index/metadata/
```


Issue: None

#### Reviewers must know:
testing is done with aap-dev
