### PR TITLE
Update gitlaks to indicate the new keys are safe to expose

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,5 +4,8 @@
     "openshift/clowder/clowd-app.yaml",
     "dev/Dockerfile.base",
     "dev/standalone-ldap/galaxy_ng.env",
-    "galaxy_ng/tests"
+    "galaxy_ng/tests",
+    "/dev/compose/signing/signing-secret.key",
+    "/dev/compose/signing/signing-secret.key.password.txt",
+    "/dev/compose/"
   ]


### PR DESCRIPTION
The keys are for development and testing only
