### PR TITLE
AAP-37675- DAB Dynaconf

### DIFF
--- a/galaxy_ng/app/api/views.py
+++ b/galaxy_ng/app/api/views.py
@@ -43,6 +43,8 @@ VERSIONS = {
     "pulp_ansible_version": apps.get_app_config('ansible').version,
     "pulp_container_version": apps.get_app_config('container').version,
     "ansible_base_version": get_version_from_metadata("django-ansible-base"),
+    "dynaconf_version": get_version_from_metadata("dynaconf"),
+    "django_version": get_version_from_metadata("django"),
 }
 
 # Add in v1 support if configured

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -19,12 +19,17 @@ import sys
 from typing import Any
 
 import ldap
-from ansible_base.lib.dynamic_config.settings_logic import get_dab_settings
+from ansible_base.lib.dynamic_config import (
+    factory,
+    load_dab_settings,
+    load_standard_settings_files,
+    toggle_feature_flags,
+    validate as dab_validate,
+)
 from crum import get_current_request
 from django.apps import apps
 from django_auth_ldap.config import LDAPSearch
 from dynaconf import Dynaconf, Validator
-from dynaconf.utils.functional import empty
 
 from galaxy_ng.app.dynamic_settings import DYNAMIC_SETTINGS_SCHEMA
 
