### PR TITLE
Enable flake8-pytest-style plugin for ruff

### DIFF
--- a/galaxy_ng/tests/integration/api/test_aiindex.py
+++ b/galaxy_ng/tests/integration/api/test_aiindex.py
@@ -12,7 +12,7 @@ from ..utils.repo_management_utils import create_test_namespace
 from ..utils.legacy import cleanup_social_user
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def flags(ansible_config):
     config = ansible_config("admin")
     api_client = get_client(config, request_token=True, require_auth=True)
@@ -20,14 +20,14 @@ def flags(ansible_config):
     return api_client(f"{api_prefix}/_ui/v1/feature-flags/")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def namespace(ansible_config, galaxy_client) -> str:
     """create a new namespace."""
     gc = galaxy_client("partner_engineer")
     return create_test_namespace(gc)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def pe_namespace(ansible_config, galaxy_client) -> str:
     """create a new namespace owned by PE user."""
     config = ansible_config("partner_engineer")
@@ -53,7 +53,7 @@ def pe_namespace(ansible_config, galaxy_client) -> str:
     return new_namespace
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def legacy_namespace(ansible_config):
     """Creates a new legacy namespace owned by gh01 user"""
 

--- a/galaxy_ng/tests/integration/api/test_auth.py
+++ b/galaxy_ng/tests/integration/api/test_auth.py
@@ -16,7 +16,7 @@ from ..utils.tools import generate_random_string
 pytestmark = pytest.mark.qa  # noqa: F821
 
 
-@pytest.mark.parametrize("profile", ("basic_user", "partner_engineer", "org_admin", "admin"))
+@pytest.mark.parametrize("profile", ["basic_user", "partner_engineer", "org_admin", "admin"])
 @pytest.mark.deployment_standalone
 @pytest.mark.galaxyapi_smoke
 @pytest.mark.skip_in_gw

--- a/galaxy_ng/tests/integration/api/test_collection_signing.py
+++ b/galaxy_ng/tests/integration/api/test_collection_signing.py
@@ -34,13 +34,13 @@ log = logging.getLogger(__name__)
 NAMESPACE = "signing"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def flags(galaxy_client):
     gc = galaxy_client("admin")
     return gc.get("_ui/v1/feature-flags/")
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def namespace(galaxy_client):
     # ensure namespace exists
     gc = galaxy_client("admin")

--- a/galaxy_ng/tests/integration/api/test_container_signing.py
+++ b/galaxy_ng/tests/integration/api/test_container_signing.py
@@ -15,7 +15,7 @@ from galaxykit.container_images import get_container
 from galaxykit.utils import wait_for_task
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def flags(galaxy_client):
     gc = galaxy_client("admin")
     return gc.get("_ui/v1/feature-flags/")

--- a/galaxy_ng/tests/integration/api/test_groups.py
+++ b/galaxy_ng/tests/integration/api/test_groups.py
@@ -70,7 +70,8 @@ def test_gw_group_role_listing(galaxy_client, settings, test_data):
     assert f'/groups/{group_response["id"]}/' in group_roles_response["results"][0]["pulp_href"]
 
     delete_group_v3(gc, group_name)
-    with pytest.raises(ValueError):
+
+    with pytest.raises(ValueError, match=fr"^No group '{group_name}' found\.$"):
         get_group_v3(gc, group_name)
 
 

--- a/galaxy_ng/tests/integration/api/test_iqe_rbac.py
+++ b/galaxy_ng/tests/integration/api/test_iqe_rbac.py
@@ -759,13 +759,11 @@ class TestRBAC:
         ee_name = create_emtpy_local_image_container(ansible_config("admin"), gc)
         user, _ = add_new_user_to_new_group(gc)
         gc_user = galaxy_client(user)
-        try:
+        # We expect the underlying podman command to fail, but we don't
+        # want to accidentally catch any other error, so we check that
+        # the error is the podman return code.
+        with pytest.raises(GalaxyClientError, match="retcode"):
             gc_user.push_image(ee_name + ":latest")
-        except GalaxyClientError as e:
-            # We expect the underlying podman command to fail, but we don't
-            # want to accidentally catch any other error, so we check that
-            # the error is the podman return code.
-            assert "retcode" in str(e)
 
     @pytest.mark.iqe_rbac_test
     def test_object_role_push_image_to_ee(self, galaxy_client, ansible_config):
