### PR TITLE
Docs: remove duplicate option GALAXY_ENABLE_API_ACCESS_LOG

### DIFF
--- a/docs/config/options.md
+++ b/docs/config/options.md
@@ -161,7 +161,6 @@ Here is a [diagram explaining](https://www.xmind.net/m/VPSF59/#) the loading ord
 | `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS`      | Enabled anonymous browsing, Default: `False` |
 | `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD`      | Enabled anonymous download, Default: `False` |
 | `GALAXY_ENABLE_API_ACCESS_LOG`      | Enable gathering of logs, Default: `False` |
-| `GALAXY_ENABLE_API_ACCESS_LOG`      | Enable gathering of logs, Default: `False` |
 | `CONNECTED_ANSIBLE_CONTROLLERS`      | List of controllers connected , Default: `[]` |
 | `CONTENT_PATH_PREFIX`      | URL prefix for content serving , Default: `"/api/automation-hub/v3/artifacts/collections/"` |
 | `GALAXY_AUTHENTICATION_CLASSES`      | List of auth classes for DRF , Default: `[Session, Token, Basic]` |


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
The GALAXY_ENABLE_API_ACCESS_LOG option is documented twice.
<!-- Add Jira issue link or replace with No-Issue -->
No-Issue

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
