### PR TITLE
Skip test load repositories in 2.3 to 2.4 upgrade

### DIFF
--- a/galaxy_ng/tests/integration/api/test_load_data.py
+++ b/galaxy_ng/tests/integration/api/test_load_data.py
@@ -179,7 +179,6 @@ class TestLoadData:
                 else:
                     raise e
 
-
     @pytest.mark.min_hub_version("4.6")
     @pytest.mark.load_data
     def test_load_remotes(self, galaxy_client, data):

--- a/galaxy_ng/tests/integration/api/test_load_data.py
+++ b/galaxy_ng/tests/integration/api/test_load_data.py
@@ -163,7 +163,7 @@ class TestLoadData:
                 add_group(gc, ns["name"], ns["group"],
                           object_roles=["galaxy.collection_namespace_owner"])
 
-    @pytest.mark.min_hub_version("4.6")
+    @pytest.mark.min_hub_version("4.7")
     @pytest.mark.load_data
     def test_load_repositories_and_remotes(self, galaxy_client, data):
         gc = galaxy_client("admin")

--- a/galaxy_ng/tests/integration/api/test_load_data.py
+++ b/galaxy_ng/tests/integration/api/test_load_data.py
@@ -165,7 +165,7 @@ class TestLoadData:
 
     @pytest.mark.min_hub_version("4.7")
     @pytest.mark.load_data
-    def test_load_repositories_and_remotes(self, galaxy_client, data):
+    def test_load_repositories(self, galaxy_client, data):
         gc = galaxy_client("admin")
 
         for repo in data["repositories"]:
@@ -179,6 +179,11 @@ class TestLoadData:
                 else:
                     raise e
 
+
+    @pytest.mark.min_hub_version("4.6")
+    @pytest.mark.load_data
+    def test_load_remotes(self, galaxy_client, data):
+        gc = galaxy_client("admin")
         for remote in data["remotes"]:
             try:
                 logger.debug(f"Creating remote {remote['name']}")

--- a/galaxy_ng/tests/integration/api/test_verify_data.py
+++ b/galaxy_ng/tests/integration/api/test_verify_data.py
@@ -140,13 +140,29 @@ class TestVerifyData:
     @pytest.mark.min_hub_version("4.7dev")
     @pytest.mark.skipif(is_upgrade_from_aap23_hub46(), reason=SKIP_MESSAGE_23)
     @pytest.mark.verify_data
-    def test_verify_data_repos(self, galaxy_client, data):
+    def test_verify_data_repositories(self, galaxy_client, data):
         """
         Test that verifies the data previously loaded by test_load_data
         """
         gc = galaxy_client("admin")
         for expected_repo in data["repositories"]:
             get_repository_href(gc, expected_repo["name"])
+
+
+    @pytest.mark.min_hub_version("4.6dev")
+    @pytest.mark.verify_data
+    def test_verify_data_remotes(self, galaxy_client, data):
+        """
+        Test that verifies the data previously loaded by test_load_data
+        """
+        gc = galaxy_client("admin")
+        for remote in data["remotes"]:
+            actual_remote = view_remotes(gc, remote["name"])
+            assert actual_remote["results"][0]["url"] == remote["url"]
+            assert actual_remote["results"][0]["name"] == remote["name"]
+            assert actual_remote["results"][0]["signed_only"] == remote["signed_only"]
+            assert actual_remote["results"][0]["tls_validation"] == remote["tls_validation"]
+
 
     @pytest.mark.min_hub_version("4.6dev")
     @pytest.mark.verify_data
@@ -192,17 +208,3 @@ class TestVerifyData:
                                f"?name={remote_registry['name']}")
             assert actual_rr["data"][0]["name"] == remote_registry["name"]
             assert actual_rr["data"][0]["url"] == remote_registry["url"]
-
-    @pytest.mark.min_hub_version("4.6dev")
-    @pytest.mark.verify_data
-    def test_verify_data_remotes(self, galaxy_client, data):
-        """
-        Test that verifies the data previously loaded by test_load_data
-        """
-        gc = galaxy_client("admin")
-        for remote in data["remotes"]:
-            actual_remote = view_remotes(gc, remote["name"])
-            assert actual_remote["results"][0]["url"] == remote["url"]
-            assert actual_remote["results"][0]["name"] == remote["name"]
-            assert actual_remote["results"][0]["signed_only"] == remote["signed_only"]
-            assert actual_remote["results"][0]["tls_validation"] == remote["tls_validation"]

--- a/galaxy_ng/tests/integration/api/test_verify_data.py
+++ b/galaxy_ng/tests/integration/api/test_verify_data.py
@@ -148,7 +148,6 @@ class TestVerifyData:
         for expected_repo in data["repositories"]:
             get_repository_href(gc, expected_repo["name"])
 
-
     @pytest.mark.min_hub_version("4.6dev")
     @pytest.mark.verify_data
     def test_verify_data_remotes(self, galaxy_client, data):
@@ -162,7 +161,6 @@ class TestVerifyData:
             assert actual_remote["results"][0]["name"] == remote["name"]
             assert actual_remote["results"][0]["signed_only"] == remote["signed_only"]
             assert actual_remote["results"][0]["tls_validation"] == remote["tls_validation"]
-
 
     @pytest.mark.min_hub_version("4.6dev")
     @pytest.mark.verify_data


### PR DESCRIPTION
Issue: [AAH-37593](https://issues.redhat.com/browse/AAP-37593)

Skip `test_load_repositories` in 4.6, repository management was introduced in 4.7+.

Changes tested on https://jenkins-csb-aap-main.dno.corp.redhat.com/job/AAPQA/job/Sandbox/job/christian/job/upgrade-from-2.3_released-to-2.4_public-minor/
