### PR TITLE
Skip signing tests in gw

### DIFF
--- a/galaxy_ng/tests/integration/api/test_artifact_download.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_download.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 # TODO Refactor get_client to provide access to bearer token
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.deployment_standalone
 @pytest.mark.installer_smoke_test
 def test_download_artifact(ansible_config, galaxy_client):

--- a/galaxy_ng/tests/integration/api/test_artifact_upload.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_upload.py
@@ -275,6 +275,8 @@ def test_long_field_values(galaxy_client, field):
     assert fieldname in resp["error"]["description"]
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.parametrize(
     "spec",
     [

--- a/galaxy_ng/tests/integration/api/test_collection_delete.py
+++ b/galaxy_ng/tests/integration/api/test_collection_delete.py
@@ -43,6 +43,8 @@ def test_delete_collection(galaxy_client, uncertifiedv2):
             get_collection(gc, cnamespace, cname, ckey[2])
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.galaxyapi_smoke
 @pytest.mark.delete
 @pytest.mark.collection_version_delete
@@ -88,6 +90,8 @@ def test_delete_collection_version(galaxy_client, uncertifiedv2):
             get_collection(gc, cnamespace, cname, ckey[2])
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.delete
 @pytest.mark.min_hub_version("4.7dev")
 @pytest.mark.all

--- a/galaxy_ng/tests/integration/api/test_collection_signing.py
+++ b/galaxy_ng/tests/integration/api/test_collection_signing.py
@@ -69,6 +69,8 @@ def sign_on_demand(gc, signing_service, sign_url=None, **payload):
     return resp
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.collection_signing
 @pytest.mark.collection_move
 @pytest.mark.deployment_standalone
@@ -141,6 +143,8 @@ def test_collection_auto_sign_on_approval(ansible_config, flags, galaxy_client, 
     assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.collection_signing
 @pytest.mark.deployment_standalone
 @pytest.mark.parametrize(
@@ -328,6 +332,8 @@ def test_collection_move_with_signatures(ansible_config, flags, galaxy_client, s
     assert metadata["signatures"][0]["pubkey_fingerprint"] is not None
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.collection_signing
 @pytest.mark.collection_move
 @pytest.mark.deployment_standalone

--- a/galaxy_ng/tests/integration/api/test_container_push_update.py
+++ b/galaxy_ng/tests/integration/api/test_container_push_update.py
@@ -14,6 +14,8 @@ from galaxy_ng.tests.integration.utils.iqe_utils import pull_and_tag_test_image
 from galaxykit.utils import wait_for_task
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.deployment_standalone
 @pytest.mark.min_hub_version("4.7.1")
 @pytest.mark.min_hub_version("4.6.6")

--- a/galaxy_ng/tests/integration/api/test_cross_repository_search.py
+++ b/galaxy_ng/tests/integration/api/test_cross_repository_search.py
@@ -4,6 +4,8 @@ from galaxykit.repositories import search_collection
 from ..utils import get_client, SocialGithubClient
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.min_hub_version("4.7dev")
 @pytest.mark.all
 def test_x_repo_search_acl_basic_user(uncertifiedv2, galaxy_client,

--- a/galaxy_ng/tests/integration/api/test_move.py
+++ b/galaxy_ng/tests/integration/api/test_move.py
@@ -18,6 +18,8 @@ from ..utils.iqe_utils import is_ocp_env
 pytestmark = pytest.mark.qa  # noqa: F821
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.galaxyapi_smoke
 @pytest.mark.certification
 @pytest.mark.collection_move

--- a/galaxy_ng/tests/integration/api/test_ui_paths_gateway.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths_gateway.py
@@ -78,6 +78,8 @@ def test_gw_api_ui_v1_collection_versions(galaxy_client, uncertifiedv2):
         validate_json(instance=cv_resp['metadata'], schema=schema_collectionversion_metadata)
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.deployment_standalone
 @pytest.mark.api_ui
 @pytest.mark.skipif(not aap_gateway(), reason="This test only runs if AAP Gateway is deployed")

--- a/galaxy_ng/tests/integration/api/test_x_repo_search.py
+++ b/galaxy_ng/tests/integration/api/test_x_repo_search.py
@@ -400,6 +400,8 @@ class TestXRepoSearch:
         expected = [{"repo_name": test_repo_name, "cv_name": artifact.name, "cv_version": version}]
         assert verify_repo_data(expected, results)
 
+    # FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+    @pytest.mark.skip_in_gw
     @pytest.mark.parametrize("is_highest,cv_version", [(True, "4.0.2"), (False, "4.0.1")])
     @pytest.mark.x_repo_search
     def test_search_is_highest_true_false(self, galaxy_client, is_highest, cv_version):

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac.py
@@ -140,6 +140,8 @@ def test_dab_rbac_repository_owner_by_user_or_team(
     assert result['state'] == 'completed'
 
 
+# FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
+@pytest.mark.skip_in_gw
 @pytest.mark.deployment_standalone
 @pytest.mark.min_hub_version("4.10dev")
 @pytest.mark.skipif(


### PR DESCRIPTION
Related issue: [AAP-32015](https://issues.redhat.com/browse/AAP-32015)

Mark signing tests  with `skip_in_gw` as they fail in `rpm-b` topology.


lint-po failed with
```
1s
Run pip3 install lint-po
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.[1](https://github.com/ansible/galaxy_ng/actions/runs/11253309325/job/31288294303?pr=2296#step:3:1)2/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/ansible/galaxy_ng/actions/runs/11253309325/job/31288294303?pr=2296#step:3:7)68 for the detailed specification.
Error: Process completed with exit code 1.
```
fixed by
```
      - uses: actions/setup-python@v4
        with:
          python-version: "3.11"
```