@@ -816,13 +814,11 @@ class TestRBAC:
         gc.add_role_to_group(role_user, group["id"])
         ee_name = create_emtpy_local_image_container(ansible_config("admin"), gc)
         gc_user = galaxy_client(user)
-        try:
+        # We expect the underlying podman command to fail, but we don't
+        # want to accidentally catch any other error, so we check that
+        # the error is the podman return code.
+        with pytest.raises(GalaxyClientError, match="retcode"):
             gc_user.push_image(ee_name + ":latest")
-        except GalaxyClientError as e:
-            # We expect the underlying podman command to fail, but we don't
-            # want to accidentally catch any other error, so we check that
-            # the error is the podman return code.
-            assert "retcode" in str(e)
 
     @pytest.mark.iqe_rbac_test
     def test_missing_object_role_delete_image_from_ee(self, galaxy_client, ansible_config):

--- a/galaxy_ng/tests/integration/api/test_ldap.py
+++ b/galaxy_ng/tests/integration/api/test_ldap.py
@@ -18,7 +18,7 @@ from ..utils import get_client
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def settings(ansible_config):
     config = ansible_config("admin")
     api_prefix = config.get("api_prefix").rstrip("/")

--- a/galaxy_ng/tests/integration/api/test_x_repo_search.py
+++ b/galaxy_ng/tests/integration/api/test_x_repo_search.py
@@ -402,7 +402,7 @@ class TestXRepoSearch:
 
     # FIXME: unskip when https://issues.redhat.com/browse/AAP-32675 is merged
     @pytest.mark.skip_in_gw
-    @pytest.mark.parametrize("is_highest,cv_version", [(True, "4.0.2"), (False, "4.0.1")])
+    @pytest.mark.parametrize(("is_highest", "cv_version"), [(True, "4.0.2"), (False, "4.0.1")])
     @pytest.mark.x_repo_search
     def test_search_is_highest_true_false(self, galaxy_client, is_highest, cv_version):
         """

--- a/galaxy_ng/tests/integration/cli/test_cli_flow.py
+++ b/galaxy_ng/tests/integration/cli/test_cli_flow.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 @pytest.mark.cli
 @pytest.mark.all
 @pytest.mark.skip_in_gw
-def test_publish_newer_version_collection(galaxy_client, cleanup_collections, uncertifiedv2):
+@pytest.mark.usefixtures("cleanup_collections")
+def test_publish_newer_version_collection(galaxy_client, uncertifiedv2):
     """Test whether a newer version of collection can be installed after being published.
 
     If the collection version was not certified the version to be installed
