### PR TITLE
ci: fix lint-po workflow error

### DIFF
--- a/.github/workflows/ci_full.yml
+++ b/.github/workflows/ci_full.yml
@@ -18,9 +18,13 @@ jobs:
           ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
           fetch-depth: 0  # include all history
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
       - name: intsall and run lint-po
         run: |
-          pip install lint-po
+          pip3.11 install lint-po
           lint-po ./galaxy_ng/locale/*/LC_MESSAGES/*.po
 
   lint:


### PR DESCRIPTION
Default GHA image now installs and set as default python 3.12 on CI, we need to force a checkout to a python version that is not managed by the system or use a venv

this was the error

```
Run pip install lint-po
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/ansible/galaxy_ng/actions/runs/11260746667/job/31312642073?pr=2299#step:3:7)68 for the detailed specification.
```