### PR TITLE
Keycloak prefix setting rename

### DIFF
--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -99,7 +99,13 @@ def configure_keycloak(settings: Dynaconf) -> Dict[str, Any]:
     KEYCLOAK_PORT = settings.get("KEYCLOAK_PORT", default=None)
     KEYCLOAK_REALM = settings.get("KEYCLOAK_REALM", default=None)
 
-    KEYCLOAK_AUTH_PREFIX = settings.get("KEYCLOAK_AUTH_PREFIX", default="")
+    # https://www.keycloak.org/server/all-config
+    #   In prior versions of keycloak, the auth and token url paths began
+    #   with /auth. In newer versions, that substring no longer exists.
+    #   There is a setting which can re-add that substring to make
+    #   a newer system operate similar to the old.
+    KEYCLOAK_KC_HTTP_RELATIVE_PATH = settings.get("KEYCLOAK_KC_HTTP_RELATIVE_PATH", default="")
+
     SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = \
         settings.get("SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL", default=None)
     SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL = \
@@ -129,13 +135,13 @@ def configure_keycloak(settings: Dynaconf) -> Dict[str, Any]:
         data["KEYCLOAK_HOST_LOOPBACK"] = settings.get("KEYCLOAK_HOST_LOOPBACK", default=None)
         data["KEYCLOAK_URL"] = f"{KEYCLOAK_PROTOCOL}://{KEYCLOAK_HOST}:{KEYCLOAK_PORT}"
 
-        auth_url_str = "{keycloak}/{prefix}realms/{realm}/protocol/openid-connect/auth/"
+        auth_url_str = "{keycloak}{prefix}/realms/{realm}/protocol/openid-connect/auth/"
 
         if SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL is not None:
             data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] = SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL
         else:
             data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] = auth_url_str.format(
-                keycloak=data["KEYCLOAK_URL"], realm=KEYCLOAK_REALM, prefix=KEYCLOAK_AUTH_PREFIX
+                keycloak=data["KEYCLOAK_URL"], realm=KEYCLOAK_REALM, prefix=KEYCLOAK_KC_HTTP_RELATIVE_PATH
             )
 
             if data["KEYCLOAK_HOST_LOOPBACK"]:
@@ -145,7 +151,7 @@ def configure_keycloak(settings: Dynaconf) -> Dict[str, Any]:
                     port=KEYCLOAK_PORT
                 )
                 data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] = auth_url_str.format(
-                    keycloak=loopback_url, realm=KEYCLOAK_REALM, prefix=KEYCLOAK_AUTH_PREFIX
+                    keycloak=loopback_url, realm=KEYCLOAK_REALM, prefix=KEYCLOAK_KC_HTTP_RELATIVE_PATH
                 )
 
         if SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL is not None:
@@ -154,7 +160,7 @@ def configure_keycloak(settings: Dynaconf) -> Dict[str, Any]:
             data[
                 "SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL"
             ] = (
-                f"{data['KEYCLOAK_URL']}/{KEYCLOAK_AUTH_PREFIX}realms/"
+                f"{data['KEYCLOAK_URL']}{KEYCLOAK_KC_HTTP_RELATIVE_PATH}/realms/"
                 f"{KEYCLOAK_REALM}/protocol/openid-connect/token/"
             )
 

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -141,7 +141,9 @@ def configure_keycloak(settings: Dynaconf) -> Dict[str, Any]:
             data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] = SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL
         else:
             data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] = auth_url_str.format(
-                keycloak=data["KEYCLOAK_URL"], realm=KEYCLOAK_REALM, prefix=KEYCLOAK_KC_HTTP_RELATIVE_PATH
+                keycloak=data["KEYCLOAK_URL"],
+                realm=KEYCLOAK_REALM,
+                prefix=KEYCLOAK_KC_HTTP_RELATIVE_PATH
             )
 
             if data["KEYCLOAK_HOST_LOOPBACK"]:
@@ -151,7 +153,9 @@ def configure_keycloak(settings: Dynaconf) -> Dict[str, Any]:
                     port=KEYCLOAK_PORT
                 )
                 data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] = auth_url_str.format(
-                    keycloak=loopback_url, realm=KEYCLOAK_REALM, prefix=KEYCLOAK_KC_HTTP_RELATIVE_PATH
+                    keycloak=loopback_url,
+                    realm=KEYCLOAK_REALM,
+                    prefix=KEYCLOAK_KC_HTTP_RELATIVE_PATH
                 )
 
         if SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL is not None:

--- a/galaxy_ng/tests/unit/app/test_dynaconf_hooks.py
+++ b/galaxy_ng/tests/unit/app/test_dynaconf_hooks.py
@@ -369,7 +369,7 @@ def test_dynaconf_hooks_authentication_backends_and_classes(
         (
             True,
             {
-                "KEYCLOAK_AUTH_PREFIX": "auth/",
+                "KEYCLOAK_KC_HTTP_RELATIVE_PATH": "/auth",
                 "KEYCLOAK_PROTOCOL": "http",
                 "GALAXY_TOKEN_EXPIRATION": 0,
             },


### PR DESCRIPTION
This variable name better matches the related keycloak setting and should be less cognitive load on sysadmins.

https://www.keycloak.org/server/all-config

![image](https://github.com/user-attachments/assets/8e7d9d36-3f31-4ef9-9e35-de863c3043b0)
