### PR TITLE
Add pyupgrade plugin for ruff

### DIFF
--- a/dev/common/tdd.py
+++ b/dev/common/tdd.py
@@ -27,7 +27,7 @@ def get_changed_files(pr_branch, target_branch="master"):
         cmd = f'curl -s -o /tmp/pr.diff {url}'
         pid = subprocess.run(cmd, shell=True)
         assert pid.returncode == 0
-        with open('/tmp/pr.diff', 'r') as f:
+        with open('/tmp/pr.diff') as f:
             raw = f.read()
         filenames = raw.split('\n')
         filenames = [x for x in filenames if x.startswith('---') or x.startswith('+++')]

--- a/dev/oci_env_integration/actions/rbac-parallel.py
+++ b/dev/oci_env_integration/actions/rbac-parallel.py
@@ -6,7 +6,7 @@ rbac_parallel_group = None
 rbac_parallel_group = sys.argv[1] if len(sys.argv) == 2 else None
 rbac_marker = rbac_parallel_group if rbac_parallel_group else "rbac_roles"
 
-pytest_flags = "-m {0}".format(rbac_marker)
+pytest_flags = f"-m {rbac_marker}"
 
 env = action_lib.OCIEnvIntegrationTest(
     envs=[

--- a/galaxy-operator/bin/readyz.py
+++ b/galaxy-operator/bin/readyz.py
@@ -56,7 +56,7 @@ OR
 /usr/bin/python3.9/usr/bin/gunicorn--bind[::]:2481{6,7}pulpcore.app.wsgi:application--namepulp-{api,content}--timeout90--workers2
 ```
 """
-with open("/proc/1/cmdline", "r") as f:
+with open("/proc/1/cmdline") as f:
     cmdline = f.readline()
 
 if "pulp-api" in cmdline:

--- a/galaxy_ng/app/api/ui/v1/views/landing_page.py
+++ b/galaxy_ng/app/api/ui/v1/views/landing_page.py
@@ -32,8 +32,8 @@ class LandingPageView(api_base.APIView):
                         "id": "ansible-partner",
                         "icon": "bulb",
                         "action": {
-                            "title": "Check out our partner %s" % namespace.company,
-                            "href": "./ansible/automation-hub/partners/%s" % namespace.name,
+                            "title": f"Check out our partner {namespace.company}",
+                            "href": f"./ansible/automation-hub/partners/{namespace.name}",
                         },
                         "description": "Discover automation from our partners.",
                     }

--- a/galaxy_ng/app/api/ui/v1/viewsets/collection.py
+++ b/galaxy_ng/app/api/ui/v1/viewsets/collection.py
@@ -194,7 +194,10 @@ class CollectionVersionFilter(filterset.FilterSet):
 
             return queryset.filter(version__in=version_list)
         except ValueError:
-            raise ValidationError(_('%s must be a valid semantic version range.' % name))
+            # FIXME(cutwater): String interpolation must be applied AFTER localization
+            raise ValidationError(
+                _('%s must be a valid semantic version range.' % name)  # noqa: UP031
+            )
 
     sort = OrderingFilter(
         fields=(

--- a/galaxy_ng/app/api/utils.py
+++ b/galaxy_ng/app/api/utils.py
@@ -169,6 +169,6 @@ class GetObjectByIdMixin:
 
 def get_aap_version():
     if os.path.isfile(AAP_VERSION_FILE_PATH):
-        with open(AAP_VERSION_FILE_PATH, "r") as f:
+        with open(AAP_VERSION_FILE_PATH) as f:
             return f.read().strip('\n')
     return None

--- a/galaxy_ng/app/api/v1/serializers.py
+++ b/galaxy_ng/app/api/v1/serializers.py
@@ -534,7 +534,7 @@ class LegacyRoleVersionsSerializer(serializers.ModelSerializer):
         return results
 
 
-class LegacyTaskSerializer():
+class LegacyTaskSerializer:
 
     @property
     def data(self):

--- a/galaxy_ng/app/api/v1/viewsets/roles.py
+++ b/galaxy_ng/app/api/v1/viewsets/roles.py
@@ -245,7 +245,7 @@ class LegacyRoleImportsViewSet(viewsets.ModelViewSet, LegacyTasksMixin):
         """
         if request.query_params.get('id'):
             return self.get_task(request, id=int(request.query_params['id']))
-        return super(LegacyRoleImportsViewSet, self).list(request, *args, **kwargs)
+        return super().list(request, *args, **kwargs)
 
     def retrieve(self, request, *args, **kwargs):
         """

--- a/galaxy_ng/app/api/v3/serializers/collection.py
+++ b/galaxy_ng/app/api/v3/serializers/collection.py
@@ -19,7 +19,7 @@ class CollectionUploadSerializer(Serializer):
 
     sha256 = serializers.CharField(required=False, default=None)
 
-    class Meta():
+    class Meta:
         ref_name = "CollectionUploadWithDownloadUrlSerializer"
 
     def to_internal_value(self, data):

--- a/galaxy_ng/app/api/v3/viewsets/collection.py
+++ b/galaxy_ng/app/api/v3/viewsets/collection.py
@@ -120,7 +120,7 @@ class CollectionUploadViewSet(api_base.LocalSettingsMixin,
         self.check_object_permissions(request, namespace)
 
         try:
-            response = super(CollectionUploadViewSet, self).create(request, path)
+            response = super().create(request, path)
         except ValidationError:
             log.exception('Failed to publish artifact %s (namespace=%s, sha256=%s)',  # noqa
                           data['file'].name, namespace, data.get('sha256'))

--- a/galaxy_ng/app/common/parsers.py
+++ b/galaxy_ng/app/common/parsers.py
@@ -29,6 +29,4 @@ class AnsibleGalaxy29MultiPartParser(MultiPartParser):
 
         new_stream.seek(0)
 
-        return super(AnsibleGalaxy29MultiPartParser, self).parse(new_stream,
-                                                                 media_type=media_type,
-                                                                 parser_context=parser_context)
+        return super().parse(new_stream, media_type=media_type, parser_context=parser_context)

--- a/galaxy_ng/app/tasks/namespaces.py
+++ b/galaxy_ng/app/tasks/namespaces.py
@@ -1,7 +1,7 @@
 import aiohttp
 import asyncio
 import contextlib
-import xml.etree.cElementTree as et
+import xml.etree.ElementTree as ET
 
 from django.db import transaction
 from django.forms.fields import ImageField
@@ -72,9 +72,9 @@ def _download_avatar(url, namespace_name):
         except ValidationError:
             # Not a PIL valid image lets handle SVG case
             tag = None
-            with contextlib.suppress(et.ParseError):
+            with contextlib.suppress(ET.ParseError):
                 f.seek(0)
-                tag = et.parse(f).find(".").tag
+                tag = ET.parse(f).find(".").tag
             if tag != '{http://www.w3.org/2000/svg}svg':
                 raise ValidationError(
                     f"Provided avatar_url for {namespace_name} on {url} is not a valid image"

--- a/galaxy_ng/app/tasks/promotion.py
+++ b/galaxy_ng/app/tasks/promotion.py
@@ -34,7 +34,7 @@ def auto_approve(src_repo_pk, cv_pk, ns_pk=None):
     try:
         signing_service = AUTO_SIGN and SigningService.objects.get(name=SIGNING_SERVICE_NAME)
     except SigningService.DoesNotExist:
-        raise RuntimeError('Signing %s service not found' % SIGNING_SERVICE_NAME)
+        raise RuntimeError(f'Signing {SIGNING_SERVICE_NAME} service not found')
 
     # Sign the collection if auto sign is enabled
     if AUTO_SIGN:

--- a/galaxy_ng/app/utils/roles.py
+++ b/galaxy_ng/app/utils/roles.py
@@ -34,7 +34,7 @@ def get_path_role_repository(path):
 def get_path_role_meta(path):
     """ Retrive the meta/main.yml from a role """
     metaf = os.path.join(path, 'meta', 'main.yml')
-    with open(metaf, 'r') as f:
+    with open(metaf) as f:
         meta = yaml.safe_load(f.read())
     return meta
 
@@ -48,7 +48,7 @@ def get_path_role_name(path):
     metaf = os.path.join(path, 'meta', 'main.yml')
     meta = None
     if os.path.exists(metaf):
-        with open(metaf, 'r') as f:
+        with open(metaf) as f:
             meta = yaml.safe_load(f.read())
 
     if meta and 'role_name' in meta['galaxy_info']:
@@ -162,7 +162,7 @@ def get_path_galaxy_key(path, key):
     if not os.path.exists(gfn):
         return None
 
-    with open(gfn, 'r') as f:
+    with open(gfn) as f:
         ds = yaml.safe_load(f.read())
 
     return ds.get(key)
@@ -171,7 +171,7 @@ def get_path_galaxy_key(path, key):
 def set_path_galaxy_key(path, key, value):
     """ Set a specific key in a galaxy.yml """
     gfn = os.path.join(path, 'galaxy.yml')
-    with open(gfn, 'r') as f:
+    with open(gfn) as f:
         ds = yaml.safe_load(f.read())
 
     ds[key] = value

--- a/galaxy_ng/app/views.py
+++ b/galaxy_ng/app/views.py
@@ -19,7 +19,7 @@ class PulpAPIRedirectView(api_base.APIView):
 
         args = request.META.get("QUERY_STRING", "")
         if args:
-            url = "%s?%s" % (url, args)
+            url = f"{url}?{args}"
 
         # Returning 308 instead of 302 since 308 requires that clients maintain the
         # same method as the original request.

--- a/galaxy_ng/tests/integration/api/rbac_actions/collections.py
+++ b/galaxy_ng/tests/integration/api/rbac_actions/collections.py
@@ -112,7 +112,7 @@ def _upload_collection_common(user, password, expect_pass, extra, base_path=None
         server,
         artifact.filename
     ]
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.run(cmd, capture_output=True)
 
     del_collection(name, extra['collection'].get_namespace()["name"], repo=base_path)
 

--- a/galaxy_ng/tests/integration/api/rbac_actions/utils.py
+++ b/galaxy_ng/tests/integration/api/rbac_actions/utils.py
@@ -142,10 +142,10 @@ def wait_for_all_tasks():
 def ensure_test_container_is_pulled():
     container_engine = CLIENT_CONFIG["container_engine"]
     cmd = [container_engine, "image", "exists", TEST_CONTAINER]
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.run(cmd, capture_output=True)
     if proc.returncode == 1:
         cmd = [container_engine, "image", "pull", TEST_CONTAINER]
-        rc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        rc = subprocess.run(cmd, capture_output=True)
         assert rc.returncode == 0
 
 
@@ -459,7 +459,7 @@ class ReusableAnsibleRepository(AnsibleDistroAndRepo):
             server,
             artifact.filename
         ]
-        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.run(cmd, capture_output=True)
         assert proc.returncode == 0
         wait_for_all_tasks()
 

--- a/galaxy_ng/tests/integration/api/test_artifact_upload.py
+++ b/galaxy_ng/tests/integration/api/test_artifact_upload.py
@@ -271,7 +271,7 @@ def test_long_field_values(galaxy_client, field):
     resp = wait_for_task(gc, resp)
     assert resp["state"] == "failed"
     # Should END with an error
-    assert "must not be greater than %s characters" % fieldmax in resp["error"]["description"]
+    assert f"must not be greater than {fieldmax} characters" in resp["error"]["description"]
     assert fieldname in resp["error"]["description"]
 
 

--- a/galaxy_ng/tests/integration/api/test_openapi.py
+++ b/galaxy_ng/tests/integration/api/test_openapi.py
@@ -90,12 +90,7 @@ def test_openapi_bindings_generation(ansible_config, galaxy_client):
     pulp_spec = gc.get('pulp/api/v3/docs/api.json')
     status = gc.get('pulp/api/v3/status/')
     version = [x['version'] for x in status['versions'] if x['component'] == 'galaxy'][0]
-    my_id = subprocess.run(
-        'id -u',
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    ).stdout.decode('utf-8').strip()
+    my_id = subprocess.run('id -u', shell=True, capture_output=True).stdout.decode('utf-8').strip()
     volume_name = '/local'
     generator_repo = 'https://github.com/pulp/pulp-openapi-generator'
 
@@ -105,8 +100,7 @@ def test_openapi_bindings_generation(ansible_config, galaxy_client):
         clone_pid = subprocess.run(
             f'git clone {generator_repo} {generator_checkout}',
             shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            capture_output=True,
         )
         assert clone_pid.returncode == 0, clone_pid.stderr.decode('utf-8')
 
@@ -137,12 +131,7 @@ def test_openapi_bindings_generation(ansible_config, galaxy_client):
             '--strict-spec=false'
         ]
 
-        docker_pid = subprocess.run(
-            ' '.join(cmd),
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
+        docker_pid = subprocess.run(' '.join(cmd), shell=True, capture_output=True)
         try:
             assert docker_pid.returncode == 0, docker_pid.stderr.decode('utf-8')
         except AssertionError as e:

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -890,7 +890,8 @@ def test_api_ui_v1_tags_roles(ansible_config):
     def _populate_tags_cmd():
         proc = subprocess.run(
             "django-admin populate-role-tags",
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+            shell=True,
+            capture_output=True,
         )
         assert proc.returncode == 0
 

--- a/galaxy_ng/tests/integration/cli/test_community_sync.py
+++ b/galaxy_ng/tests/integration/cli/test_community_sync.py
@@ -86,8 +86,7 @@ def test_community_collection_download_count_sync(ansible_config):
     pid = subprocess.run(
         'pulpcore-manager sync-collection-download-counts',
         shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        capture_output=True,
     )
     assert pid.returncode == 0
 

--- a/galaxy_ng/tests/integration/community/test_community_api.py
+++ b/galaxy_ng/tests/integration/community/test_community_api.py
@@ -587,7 +587,7 @@ def test_v1_username_autocomplete_search(ansible_config):
         + " --server "
         + server
     ]
-    proc = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.run(cmd, shell=True, capture_output=True)
     assert b"Found 5 roles matching your search" in proc.stdout
 
     cmd = [
@@ -599,7 +599,7 @@ def test_v1_username_autocomplete_search(ansible_config):
         + " --server "
         + server
     ]
-    proc = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.run(cmd, shell=True, capture_output=True)
     assert b"Found 1 roles matching your search" in proc.stdout
     assert b"geerlingguy.adminer" in proc.stdout
 

--- a/galaxy_ng/tests/integration/community/test_community_cli.py
+++ b/galaxy_ng/tests/integration/community/test_community_cli.py
@@ -385,7 +385,7 @@ def test_delete_role_with_cli(ansible_config):
         + f' {github_user}'
         + f' {role_name}'
     )
-    delete_pid = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    delete_pid = subprocess.run(cmd, shell=True, capture_output=True)
 
     # FIXME: for some reason, returncode is 1 even if it runs correctly and role is deleted
     # assert delete_pid.returncode == 0 #, delete_pid.stderr.decode('utf-8')
@@ -419,7 +419,7 @@ def test_delete_missing_role_with_cli(ansible_config):
         + f' {github_user}'
         + f' {github_repo}'
     )
-    delete_pid = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    delete_pid = subprocess.run(cmd, shell=True, capture_output=True)
     # FIXME: should return 1?
     # assert delete_pid.returncode == 0 # , delete_pid.stderr.decode('utf-8')
 

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -617,7 +617,7 @@ def keep_generated_test_artifact(ansible_config):
 @pytest.fixture(scope="session")
 def data():
     path = 'galaxy_ng/tests/integration/load_data.yaml'
-    with open(path, 'r') as yaml_file:
+    with open(path) as yaml_file:
         data = yaml.safe_load(yaml_file)
     return data
 

--- a/galaxy_ng/tests/integration/utils/client_ansible_galaxy_cli.py
+++ b/galaxy_ng/tests/integration/utils/client_ansible_galaxy_cli.py
@@ -4,8 +4,7 @@ import re
 import shutil
 import tempfile
 import time
-
-from subprocess import run, PIPE
+import subprocess
 
 from galaxy_ng.tests.integration.constants import SLEEP_SECONDS_POLLING
 
@@ -77,7 +76,13 @@ def ansible_galaxy(
 
     for x in range(0, retries + 1):
         try:
-            p = run(command_string, cwd=tdir, shell=True, stdout=PIPE, stderr=PIPE, env=os.environ)
+            p = subprocess.run(
+                command_string,
+                cwd=tdir,
+                shell=True,
+                capture_output=True,
+                env=os.environ,
+            )
             logger.debug(f"RUN [retry #{x}] {command_string}")
             logger.debug("STDOUT---")
             for line in p.stdout.decode("utf8").split("\n"):

--- a/galaxy_ng/tests/integration/utils/collection_inspector.py
+++ b/galaxy_ng/tests/integration/utils/collection_inspector.py
@@ -26,16 +26,11 @@ class CollectionInspector:
         if self.tarball:
             self._extract_path = tempfile.mkdtemp(prefix='collection-extract-')
             cmd = f'cd {self._extract_path}; tar xzvf {self.tarball}'
-            subprocess.run(
-                cmd,
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
-            )
+            subprocess.run(cmd, shell=True, capture_output=True)
         else:
             self._extract_path = self.directory
 
-        with open(os.path.join(self._extract_path, 'MANIFEST.json'), 'r') as f:
+        with open(os.path.join(self._extract_path, 'MANIFEST.json')) as f:
             self.manifest = json.loads(f.read())
 
         if self.tarball:

--- a/galaxy_ng/tests/integration/utils/collections.py
+++ b/galaxy_ng/tests/integration/utils/collections.py
@@ -149,8 +149,7 @@ def build_collection(
             cmd,
             shell=True,
             cwd=tdir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            capture_output=True,
         )
         assert pid.returncode == 0, str(pid.stdout.decode('utf-8')) \
             + str(pid.stderr.decode('utf-8'))
@@ -163,15 +162,14 @@ def build_collection(
                     cmd,
                     shell=True,
                     cwd=rolesdir,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE
+                    capture_output=True,
                 )
                 assert pid2.returncode == 0, str(pid2.stdout.decode('utf-8')) \
                     + str(pid2.stderr.decode('utf-8'))
 
         # fix galaxy.yml
         galaxy_file = os.path.join(basedir, 'galaxy.yml')
-        with open(galaxy_file, 'r') as f:
+        with open(galaxy_file) as f:
             meta = yaml.safe_load(f.read())
         meta.update(config)
         with open(galaxy_file, 'w') as f:
@@ -213,8 +211,7 @@ def build_collection(
             cmd,
             shell=True,
             cwd=basedir,
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE
+            capture_output=True,
         )
         assert pid3.returncode == 0, str(pid3.stdout.decode('utf-8')) \
             + str(pid3.stderr.decode('utf-8'))
@@ -258,7 +255,7 @@ def upload_artifact(
     def to_bytes(s, errors=None):
         return s.encode("utf8")
 
-    boundary = "--------------------------%s" % uuid.uuid4().hex
+    boundary = "--------------------------" + uuid.uuid4().hex
     file_name = os.path.basename(collection_path)
     part_boundary = b"--" + to_bytes(boundary, errors="surrogate_or_strict")
 
@@ -301,7 +298,7 @@ def upload_artifact(
     data = b"\r\n".join(form)
 
     headers = {
-        "Content-Type": "multipart/form-data; boundary=%s" % boundary,
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
         "Content-length": len(data),
     }
 
@@ -721,8 +718,9 @@ def setup_multipart(path: str, data: dict) -> dict:
 
     data = b"\r\n".join(buffer)
     headers = {
-        "Content-Type": "multipart/form-data; boundary=%s"
-        % boundary[2:].decode("ascii"),  # strip --
+        "Content-Type": "multipart/form-data; boundary={}".format(
+            boundary[2:].decode("ascii")  # strip --
+        ),
         "Content-length": len(data),
     }
 

--- a/galaxy_ng/tests/integration/utils/iqe_utils.py
+++ b/galaxy_ng/tests/integration/utils/iqe_utils.py
@@ -663,7 +663,7 @@ def has_old_credentials():
     return parse_version(hub_version) < parse_version('4.7')
 
 
-@lru_cache()
+@lru_cache
 def get_hub_version(ansible_config):
     if aap_gateway():
         cfg = ansible_config("admin")
@@ -705,7 +705,7 @@ def get_hub_version(ansible_config):
         return gc.get(gc.galaxy_root)["galaxy_ng_version"]
 
 
-@lru_cache()
+@lru_cache
 def get_vault_loader():
     from .vault_loading import VaultSecretFetcher
     vault_settings = {

--- a/galaxy_ng/tests/integration/utils/legacy.py
+++ b/galaxy_ng/tests/integration/utils/legacy.py
@@ -274,7 +274,7 @@ class LegacyRoleGitRepoBuilder:
         if self.meta_namespace or self.meta_name:
 
             meta_file = os.path.join(self.role_dir, 'meta', 'main.yml')
-            with open(meta_file, 'r') as f:
+            with open(meta_file) as f:
                 meta = yaml.safe_load(f.read())
 
             if self.meta_namespace:

--- a/galaxy_ng/tests/integration/utils/oci_env.py
+++ b/galaxy_ng/tests/integration/utils/oci_env.py
@@ -15,7 +15,7 @@ def _set_settings(text):
 
 
 def _get_settings():
-    with open("/etc/pulp/settings.py", "r") as f:
+    with open("/etc/pulp/settings.py") as f:
         return f.read().splt("\n")
 
 

--- a/galaxy_ng/tests/integration/utils/podman.py
+++ b/galaxy_ng/tests/integration/utils/podman.py
@@ -7,10 +7,10 @@ def ensure_test_container_is_pulled(container="alpine"):
     """
 
     cmd = ["podman", "image", "exists", container]
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.run(cmd, capture_output=True)
     if proc.returncode == 1:
         cmd = ["podman", "image", "pull", container]
-        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.run(cmd, capture_output=True)
         assert proc.returncode == 0
 
 
@@ -18,7 +18,7 @@ def tag_hub_with_registry(config, src_image, dest_image):
     registry = config["container_registry"]
     dest = registry + f"/{dest_image}"
     tag_cmd = ["podman", "image", "tag", src_image, dest]
-    proc = subprocess.run(tag_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.run(tag_cmd, capture_output=True)
 
     assert proc.returncode == 0
 

--- a/galaxy_ng/tests/integration/utils/tools.py
+++ b/galaxy_ng/tests/integration/utils/tools.py
@@ -41,8 +41,7 @@ def iterate_all(api_client, url, gc=None):
         # pulp uses "results"
         if "data" not in r:
             key = "results"
-        for x in r[key]:
-            yield x
+        yield from r[key]
         if "next" in r:
             next = r["next"]
         else:
@@ -67,8 +66,7 @@ def iterate_all_gk(gc_admin, url):
         # pulp uses "results"
         if "data" not in r:
             key = "results"
-        for x in r[key]:
-            yield x
+        yield from r[key]
         if "next" in r:
             next = r["next"]
         else:

--- a/galaxy_ng/tests/unit/api/rh_auth.py
+++ b/galaxy_ng/tests/unit/api/rh_auth.py
@@ -1,28 +1,23 @@
 import base64
+import json
 
 
-def user_x_rh_identity(username, account_number=None):
-    account_number = account_number or "12345"
+def user_x_rh_identity(username: str, account_number: str = "12345") -> bytes:
     title_username = username.title()
-    token_json = """{
-        "entitlements":
-            {"insights":
-                {"is_entitled": true}
+
+    token = {
+        "entitlements": {"insights": {"is_entitled": True}},
+        "identity": {
+            "account_number": account_number,
+            "user": {
+                "username": username,
+                "email": username,
+                "first_name": f"{title_username}s",
+                "last_name": f"{title_username}sington",
+                "is_org_admin": True,
             },
-        "identity":
-            {"account_number": "%(account_number)s",
-            "user":
-                {"username": "%(username)s",
-                "email": "%(username)s",
-                "first_name": "%(title_username)s",
-                "last_name": "%(title_username)sington",
-                "is_org_admin": true
-                },
-            "internal": {"org_id": "54321"}
-            }
-            }""" % {'username': username, 'title_username': title_username,
-                    'account_number': account_number}
+            "internal": {"org_id": "54321"},
+        },
+    }
 
-    token_b64 = base64.b64encode(token_json.encode())
-
-    return token_b64
+    return base64.b64encode(json.dumps(token).encode())

--- a/galaxy_ng/tests/unit/test_models.py
+++ b/galaxy_ng/tests/unit/test_models.py
@@ -62,7 +62,7 @@ class TestSignalCreateNamespace(TestCase):
             namespace=self.namespace_name,
         )
         namespace = Namespace.objects.get(name=self.namespace_name)
-        self.assertEquals(namespace.description, description)
+        self.assertEqual(namespace.description, description)
 
 
 class TestSetting(TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,11 +109,16 @@ extend-select = [
     "C4",
     # flake8-no-pep420
     "INP",
+    # pyupgrade
+    "UP",
 ]
 extend-ignore = [
     # B904 requires using `raise ... from ...` to explicitly tell what to do with "parent"
     # exception. Would be nice to fix, but ignoring for now.
     "B904",
+    # UP032 Use f-string instead of `format` call.
+    # No need to replace all str.format usage with f-strings in entire codebase.
+    "UP032",
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Warnings fixed:

* UP005 [*] `assertEquals` is deprecated, use `assertEqual`
* UP008 Use `super()` instead of `super(__class__, self)`
* UP011 [*] Unnecessary parentheses to `functools.lru_cache`
* UP015 [*] Unnecessary open mode parameters
* UP022 Prefer `capture_output` over sending `stdout` and `stderr` to `PIPE`
* UP028 Replace `yield` over `for` loop with `yield from`
* UP030 Use implicit references for positional format fields
* UP031 Use format specifiers instead of percent format
* UP039 [*] Unnecessary parentheses after class definition

Statistics:
```
21      UP022   [*] replace-stdout-stderr
12      UP015   [*] redundant-open-modes
10      UP031   [*] printf-string-formatting
 3      UP008   [*] super-call-with-parameters
 2      UP011   [*] lru-cache-without-parameters
 2      UP028   [*] yield-in-for-loop
 2      UP039   [*] unnecessary-class-parentheses
 1      UP005   [*] deprecated-unittest-alias
 1      UP023   [*] deprecated-c-element-tree
 1      UP030   [*] format-literals
```