@@ -45,9 +46,9 @@ def test_publish_newer_version_collection(galaxy_client, cleanup_collections, un
 @pytest.mark.all
 @pytest.mark.cli
 @pytest.mark.skip_in_gw
+@pytest.mark.usefixtures("cleanup_collections")
 def test_publish_newer_certified_collection_version(
     galaxy_client,
-    cleanup_collections,
     certifiedv2,
     settings,
     skip_if_require_signature_for_approval
@@ -96,7 +97,8 @@ def test_publish_same_collection_version(ansible_config, galaxy_client):
 @pytest.mark.all
 @pytest.mark.cli
 @pytest.mark.skip_in_gw
-def test_publish_and_install_by_self(galaxy_client, published, cleanup_collections):
+@pytest.mark.usefixtures("cleanup_collections")
+def test_publish_and_install_by_self(galaxy_client, published):
     """A publishing user has the permission to install an uncertified version of their
     own collection.
     """
@@ -111,10 +113,10 @@ def test_publish_and_install_by_self(galaxy_client, published, cleanup_collectio
 @pytest.mark.cli
 @pytest.mark.deployment_cloud
 @pytest.mark.skip_in_gw
+@pytest.mark.usefixtures("cleanup_collections")
 def test_publish_and_expect_uncertified_hidden(
     galaxy_client,
     published,
-    cleanup_collections,
     settings,
     skip_if_require_signature_for_approval
 ):

--- a/galaxy_ng/tests/integration/cli/test_dependencies.py
+++ b/galaxy_ng/tests/integration/cli/test_dependencies.py
@@ -24,9 +24,10 @@ class DependencySpec:
 @pytest.mark.cli
 @pytest.mark.slow_in_cloud
 @pytest.mark.skip_in_gw
+@pytest.mark.usefixtures("cleanup_collections")
 @pytest.mark.parametrize(
     "params",
-    (
+    [
         DependencySpec("normal", "1.0.0", 0),
         DependencySpec("exact", "=1.0.0", 0),
         DependencySpec("lt", "<2.0.0", 0),
@@ -40,11 +41,10 @@ class DependencySpec:
         # DependencySpec("exception", ">0.0.0,!=1.0.0", 1, xfail="galaxy-dev#104"),
         # DependencySpec("missing1", "2.0.0", 1, xfail="galaxy-dev#104"),
         # DependencySpec("missing2", ">1.0.0", 1, xfail="galaxy-dev#104"),
-    ),
+    ],
     ids=lambda s: s.name,
 )
-def test_collection_dependency_install(ansible_config, published, cleanup_collections,
-                                       params, galaxy_client):
+def test_collection_dependency_install(ansible_config, published, params, galaxy_client):
     """Collections defining dependencies can be installed and their dependencies are installed
     as well.
 

--- a/galaxy_ng/tests/integration/community/test_search.py
+++ b/galaxy_ng/tests/integration/community/test_search.py
@@ -62,7 +62,7 @@ def my_setup_module(ansible_config):
         },
     )
     resp = upload_artifact(admin_config, admin_client, artifact)
-    resp = wait_for_task(admin_client, resp)
+    wait_for_task(admin_client, resp)
     """
     {'name': 'galaxy_fake_collection', 'namespace': 'ansible', 'description':
     'A collection to pretend to manage galaxy with infinidash support', 'type': 'collection',

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -106,7 +106,7 @@ def ansible_config():
     return get_ansible_config()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def published(ansible_config, artifact, galaxy_client):
     # make sure the expected namespace exists ...
     gc = galaxy_client("partner_engineer")
@@ -125,7 +125,7 @@ def published(ansible_config, artifact, galaxy_client):
     return artifact
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def certifiedv2(ansible_config, artifact, galaxy_client):
     """ Create and publish+certify collection version N and N+1 """
 
@@ -164,7 +164,7 @@ def certifiedv2(ansible_config, artifact, galaxy_client):
     return (artifact, artifact2)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def uncertifiedv2(ansible_config, artifact, settings, galaxy_client):
     """ Create and publish collection version N and N+1 but only certify N"""
 
@@ -204,7 +204,7 @@ def uncertifiedv2(ansible_config, artifact, settings, galaxy_client):
     return artifact, artifact2
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def auto_approved_artifacts(ansible_config, artifact, galaxy_client):
     """ Create and publish collection version N and N+1"""
 
@@ -249,7 +249,7 @@ def auto_approved_artifacts(ansible_config, artifact, galaxy_client):
     return artifact, artifact2
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def artifact():
     """Generate a randomized collection for testing."""
 
@@ -269,17 +269,14 @@ def upload_artifact():
 
 
 @pytest.fixture
-def cleanup_collections(request):
+def cleanup_collections():
     """Clean created resources during test executions."""
 
-    def cleanup():
-        path = os.path.expanduser(
-            f"~/.ansible/collections/ansible_collections/{USERNAME_PUBLISHER}/"
-        )
-        if os.path.exists(path):
-            shutil.rmtree(path)
+    yield
 
-    request.addfinalizer(cleanup)
+    path = os.path.expanduser(f"~/.ansible/collections/ansible_collections/{USERNAME_PUBLISHER}/")
+    if os.path.exists(path):
+        shutil.rmtree(path)
 
 
 @pytest.fixture(scope="session")
@@ -384,13 +381,13 @@ def sync_instance_crc():
     return (manifest, config)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def settings(galaxy_client):
     gc = galaxy_client("admin")
     return gc.get("_ui/v1/settings/")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def use_collection_signatures(settings):
     """A shortcut to know if a test should attempt to work with signatures."""
     service = settings["GALAXY_COLLECTION_SIGNING_SERVICE"]
@@ -400,7 +397,7 @@ def use_collection_signatures(settings):
     return False
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def autohubtest2(galaxy_client):
     """A carry over pre-created namespace from the original IQE tests."""
     gc = galaxy_client("admin")
@@ -408,7 +405,7 @@ def autohubtest2(galaxy_client):
     return {"name": "autohubtest2"}
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def random_namespace(galaxy_client, settings):
     """Make a randomized namespace."""
 
@@ -423,7 +420,7 @@ def random_namespace(galaxy_client, settings):
     return get_namespace(ns_name, gc=gc)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def random_username(galaxy_client):
     """Make a random username."""
     return 'user_' + generate_namespace()
@@ -531,7 +528,7 @@ def hub_version(ansible_config):
     return get_hub_version(ansible_config)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def gh_user_1_post(ansible_config):
     """
     Returns a galaxy kit client with a GitHub user logged into beta galaxy stage
@@ -544,7 +541,7 @@ def gh_user_1_post(ansible_config):
     remove_from_cache("github_user")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def gh_user_1(ansible_config):
     """
     Returns a galaxy kit client with a GitHub user logged into beta galaxy stage
@@ -553,7 +550,7 @@ def gh_user_1(ansible_config):
     return gc("github_user", github_social_auth=True)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def gh_user_2(ansible_config):
     """
     Returns a galaxy kit client with a GitHub user logged into beta galaxy stage
@@ -562,7 +559,7 @@ def gh_user_2(ansible_config):
     return gc("github_user_alt", github_social_auth=True)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def gh_user_1_pre(ansible_config):
     """
     Removes everything related to the GitHub user and the user itself and
@@ -573,7 +570,7 @@ def gh_user_1_pre(ansible_config):
     return gc("github_user", github_social_auth=True, ignore_cache=True)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def gw_user_1(ansible_config):
     """
     Returns a galaxy kit client with a GitHub user logged into beta galaxy stage
@@ -582,7 +579,7 @@ def gw_user_1(ansible_config):
     return gc("github_user", github_social_auth=True)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def generate_test_artifact(ansible_config):
     """
     Generates a test artifact and deletes it after the test
@@ -600,7 +597,7 @@ def generate_test_artifact(ansible_config):
     delete_collection(gc_admin, namespace=artifact.namespace, collection=artifact.name)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def keep_generated_test_artifact(ansible_config):
     """
     Generates a test artifact

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -601,8 +601,8 @@ def assert_user_in_group(galaxy_client):
 
 
 @pytest.fixture
-def user_and_group(request, galaxy_client):
-    "Return a tuple of a user and group where the user is not in the group"
+def user_and_group(galaxy_client):
+    """Return a tuple of a user and group where the user is not in the group."""
     gc = galaxy_client("admin")
     user_r = gc.get("_ui/v2/users/", params={"username": "jdoe"})
     assert user_r["count"] > 0
@@ -620,9 +620,9 @@ def user_and_group(request, galaxy_client):
 
     assure_user_not_in_group()
 
-    request.addfinalizer(assure_user_not_in_group)
+    yield user, group
 
-    return (user, group)
+    assure_user_not_in_group()
 
 
 @pytest.mark.min_hub_version("4.10dev")

--- a/galaxy_ng/tests/integration/utils/client_ansible_lib.py
+++ b/galaxy_ng/tests/integration/utils/client_ansible_lib.py
@@ -167,18 +167,10 @@ class AnsibeGalaxyHttpClient:
         )
 
         # construct a helpful error message ...
-        msg = (
-            self.config.get('auth_url')
-            + '\n'
-            + str(payload)
-            + '\n'
-            + str(rr.status_code)
-            + '\n'
-            + rr.text
-        )
+        msg = "{}\n{}\n{}\n{}".format(self.config.get('auth_url'), payload, rr.status_code, rr.text)
 
         # bail out early if auth failed ...
-        assert rr.status_code >= 200 and rr.status_code < 300, msg
+        assert 200 <= rr.status_code < 300, msg
         assert rr.headers.get('Content-Type') == 'application/json', msg
         assert 'access_token' in rr.json(), msg
 

--- a/galaxy_ng/tests/integration/utils/oci_env.py
+++ b/galaxy_ng/tests/integration/utils/oci_env.py
@@ -1,6 +1,6 @@
 import subprocess
 import os
-from pytest import skip
+import pytest
 
 
 def _set_settings(text):
@@ -23,7 +23,7 @@ def with_oci_env_setting(settings):
     def decorator(function):
         def wrapper(*args, **kwargs):
             if not os.path.isdir('/opt/oci-env/'):
-                skip(reason="@with_oci_env_setting tests only work when run in oci-env")
+                pytest.skip(reason="@with_oci_env_setting tests only work when run in oci-env")
 
             current_settings = _get_settings()
             new_settings = current_settings + [f"{x}={settings[x]}" for x in settings]

--- a/galaxy_ng/tests/integration/utils/users.py
+++ b/galaxy_ng/tests/integration/utils/users.py
@@ -1,6 +1,8 @@
 import random
 import string
 
+import pytest
+
 from .client_ui import UIClient
 
 
@@ -28,11 +30,8 @@ def delete_group(groupname, api_client=None):
         assert rr.status_code == 204
         return
 
-    try:
-        resp = api_client(api_prefix + f'/_ui/v1/groups/{gid}/', method='DELETE')
-    except Exception as e:
-        error = str(e)
-        assert 'as JSON' in error, e
+    with pytest.raises(Exception, match="as JSON"):
+        api_client(api_prefix + f'/_ui/v1/groups/{gid}/', method='DELETE')
 
 
 def create_user(username, password, api_client=None):
@@ -84,11 +83,8 @@ def delete_user(username, api_client=None):
         assert rr.status_code == 204
         return
 
-    try:
-        resp = api_client(api_prefix + f'/_ui/v1/users/{uid}/', method='DELETE')
-    except Exception as e:
-        error = str(e)
-        assert 'as JSON' in error, e
+    with pytest.raises(Exception, match="as JSON"):
+        api_client(api_prefix + f'/_ui/v1/users/{uid}/', method='DELETE')
 
 
 def delete_group_gk(groupname, gc_admin):
@@ -100,8 +96,5 @@ def delete_group_gk(groupname, gc_admin):
     ginfo = resp['data'][0]
     gid = ginfo['id']
 
-    try:
-        resp = gc_admin.delete(f'_ui/v1/groups/{gid}/')
-    except Exception as e:
-        error = str(e)
-        assert 'as JSON' in error, e
+    with pytest.raises(Exception, match="as JSON"):
+        gc_admin.delete(f'_ui/v1/groups/{gid}/')

--- a/galaxy_ng/tests/performance/test_performance.py
+++ b/galaxy_ng/tests/performance/test_performance.py
@@ -4,11 +4,11 @@ import pytest
 from galaxy_ng.tests.performance.constants import URLS
 from ..integration.utils import (
     UIClient,
-    get_client
+    get_client,
 )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def api_client(ansible_config):
     config = ansible_config("admin")
     api_client = get_client(
@@ -20,7 +20,7 @@ def api_client(ansible_config):
 
 
 @pytest.mark.deployment_community
-@pytest.mark.parametrize("url,info", URLS.items())
+@pytest.mark.parametrize(("url", "info"), URLS.items())
 def test_api_performance(ansible_config, api_client, url, info):
     threshold = 0.25
     results = []

--- a/galaxy_ng/tests/unit/app/test_dynaconf_hooks.py
+++ b/galaxy_ng/tests/unit/app/test_dynaconf_hooks.py
@@ -71,7 +71,7 @@ BASE_SETTINGS = {
 
 
 @pytest.mark.parametrize(
-    "do_stuff, extra_settings, expected_results",
+    ("do_stuff", "extra_settings", "expected_results"),
     [
         # 0 >=4.10 no external auth ...
         (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ select = [
     "INP",
     # pyupgrade
     "UP",
+    # flake8-pytest-style
+    "PT",
 ]
 extend-ignore = [
     # B904 requires using `raise ... from ...` to explicitly tell what to do with "parent"
@@ -121,6 +123,12 @@ extend-ignore = [
     # UP032 Use f-string instead of `format` call.
     # No need to replace all str.format usage with f-strings in entire codebase.
     "UP032",
+    # PT004,PT005 are incorrect and deprecated
+    # See https://github.com/astral-sh/ruff/issues/8796
+    "PT004", "PT005",
+    # PT009 Use a regular `assert` instead of unittest-style
+    # Ignoring, since we have mixed pytest and legacy unittest styled tests
+    "PT009",
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Warnings fixed:

* PT003 `scope='function'` is implied in `@pytest.fixture()`
* PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
* PT007 Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
* PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
* PT013 Incorrect import of `pytest`; use `import pytest` instead
* PT017 Found assertion on exception `e` in `except` block, use `pytest.raises()` instead
* PT018 Assertion should be broken down into multiple parts
* PT021 Use `yield` instead of `request.addfinalizer`

Statistics:
```
26      PT003   [*] pytest-extraneous-scope-function
 5      PT017   [ ] pytest-assert-in-except
 3      PT006   [*] pytest-parametrize-names-wrong-type
 2      PT007   [*] pytest-parametrize-values-wrong-type
 2      PT021   [ ] pytest-fixture-finalizer-callback
 1      PT011   [ ] pytest-raises-too-broad
 1      PT013   [ ] pytest-incorrect-pytest-import
 1      PT018   [ ] pytest-composite-assertion
```