### PR TITLE
Issue: AAP-32587 - Add docker-compose file for LDAP

### DIFF
--- a/dev/compose/ldap.yaml
+++ b/dev/compose/ldap.yaml
@@ -1,0 +1,320 @@
+x-common-env: &common-env
+
+  GNUPGHOME: /root/.gnupg/
+
+  DJANGO_SUPERUSER_USERNAME: admin
+  DJANGO_SUPERUSER_EMAIL: admin@example.com
+  DJANGO_SUPERUSER_PASSWORD: admin
+
+  POSTGRES_USER: galaxy_ng
+  POSTGRES_PASSWORD: galaxy_ng
+  POSTGRES_DB: galaxy_ng
+
+  PULP_ANALYTICS: 'false'
+
+  PULP_DATABASES__default__ENGINE: django.db.backends.postgresql
+  PULP_DATABASES__default__NAME: galaxy_ng
+  PULP_DATABASES__default__USER: galaxy_ng
+  PULP_DATABASES__default__PASSWORD: galaxy_ng
+  PULP_DATABASES__default__HOST: postgres
+  PULP_DATABASES__default__PORT: 5432
+
+  PULP_DEBUG: 1
+  PULP_GALAXY_DEPLOYMENT_MODE: 'standalone'
+  PULP_DEFAULT_FILE_STORAGE: "pulpcore.app.models.storage.FileSystem"
+  PULP_REDIRECT_TO_OBJECT_STORAGE: 'false'
+
+  PULP_GALAXY_API_PATH_PREFIX: '/api/galaxy/'
+  PULP_CONTENT_PATH_PREFIX: '/pulp/content/'
+  PULP_ANSIBLE_API_HOSTNAME: 'http://localhost:5001'
+  PULP_ANSIBLE_CONTENT_HOSTNAME: "http://localhost:5001"
+  PULP_CONTENT_ORIGIN: "http://localhost:5001"
+  PULP_CSRF_TRUSTED_ORIGINS: "['http://localhost']"
+
+  PULP_GALAXY_AUTO_SIGN_COLLECTIONS: 'false'
+  PULP_GALAXY_REQUIRE_CONTENT_APPROVAL: 'true'
+  PULP_GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL: 'false'
+  PULP_GALAXY_COLLECTION_SIGNING_SERVICE: 'ansible-default'
+  PULP_GALAXY_CONTAINER_SIGNING_SERVICE: 'container-default'
+
+  PULP_TOKEN_AUTH_DISABLED: 'false'
+  PULP_TOKEN_SERVER: 'http://localhost:5001/token/'
+  PULP_TOKEN_SIGNATURE_ALGORITHM: 'ES256'
+  PULP_PUBLIC_KEY_PATH: '/src/galaxy_ng/dev/common/container_auth_public_key.pem'
+  PULP_PRIVATE_KEY_PATH: '/src/galaxy_ng/dev/common/container_auth_private_key.pem'
+
+  PULP_GALAXY_AUTHENTICATION_CLASSES: "['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication', 'rest_framework.authentication.BasicAuthentication']"
+  PULP_ANSIBLE_BASE_JWT_VALIDATE_CERT: 'false'
+  PULP_ANSIBLE_BASE_JWT_KEY: 'https://localhost'
+  PULP_GALAXY_FEATURE_FLAGS__external_authentication: 'true'
+
+  PULP_ALLOW_LOCAL_RESOURCE_MANAGEMENT: 'true'
+
+  PULP_ANSIBLE_BASE_ROLES_REQUIRE_VIEW: 'false'
+
+  PULP_RESOURCE_SERVER_SYNC_ENABLED: 'false'
+
+  HUB_API_ROOT: 'http://localhost:5001/api/galaxy/'
+  HUB_TEST_MARKS: "deployment_standalone or all or ldap"
+  HUB_USE_MOVE_ENDPOINT: 'true'
+  CONTAINER_REGISTRY: 'localhost:5001'
+
+  LOCK_REQUIREMENTS: 0
+
+  DEV_SOURCE_PATH:
+
+  PULP_AUTHENTICATION_BACKEND_PRESET: ldap
+  PULP_AUTH_LDAP_SERVER_URI: "ldap://ldap:10389"
+  PULP_AUTH_LDAP_BIND_DN: "cn=admin,dc=planetexpress,dc=com"
+  PULP_AUTH_LDAP_BIND_PASSWORD: "GoodNewsEveryone"
+  PULP_AUTH_LDAP_USER_SEARCH_BASE_DN: "ou=people,dc=planetexpress,dc=com"
+  PULP_AUTH_LDAP_USER_SEARCH_SCOPE: "SUBTREE"
+  PULP_AUTH_LDAP_USER_SEARCH_FILTER: "(uid=%(user)s)"
+  PULP_AUTH_LDAP_GROUP_SEARCH_BASE_DN: "ou=people,dc=planetexpress,dc=com"
+  PULP_AUTH_LDAP_GROUP_SEARCH_SCOPE: "SUBTREE"
+  PULP_AUTH_LDAP_GROUP_SEARCH_FILTER: "(objectClass=Group)"
+  PULP_AUTH_LDAP_GROUP_TYPE_CLASS: "django_auth_ldap.config:GroupOfNamesType"
+
+  PULP_AUTH_LDAP_ALWAYS_UPDATE_USER: true
+
+  PULP_AUTH_LDAP_USER_ATTR_MAP__first_name: givenName
+  PULP_AUTH_LDAP_USER_ATTR_MAP__last_name: sn
+  PULP_AUTH_LDAP_USER_ATTR_MAP__email: mail
+
+  PULP_AUTH_LDAP_MIRROR_GROUPS: true
+  PULP_AUTH_LDAP_USER_FLAGS_BY_GROUP__is_staff: "cn=ship_crew,ou=people,dc=planetexpress,dc=com"
+  PULP_AUTH_LDAP_USER_FLAGS_BY_GROUP__is_superuser: "cn=admin_staff,ou=people,dc=planetexpress,dc=com"
+
+  PULP_GALAXY_LDAP_LOGGING: true
+
+  HUB_TEST_AUTHENTICATION_BACKEND: "ldap"
+
+x-debugging: &debugging
+  stdin_open: true
+  tty: true
+
+services:
+  base_img:
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+    image: "localhost/galaxy_ng/galaxy_ng:base"
+
+  base_img_dev:
+    depends_on:
+      - base_img
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        <<: *common-env
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+
+  redis:
+    image: "redis:5"
+
+  postgres:
+    image: "postgres:13"
+    ports:
+      - '5433:5432'
+    environment:
+      <<: *common-env
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "galaxy_ng"]
+      interval: 10s
+      retries: 5
+
+  migrations:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        set -e;
+        rm -rf /var/lib/pulp/.migrated;
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+
+        pulpcore-manager check --database default;
+        pulpcore-manager migrate;
+        pulpcore-manager shell < /src/galaxy_ng/dev/common/setup_test_data.py;
+        pulpcore-manager createsuperuser --noinput || true;
+
+        touch /var/lib/pulp/.migrated;
+      "
+
+  api:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+      - migrations
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    extra_hosts:
+      localhost: "host-gateway"
+    networks:
+      - default
+      - service-mesh
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+        /src/galaxy_ng/dev/compose/bin/wait /var/lib/pulp/.migrated;
+
+        /src/galaxy_ng/dev/compose/bin/reloader /src/galaxy_ng/dev/compose/bin/pulpcore-api
+      "
+
+  content:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+      - migrations
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    extra_hosts:
+      localhost: "host-gateway"
+    networks:
+      - default
+      - service-mesh
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+        /src/galaxy_ng/dev/compose/bin/wait /var/lib/pulp/.migrated;
+
+        /src/galaxy_ng/dev/compose/bin/reloader /src/galaxy_ng/dev/compose/bin/pulpcore-content
+      "
+
+  worker:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+      - migrations
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+        /src/galaxy_ng/dev/compose/bin/wait /var/lib/pulp/.migrated;
+
+        gpg --list-secret-keys;
+
+        /src/galaxy_ng/dev/compose/bin/reloader /venv/bin/pulpcore-worker
+      "
+
+  manager:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+      - migrations
+      - worker
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+        /src/galaxy_ng/dev/compose/bin/wait /var/lib/pulp/.migrated;
+
+        sleep 5;
+
+        # Setup signing services;
+        gpg --list-secret-keys;
+        /src/galaxy_ng/dev/compose/signing/setup_signing_services.sh;
+        echo 'Signing Services';
+        curl -s -u $$DJANGO_SUPERUSER_USERNAME:$$DJANGO_SUPERUSER_PASSWORD http://api:24817/api/galaxy/pulp/api/v3/signing-services/?fields=name,script,pubkey_fingerprint | python -m json.tool;
+
+        # Setup repository gpgkey for upload verification;
+        /src/galaxy_ng/dev/compose/signing/setup_repo_keyring.sh;
+
+        echo ' ';
+        echo '###################### API ROOT ##############################';
+        curl -s -u $$DJANGO_SUPERUSER_USERNAME:$$DJANGO_SUPERUSER_PASSWORD http://api:24817/api/galaxy/ | python -m json.tool;
+        echo '################### DEV_SOURCE_PATH ##########################';
+        echo $$DEV_SOURCE_PATH;
+        echo ' ';
+        echo '######################## READY ###############################';
+        echo ' ';
+        echo 'Credentials:  ' $$DJANGO_SUPERUSER_USERNAME:$$DJANGO_SUPERUSER_PASSWORD;
+        echo 'API Spec:      http://localhost:5001/api/galaxy/v3/swagger-ui/';
+        echo 'Django Admin:  docker compose -f dev/compose/ldap.yaml exec manager pulpcore-manager';
+        echo 'Settings list: docker compose -f dev/compose/ldap.yaml exec manager dynaconf list';
+        echo 'Docs:          https://github.com/ansible/galaxy_ng/blob/master/dev/compose/README.md';
+        echo '##############################################################';
+
+        # Keep it running indefinitely to enable `docker compose -f ... exec manager /bin/bash`;
+        tail -f /dev/null
+      "
+
+  nginx:
+    image: "nginx:latest"
+    depends_on:
+      - postgres
+      - migrations
+      - api
+      - content
+      - ldap
+    ports:
+      - '5001:5001'
+    volumes:
+      - '../nginx/nginx.conf:/etc/nginx/nginx.conf:ro'
+
+  ldap:
+    image: "rroemhild/test-openldap"
+    environment:
+      <<: *common-env
+    ports:
+      - "10389:10389"
+      - "10636:10636"
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+
+volumes:
+  var_lib_pulp_ldap:
+    name: var_lib_pulp_ldap
+  etc_pulp_certs:
+    name: etc_pulp_certs
+
+networks:
+  service-mesh:
+    name: service-mesh


