### PR TITLE
dev: if DEV_SOURCE_PATH is undefined run without reloader.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,10 @@ db_snapshots/
 
 # oci-env profile files
 .compiled/
+
+
+# The compose containers runs with /app as home folder
+# So every command executed on container shell is saved to .bash_history
+# this is convenient to save history between container runs
+# but we don't want it on the repo
+.bash_history

--- a/dev/compose/README.md
+++ b/dev/compose/README.md
@@ -135,7 +135,7 @@ $ git clone https://github.com/ansible/galaxy_ng ~/projects/galaxy_ng
 ```
 
 > **IMPORTANT** Ensure all the repos are checked out to compatible branches.
-> for example. you may be on galaxy_ng:master and checking out `setup.py` you
+> for example. you may be on galaxy_ng:master and reading `setup.py` you
 > see that it requires `pulp_ansible>2.10,<3` then ensure you checkout `pulp_ansible`
 > to a compatible branch.
 
@@ -158,6 +158,33 @@ $ DEV_SOURCE_PATH="dynaconf:pulp_ansible:galaxy_ng" docker compose -f dev/compos
 
 Now when changes are detected on `.py` and `.yaml` files on any of the `DEV_SOURCE_PATH`
 directories it will trigger reload of `api`, `worker`, and `content` services.
+
+
+## Troubleshooting
+
+### VersionConflict error
+
+Example:
+```bash
+api-1         |    raise VersionConflict(dist, req).with_context(dependent_req)
+api-1         | pkg_resources.VersionConflict: (pkg_foo 3.2.6 (/venv/lib/python3.11/site-packages), Requirement.parse('pkg_foo<3.1.13,>=3.1.12'))
+```
+
+Solution 1:
+Clean up local build files:
+
+```bash
+cd ~/projects/galaxy_ng
+rm -rf .eggs
+rm -rf build
+rm -rf galaxy_ng.egg-info
+```
+
+Solution 2:
+
+- Ensure `LOCK_REQUIREMENTS` is set to `0`
+- Ensure all your local checkouts are checked out to compatible branches
+
 
 ## Tips and Tricks.
 

--- a/dev/compose/aap.yaml
+++ b/dev/compose/aap.yaml
@@ -77,7 +77,7 @@ x-common-env: &common-env
   # "dynaconf:pulpcore:galaxy_importer:pulp_ansible:pulp_container:galaxy_ng:django-ansible-base"
   # This can be done as part of the `docker compose` call:
   # $ DEV_SOURCE_PATH="pulp_container:galaxy_ng" docker compose -f dev/compose/aap.yaml up
-  DEV_SOURCE_PATH: ${DEV_SOURCE_PATH:-""}
+  DEV_SOURCE_PATH:
 
 
 services:
@@ -114,6 +114,7 @@ services:
       - "etc_pulp_certs:/etc/pulp/certs"
       - "var_lib_pulp:/var/lib/pulp"
       - "../../../:/src"
+      - "../../:/app"
     command: |
       bash -c "
         echo 'Moving required files to the required places.';
@@ -149,6 +150,7 @@ services:
       - "etc_pulp_certs:/etc/pulp/certs"
       - "var_lib_pulp:/var/lib/pulp"
       - "../../../:/src"
+      - "../../:/app"
     environment:
       <<: *common-env
     user: root
@@ -179,6 +181,7 @@ services:
       - "etc_pulp_certs:/etc/pulp/certs"
       - "var_lib_pulp:/var/lib/pulp"
       - "../../../:/src"
+      - "../../:/app"
     environment:
       <<: *common-env
     extra_hosts:
@@ -206,6 +209,7 @@ services:
       - "etc_pulp_certs:/etc/pulp/certs"
       - "var_lib_pulp:/var/lib/pulp"
       - "../../../:/src"
+      - "../../:/app"
     environment:
       <<: *common-env
     extra_hosts:
@@ -233,6 +237,7 @@ services:
       - "etc_pulp_certs:/etc/pulp/certs"
       - "var_lib_pulp:/var/lib/pulp"
       - "../../../:/src"
+      - "../../:/app"
     environment:
       <<: *common-env
     user: root
@@ -261,6 +266,7 @@ services:
       - "etc_pulp_certs:/etc/pulp/certs"
       - "var_lib_pulp:/var/lib/pulp"
       - "../../../:/src"
+      - "../../:/app"
     environment:
       <<: *common-env
     user: root
@@ -276,7 +282,7 @@ services:
         # Schedule resource sync if enabled;
         /src/galaxy_ng/dev/compose/dab/schedule_resource_sync.sh;
         echo 'Scheduled tasks';
-        curl -s -u admin:admin http://api:24817/api/galaxy/pulp/api/v3/task-schedules/?name=dab_sync | python -m json.tool;
+        curl -s -u $$DJANGO_SUPERUSER_USERNAME:$$DJANGO_SUPERUSER_PASSWORD http://api:24817/api/galaxy/pulp/api/v3/task-schedules/?name=dab_sync | python -m json.tool;
 
         # Keys are needed to register signing services;
         /src/galaxy_ng/dev/compose/signing/setup_gpg_keys.sh;
@@ -285,7 +291,7 @@ services:
         # Setup signing services;
         /src/galaxy_ng/dev/compose/signing/setup_signing_services.sh;
         echo 'Signing Services';
-        curl -s -u admin:admin http://api:24817/api/galaxy/pulp/api/v3/signing-services/?fields=name,script,pubkey_fingerprint | python -m json.tool;
+        curl -s -u $$DJANGO_SUPERUSER_USERNAME:$$DJANGO_SUPERUSER_PASSWORD http://api:24817/api/galaxy/pulp/api/v3/signing-services/?fields=name,script,pubkey_fingerprint | python -m json.tool;
 
         # Setup repository gpgkey for upload verification;
         /src/galaxy_ng/dev/compose/signing/setup_repo_keyring.sh;
@@ -296,12 +302,17 @@ services:
         echo ' ';
         echo '###################### API ROOT ##############################';
         curl -s http://api:24817/api/galaxy/ | python -m json.tool;
-
+        echo '################### DEV_SOURCE_PATH ##########################';
+        echo $$DEV_SOURCE_PATH;
+        echo ' ';
         echo '######################## READY ###############################';
         echo ' ';
-        echo 'API: http://localhost:5001/api/galaxy/v3/swagger-ui/';
-        echo 'Django Admin CLI: docker compose -f dev/compose/aap.yaml exec manager pulpcore-manager';
-        echo 'Settings list: docker compose -f ... exec manager dynaconf list';
+        echo 'Credentials:  ' $$DJANGO_SUPERUSER_USERNAME:$$DJANGO_SUPERUSER_PASSWORD;
+        echo 'API Spec:      http://localhost:5001/api/galaxy/v3/swagger-ui/';
+        echo 'Django Admin:  docker compose -f dev/compose/aap.yaml exec manager pulpcore-manager';
+        echo 'Settings list: docker compose -f dev/compose/aap.yaml exec manager dynaconf list';
+        echo 'Docs:          https://github.com/ansible/galaxy_ng/blob/master/dev/compose/README.md';
+        echo '##############################################################';
 
         # Keep it running indefinitely to enable `docker compose -f ... exec manager /bin/bash`;
         tail -f /dev/null

--- a/dev/compose/bin/reloader
+++ b/dev/compose/bin/reloader
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-# List all files in the DEV_SOURCE_PATH and watch for changes and use entr to SIGKILL + restart
-echo "Watching file changes on $DEV_SOURCE_PATH"
-
-find $(echo $DEV_SOURCE_PATH | tr ':' '\n' | while read item; do echo -n /src/$item\ ; done) \( -path /src/galaxy_ng/.venv -o -path /src/galaxy_ng/build -o -path /src/galaxy_ng/.eggs \) -prune -o -name '*.py' -o -name '*.yaml' | /src/galaxy_ng/dev/compose/bin/entr -n -r timeout -k 5 0 $1
+if [ -z "${DEV_SOURCE_PATH}" ]; then
+    echo "DEV_SOURCE_PATH is not defined, running without reload."
+    $1
+else
+    # List all files in the DEV_SOURCE_PATH and watch for changes and use entr to SIGKILL + restart
+    echo "Watching file changes on $DEV_SOURCE_PATH"
+    find $(echo $DEV_SOURCE_PATH | tr ':' '\n' | while read item; do echo -n /src/$item\ ; done) \( -path /src/galaxy_ng/.venv -o -path /src/galaxy_ng/build -o -path /src/galaxy_ng/.eggs \) -prune -o -name '*.py' -o -name '*.yaml' | /src/galaxy_ng/dev/compose/bin/entr -n -r timeout -k 5 0 $1
+fi


### PR DESCRIPTION
- If DEV_SOURCE_PATH is not defined run without reloader to save resources
- Fixed reloader to actually take the changes, it was missing `/app` mount point
- Added troubleshooting section to README


TIL:

If you leave an undefined variable on compose yaml, docker compose will try to read from external environment, if not found it will just leave as undefined, so `DEV_SOURCE_PATH: ${DEV_SOURCE_PATH}` is not required, we can just do `DEV_SOURCE_PATH:`