### PR TITLE
Disable shallow clone in CI jobs

### DIFF
--- a/.github/workflows/ci_full.yml
+++ b/.github/workflows/ci_full.yml
@@ -60,6 +60,8 @@ jobs:
           python-version: "3.11"
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: checkout dab
         run: |

--- a/.github/workflows/sonar-pr.yaml
+++ b/.github/workflows/sonar-pr.yaml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           show-progress: false
 
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
SonarCloud analysis may work incorrectly when repository is cloned in shallow clone mode.