### PR DESCRIPTION
#### What is this PR doing:

This PR introduces a new  Docker Compose configuration file, ldap.yaml ( LDAP Profile ), to the galaxy_ng/dev/compose directory.

Issue: AAP-32587 -  Add docker-compose file for LDAP profile 
Please see: https://issues.redhat.com/browse/AAP-32587


#### Reviewers must know:
- **Testing Steps**:  
  
From the `galaxy_ng` directory, run:  
  
     ```
     docker compose -f dev/compose/ldap.yaml up --build 
     ```  
  Verify that the API is accessible at [http://localhost:5001/api/galaxy/v3/swagger-ui/](http://localhost:5001/api/galaxy/v3/swagger-ui/).  
 
 Confirm the LDAP service is running by connecting to `ldap://localhost:10389`.
  ```
  ldapsearch -x -H ldap://localhost:10389 -D "cn=admin,dc=planetexpress,dc=com" -w GoodNewsEveryone -b "dc=planetexpress,dc=com"
  ```  
- **Additional Notes**:  
  - The configuration is designed for local development; adjust paths or environment variables as needed for other environments.

![ldap-test](https://github.com/user-attachments/assets/7d4d6659-483d-4e4f-8102-6a05a8af59b7)
![ldap-test0](https://github.com/user-attachments/assets/448b099a-b332-4124-a374-0453c0c25d07)

