### PR TITLE
Move tox.ini out of pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,4 +25,5 @@ include galaxy-operator/bin/readyz.py
 exclude .coveragerc
 exclude sonar-project.properties
 exclude aap_compose_dev.yaml
+exclude tox.ini
 prune .tekton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,66 +82,7 @@ ignore = [
 
 [tool.tox]
 legacy_tox_ini = """
-    [tox]
-    min_version = 4.0
-    no_package = true
-    env_list =
-        py311
-    
-    [testenv]
-    allowlist_externals = sh
-    usedevelop = True
-    deps =
-        -r unittest_requirements.txt
-        epdb
-    setenv =
-        LOCK_REQUIREMENTS=0
-        DJANGO_SETTINGS_MODULE=pulpcore.app.settings
-        PULP_DATABASES__default__ENGINE=django.db.backends.postgresql
-        PULP_DATABASES__default__NAME=galaxy_ng
-        PULP_DATABASES__default__USER=galaxy_ng
-        PULP_DATABASES__default__PASSWORD=galaxy_ng
-        PULP_DATABASES__default__HOST=localhost
-        PULP_DATABASES__default__PORT=5433
-        #PULP_INSTALLED_APPS="[galaxy_ng]"
-        PULP_DB_ENCRYPTION_KEY=/tmp/database_fields.symmetric.key
-        PULP_RH_ENTITLEMENT_REQUIRED=insights
-        PULP_DEPLOY_ROOT=/tmp/pulp
-        PULP_STATIC_ROOT=/tmp/pulp
-        PULP_WORKING_DIRECTORY=/tmp/pulp/tmp
-        PULP_MEDIA_ROOT=/tmp/pulp/media
-        PULP_FILE_UPLOAD_TEMP_DIR=/tmp/pulp/artifact-tmp
-    commands = 
-        sh -c ' \
-            docker compose -f dev/compose/aap.yaml up --force-recreate -d postgres && \
-            docker compose -f dev/compose/aap.yaml exec postgres bash -c "while ! pg_isready -U galaxy_ng; do sleep 1; done" && \
-            rm -rf /tmp/pulp && \
-            mkdir -p /tmp/pulp && \
-            mkdir -p /tmp/pulp/tmp && \
-            mkdir -p /tmp/pulp/artifact-tmp && \
-            mkdir -p /tmp/pulp/media && \
-            mkdir -p /tmp/pulp/assets && \
-            if [ ! -f /tmp/database_fields.symmetric.key ]; then \
-                openssl rand -base64 32 > /tmp/database_fields.symmetric.key; \
-            fi && \
-            if [ -d ../django-ansible-base ]; then pip install -e ../django-ansible-base; fi && \
-            (pip show galaxy_ng || pip install -e .) && \
-            if [ -d ../pulpcore ]; then pip install -e ../pulpcore; fi && \
-            if [ -d ../pulp_ansible ]; then pip install -e ../pulp_ansible; fi && \
-            if [ -d ../galaxy-importer ]; then pip install -e ../galaxy-importer; fi && \
-            if [ -d ../dynaconf ]; then pip install -e ../dynaconf; fi && \
-            if [ -d ../django ]; then pip install -e ../django; fi && \
-            if [ -d ../django-rest-framework ]; then pip install -e ../django-rest-framework; fi && \
-            pytest \
-                --log-cli-level=DEBUG \
-                --capture=no -v \
-                -p 'no:pulpcore' \
-                -p 'no:pulp_ansible' \
-                --cov-report xml:coverage.xml \
-                --cov=galaxy_ng \
-                --junit-xml=/tmp/galaxy_ng-test-results.xml \
-                --pyargs "galaxy_ng.tests.unit" \
-        '
+
 """
 
 [tool.coverage.run]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,60 @@
+[tox]
+min_version = 4.0
+no_package = true
+env_list =
+    py311
+
+[testenv]
+allowlist_externals = sh
+usedevelop = True
+deps =
+    -r unittest_requirements.txt
+    epdb
+setenv =
+    LOCK_REQUIREMENTS=0
+    DJANGO_SETTINGS_MODULE=pulpcore.app.settings
+    PULP_DATABASES__default__ENGINE=django.db.backends.postgresql
+    PULP_DATABASES__default__NAME=galaxy_ng
+    PULP_DATABASES__default__USER=galaxy_ng
+    PULP_DATABASES__default__PASSWORD=galaxy_ng
+    PULP_DATABASES__default__HOST=localhost
+    PULP_DATABASES__default__PORT=5433
+    #PULP_INSTALLED_APPS="[galaxy_ng]"
+    PULP_DB_ENCRYPTION_KEY=/tmp/database_fields.symmetric.key
+    PULP_RH_ENTITLEMENT_REQUIRED=insights
+    PULP_DEPLOY_ROOT=/tmp/pulp
+    PULP_STATIC_ROOT=/tmp/pulp
+    PULP_WORKING_DIRECTORY=/tmp/pulp/tmp
+    PULP_MEDIA_ROOT=/tmp/pulp/media
+    PULP_FILE_UPLOAD_TEMP_DIR=/tmp/pulp/artifact-tmp
+commands =
+    sh -c ' \
+        docker compose -f dev/compose/aap.yaml up --force-recreate -d postgres && \
+        docker compose -f dev/compose/aap.yaml exec postgres bash -c "while ! pg_isready -U galaxy_ng; do sleep 1; done" && \
+        rm -rf /tmp/pulp && \
+        mkdir -p /tmp/pulp && \
+        mkdir -p /tmp/pulp/tmp && \
+        mkdir -p /tmp/pulp/artifact-tmp && \
+        mkdir -p /tmp/pulp/media && \
+        mkdir -p /tmp/pulp/assets && \
+        if [ ! -f /tmp/database_fields.symmetric.key ]; then \
+            openssl rand -base64 32 > /tmp/database_fields.symmetric.key; \
+        fi && \
+        if [ -d ../django-ansible-base ]; then pip install -e ../django-ansible-base; fi && \
+        (pip show galaxy_ng || pip install -e .) && \
+        if [ -d ../pulpcore ]; then pip install -e ../pulpcore; fi && \
+        if [ -d ../pulp_ansible ]; then pip install -e ../pulp_ansible; fi && \
+        if [ -d ../galaxy-importer ]; then pip install -e ../galaxy-importer; fi && \
+        if [ -d ../dynaconf ]; then pip install -e ../dynaconf; fi && \
+        if [ -d ../django ]; then pip install -e ../django; fi && \
+        if [ -d ../django-rest-framework ]; then pip install -e ../django-rest-framework; fi && \
+        pytest \
+            --log-cli-level=DEBUG \
+            --capture=no -v \
+            -p 'no:pulpcore' \
+            -p 'no:pulp_ansible' \
+            --cov-report xml:coverage.xml \
+            --cov=galaxy_ng \
+            --junit-xml=/tmp/galaxy_ng-test-results.xml \
+            --pyargs "galaxy_ng.tests.unit" \
+    '


### PR DESCRIPTION
The `tox` tool doesn't support `pyproject.toml` file natively. Using inline ini in TOML makes it harder to read and modify tox configuration.
Until tox provides native support of `pyproject.toml` configuration file, it is better from a developer experience standpoint to keep it in a separate file.

No-Issue
