### PR TITLE
oci-env LDAP and Keycloak test fix 

### DIFF
--- a/profiles/base/Dockerfile
+++ b/profiles/base/Dockerfile
@@ -25,4 +25,9 @@ RUN bash profiles/base/setup_venv.sh
 #   that doesn't create /run/postgresql directory
 RUN mkdir -p /run/postgresql && chown postgres:postgres /run/postgresql
 
+# fixes FileNotFoundError: [Errno 2] No such file or directory: \'/.ansible/roles\'
+# for collection import galaxy-importer
+RUN mkdir -p ~/.ansible/roles/
+RUN chmod -R 775  ~/.ansible
+
 WORKDIR /


### PR DESCRIPTION
`test_ansible_lint_exception_AAH_2606` failing with creating ~/.ansible/roles and permission issues in ldap and keycloak profile.

```
Importing with galaxy-importer 0.4.27
Getting doc strings via ansible-doc
Finding content inside collection
Loading role docker_role
Linting collection via ansible-lint...
Traceback (most recent call last):
    File "/usr/lib64/python3.11/pathlib.py", line 1116, in mkdir
    os.mkdir(self, mode)
    FileNotFoundError: [Errno 2] No such file or directory: \'/.ansible/roles\'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
    File "/usr/local/bin/ansible-lint", line 8, in <module>
    sys.exit(_run_cli_entrypoint())
    ^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/ansiblelint/__main__.py", line 408, in _run_cli_entrypoint
    sys.exit(main(sys.argv))
    ^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/ansiblelint/__main__.py", line 290, in main
    cache_dir_lock = initialize_options(argv[1:])
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/ansiblelint/__main__.py", line 141, in initialize_options
    options.cache_dir = get_cache_dir(pathlib.Path(options.project_dir))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/ansible_compat/prerun.py", line 27, in get_cache_dir
    (cache_dir / name).mkdir(parents=True, exist_ok=True)
    File "/usr/lib64/python3.11/pathlib.py", line 1120, in mkdir
    self.parent.mkdir(parents=True, exist_ok=True)
    File "/usr/lib64/python3.11/pathlib.py", line 1116, in mkdir
    os.mkdir(self, mode)
    PermissionError: [Errno 13] Permission denied: \'/.ansible\'
    
    ...ansible-lint run complete
    Ignore files skip ansible-test sanity tests, found ignore-2.10.txt with 1 statement(s)
    Collection loading complete

```