@@ -70,7 +75,8 @@ def post(settings: Dynaconf, run_dynamic: bool = True, run_validate: bool = True
     data.update(configure_password_validators(settings))
     data.update(configure_api_base_path(settings))
     data.update(configure_legacy_roles(settings))
-    data.update(configure_dab_required_settings(settings))
+    # these must get the current state of data to make decisions
+    data.update(configure_dab_required_settings(settings, data))
     data.update(toggle_feature_flags(settings))
 
     # These should go last, and it needs to receive the data from the previous configuration
@@ -87,6 +93,9 @@ def post(settings: Dynaconf, run_dynamic: bool = True, run_validate: bool = True
 
     if run_validate:
         validate(settings)
+
+    # must go right before returning the data
+    data.update(configure_dynaconf_cli(settings, data))
 
     return data
 
@@ -795,43 +804,76 @@ def configure_dynamic_settings(settings: Dynaconf) -> dict[str, Any]:
     }
 
 
-def configure_dab_required_settings(settings: Dynaconf) -> dict[str, Any]:
-    dab_settings = get_dab_settings(
-        installed_apps=[
-            *settings.INSTALLED_APPS,
-            # jwt_consumer will not be part of the final INSTALLED_APPS
-            # but passed here to get the required jwt settings from DAB.
-            'ansible_base.jwt_consumer',
-        ],
-        rest_framework=settings.REST_FRAMEWORK,
-        spectacular_settings=settings.SPECTACULAR_SETTINGS,
-        authentication_backends=settings.AUTHENTICATION_BACKENDS,
-        middleware=settings.MIDDLEWARE,
-        templates=settings.TEMPLATES
+def configure_dab_required_settings(settings: Dynaconf, data: dict) -> dict[str, Any]:
+    # Create a Dynaconf object from DAB
+    dab_dynaconf = factory("", "HUB", add_dab_settings=False)
+    # update it with raw pulp settings
+    dab_dynaconf.update(settings.as_dict())
+    # Add overrides from the previous hooks
+    dab_dynaconf.update(data)
+    # Temporary add jwt_consumer to the installed apps because it is required by DAB
+    dab_dynaconf.set("INSTALLED_APPS", "@merge_unique ansible_base.jwt_consumer")
+    # Load the DAB settings that are conditionally added based on INSTALLED_APPS
+    load_dab_settings(dab_dynaconf)
+    # Remove jwt_consumer from the installed apps because galaxy uses Pulp implementation
+    dab_dynaconf.set(
+        "INSTALLED_APPS",
+        [app for app in dab_dynaconf.INSTALLED_APPS if app != 'ansible_base.jwt_consumer']
     )
-    # This doesn't perform any merging, it sets only keys that are not already set
-    # NOTE: this needs refactoring when integrating with new Dynaconf factory from DAB
-    return {k: v for k, v in dab_settings.items() if k not in settings}
+    # Load the standard AAP settings files
+    load_standard_settings_files(dab_dynaconf)  # /etc/ansible-automation-platform/*.yaml
+
+    # Load of the envvars prefixed with HUB_ is currently disabled
+    # because galaxy right now uses PULP_ as prefix and we want to avoid confusion
+    # Also some CI environments are already using HUB_ prefix to set unrelated variables
+    # load_envvars(dab_dynaconf)
+
+    # Validate the settings
+    dab_validate(dab_dynaconf)
+    # Get raw dict to return
+    data = dab_dynaconf.as_dict()
+    # to use with `dynaconf -i pulpcore.app.settings.DAB_DYNACONF [command]`
+    data["DAB_DYNACONF"] = dab_dynaconf
+    return data
 
 
-def toggle_feature_flags(settings: Dynaconf) -> dict[str, Any]:
-    """Toggle FLAGS based on installer settings.
+def configure_dynaconf_cli(pulp_settings: Dynaconf, data: dict) -> dict[str, Any]:
+    """Add an instance of Dynaconf to be used by the CLI.
+    This instance merges metadata from the PULP and DAB dynaconf instances.
 
-    FLAGS is a django-flags formatted dictionary.
-
-        FLAGS={
-            "FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
-                {"condition": "boolean", "value": False, "required": True},
-                {"condition": "before date", "value": "2022-06-01T12:00Z"},
-            ]
-        }
-
-    Installers will place `FEATURE_SOME_PLATFORM_FLAG_ENABLED=True/False` in the settings file.
-    This function will update the value in the index 0 in FLAGS with the installer value.
+    This doesn't affect the running application, it only affects the `dynaconf` CLI.
     """
-    data = {}
-    for feature_name, feature_content in settings.get("FLAGS", {}).items():
-        if (installer_value := settings.get(feature_name, empty)) is not empty:
-            feature_content[0]["value"] = installer_value
-            data[f"FLAGS__{feature_name}"] = feature_content
+    # This is the instance that will be discovered by dynaconf CLI
+    try:
+        dab_dynaconf = data["DAB_DYNACONF"]
+    except KeyError:
+        raise AttributeError(
+            "DAB_DYNACONF not found in settings "
+            "configure_dab_required_settings "
+            "must be called before configure_dynaconf_cli"
+        )
+
+    # Load data from both instances
+    cli_dynaconf = Dynaconf(core_loaders=[], envvar_prefix=None)
+    cli_dynaconf._store.update(pulp_settings._store)
+    cli_dynaconf._store.update(data)
+
+    # Merge metadata from both instances
+    # first pulp
+    cli_dynaconf._loaded_files = pulp_settings._loaded_files
+    cli_dynaconf._loaded_hooks = pulp_settings._loaded_hooks
+    cli_dynaconf._loaded_by_loaders = pulp_settings._loaded_by_loaders
+    cli_dynaconf._loaded_envs = pulp_settings._loaded_envs
+    # then dab
+    cli_dynaconf._loaded_files.extend(dab_dynaconf._loaded_files)
+    cli_dynaconf._loaded_hooks.update(dab_dynaconf._loaded_hooks)
+    cli_dynaconf._loaded_by_loaders.update(dab_dynaconf._loaded_by_loaders)
+    cli_dynaconf._loaded_envs.extend(dab_dynaconf._loaded_envs)
+
+    # Add the hook to the history
+    cli_dynaconf._loaded_hooks[__name__] = {"post": data}
+
+    # assign to the CLI can discover it
+    data["CLI_DYNACONF"] = cli_dynaconf
+
     return data

--- a/galaxy_ng/tests/unit/app/test_dynaconf_hooks.py
+++ b/galaxy_ng/tests/unit/app/test_dynaconf_hooks.py
@@ -8,6 +8,18 @@ class SuperDict(dict):
 
     immutable = False
 
+    _loaded_files = []
+    _loaded_envs = []
+    _loaded_hooks = {}
+    _loaded_by_loaders = {}
+
+    @property
+    def _store(self):
+        return self
+
+    def as_dict(self):
+        return self
+
     def set(self, key, value):
         if self.immutable:
             raise Exception("not mutable!")
@@ -368,3 +380,25 @@ def test_dynaconf_hooks_toggle_feature_flags():
     # Check that the feature flag under FLAGS is now enabled
     # the hook will return Dynaconf merging syntax.
     assert new_settings["FLAGS__FEATURE_SOME_PLATFORM_FLAG_ENABLED"][0]["value"] is True
+
+
+def test_dab_dynaconf():
+    """Ensure that the DAB settings are correctly set."""
+
+    xsettings = SuperDict()
+    xsettings.update(copy.deepcopy(BASE_SETTINGS))
+
+    # Run the post hook
+    new_settings = post_hook(xsettings, run_dynamic=True, run_validate=True)
+
+    # Check that DAB injected settings are correctly set
+    expected_keys = [
+        "ANSIBLE_BASE_OVERRIDDEN_SETTINGS",
+        "ANSIBLE_STANDARD_SETTINGS_FILES",
+        "ANSIBLE_BASE_OVERRIDABLE_SETTINGS",
+        "IS_DEVELOPMENT_MODE",
+        "CLI_DYNACONF",
+        "DAB_DYNACONF",
+    ]
+    for key in expected_keys:
+        assert key in new_settings

--- a/profiles/base/Dockerfile
+++ b/profiles/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM localhost/oci_env/pulp:base
 
 # Define the build argument
-ARG DJANGO_ANSIBLE_BASE_BRANCH=2025.1.31
+ARG DJANGO_ANSIBLE_BASE_BRANCH=2025.3.7
 
 # Set the environment variable based on the build argument
 ENV DJANGO_ANSIBLE_BASE_BRANCH=${DJANGO_ANSIBLE_BASE_BRANCH}

--- a/profiles/dab/compose.yaml
+++ b/profiles/dab/compose.yaml
@@ -7,14 +7,15 @@ services:
   _galaxy_base:
     build:
       args:
-        DJANGO_ANSIBLE_BASE_BRANCH: "2025.1.31"
+        DJANGO_ANSIBLE_BASE_BRANCH: "2025.3.7"
+        
     environment:
-      DJANGO_ANSIBLE_BASE_BRANCH: "2025.1.31"
+      DJANGO_ANSIBLE_BASE_BRANCH: "2025.3.7"
 
   pulp:
     environment:
       PULP_WORKERS: "1"
-      DJANGO_ANSIBLE_BASE_BRANCH: "2025.1.31"
+      DJANGO_ANSIBLE_BASE_BRANCH: "2025.3.7"
 
 volumes:
   pulp_certs:

--- a/profiles/dab_jwt/compose.yaml
+++ b/profiles/dab_jwt/compose.yaml
@@ -7,14 +7,15 @@ services:
   _galaxy_base:
     build:
       args:
-        DJANGO_ANSIBLE_BASE_BRANCH: "2025.1.31"
+
+        DJANGO_ANSIBLE_BASE_BRANCH: "2025.3.7"
     environment:
-      DJANGO_ANSIBLE_BASE_BRANCH: "2025.1.31"
+      DJANGO_ANSIBLE_BASE_BRANCH: "2025.3.7"
 
   pulp:
     environment:
       PULP_WORKERS: "1"
-      DJANGO_ANSIBLE_BASE_BRANCH: "2025.1.31"
+      DJANGO_ANSIBLE_BASE_BRANCH: "2025.3.7"
 
   jwtproxy:
     build:

--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -106,7 +106,7 @@ django==4.2.17
     #   insights-analytics-collector
     #   pulpcore
     #   social-auth-app-django
-django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@2025.1.31
+django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@2025.3.7
     # via galaxy-ng (setup.py)
 django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
@@ -151,7 +151,7 @@ drf-spectacular==0.26.5
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
-dynaconf==3.2.6
+dynaconf==3.2.10
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -120,7 +120,7 @@ django==4.2.17
     #   insights-analytics-collector
     #   pulpcore
     #   social-auth-app-django
-django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@2025.1.31
+django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@2025.3.7
     # via galaxy-ng (setup.py)
 django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
@@ -167,7 +167,7 @@ drf-spectacular==0.26.5
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
-dynaconf==3.2.6
+dynaconf==3.2.10
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -106,7 +106,7 @@ django==4.2.17
     #   insights-analytics-collector
     #   pulpcore
     #   social-auth-app-django
-django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@2025.1.31
+django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@2025.3.7
     # via galaxy-ng (setup.py)
 django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)
@@ -151,7 +151,7 @@ drf-spectacular==0.26.5
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore
-dynaconf==3.2.6
+dynaconf==3.2.10
     # via
     #   galaxy-ng (setup.py)
     #   pulpcore

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ class BuildPyCommand(_BuildPyCommand):
         return super().run()
 
 
-django_ansible_base_branch = os.getenv('DJANGO_ANSIBLE_BASE_BRANCH', '2025.1.31')
+django_ansible_base_branch = os.getenv('DJANGO_ANSIBLE_BASE_BRANCH', '2025.3.7')
 django_ansible_base_dependency = (
     'django-ansible-base[jwt-consumer,feature-flags] @ '
     f'git+https://github.com/ansible/django-ansible-base@{django_ansible_base_branch}'


### PR DESCRIPTION
Use DAB Dynaconf to load extra settings

This PR sets 2 new Dynaconf Hooks

1. Uses the new `factory` to load settings from DAB
2. Adds a `CLI_DYNACONF` to provide access to `dynaconf inspect` commands


Related docs https://github.com/ansible/django-ansible-base/blob/devel/docs/lib/dynamic_config.md