### PR TITLE
Add docker-compose file for keycloak profile [4.9]

### DIFF
--- a/dev/compose/keycloak-utils/keycloak-change-user-password.yaml
+++ b/dev/compose/keycloak-utils/keycloak-change-user-password.yaml
@@ -1,0 +1,43 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Get Keycloak Admin Token
+      uri:
+        url: "http://localhost:8080/auth/realms/master/protocol/openid-connect/token"
+        method: POST
+        body_format: form-urlencoded
+        body:
+          username: admin
+          password: admin
+          grant_type: password
+          client_id: admin-cli
+      register: keycloak_token
+
+    - name: Find User ID for fry
+      uri:
+        url: "http://localhost:8080/auth/admin/realms/aap/users?username=fry"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+          Content-Type: application/json
+      register: user_search
+
+    - name: Reset User Password
+      uri:
+        url: "http://localhost:8080/auth/admin/realms/aap/users/{{ user_search.json[0].id }}/reset-password"
+        method: PUT
+        body_format: json
+        body:
+          type: password
+          value: "PlanetExpress2025!"
+          temporary: false
+        headers:
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+          Content-Type: application/json
+        status_code: 204
+      register: password_reset_result
+      when: user_search.json | length > 0
+
+    - name: Debug Password Reset
+      debug:
+        var: password_reset_result

--- a/dev/compose/keycloak-utils/keycloak-client.yaml
+++ b/dev/compose/keycloak-utils/keycloak-client.yaml
@@ -1,0 +1,27 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Get Keycloak Admin Token
+      uri:
+        url: "http://localhost:8080/auth/realms/master/protocol/openid-connect/token"
+        method: POST
+        body_format: form-urlencoded
+        body:
+          username: admin
+          password: admin
+          grant_type: password
+          client_id: admin-cli
+      register: keycloak_token
+
+    - name: Get Automation Hub Client Details
+      uri:
+        url: "http://localhost:8080/auth/admin/realms/aap/clients?clientId=automation-hub"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+          Content-Type: application/json
+      register: client_details
+
+    - name: Debug Client Configuration
+      debug:
+        var: client_details.json[0]

--- a/dev/compose/keycloak-utils/keycloak-playbook.yaml
+++ b/dev/compose/keycloak-utils/keycloak-playbook.yaml
@@ -1,0 +1,383 @@
+---
+
+- name: Keycloak Setup Playbook
+  connection: local
+  gather_facts: false
+  hosts: localhost
+  tasks:
+
+    - name: Get started
+      debug:
+        msg: "Preparing Keycloak setup ..."
+
+    - name: Create or update AAP Keycloak realm
+      community.general.keycloak_realm:
+        auth_client_id: admin-cli
+        auth_keycloak_url: http://localhost:8080/auth
+        auth_realm: master
+        auth_username: admin
+        auth_password: admin
+        id: aap
+        realm: aap
+        display_name: Ansible Automation Platform
+        state: present
+        validate_certs: yes
+        enabled: yes
+
+    - name: Create or update a Keycloak client
+      community.general.keycloak_client:
+        auth_client_id: admin-cli
+        auth_keycloak_url: http://localhost:8080/auth
+        auth_realm: master
+        auth_username: admin
+        auth_password: admin
+        state: present
+        realm: aap
+        client_id: automation-hub
+        id: d8b127a3-31f6-44c8-a7e4-4ab9a3e78d95
+        name: Automation Hub
+        description: Client ID for Ansible Automation Hub
+        root_url: http://localhost:5001/
+        enabled: yes
+        client_authenticator_type: client-secret
+        secret: REALLYWELLKEPTSECRET
+        redirect_uris:
+          - http://localhost:5001/*
+        web_origins:
+          - http://localhost:5001/*
+        bearer_only: no
+        consent_required: no
+        standard_flow_enabled: yes
+        implicit_flow_enabled: no
+        direct_access_grants_enabled: yes
+        service_accounts_enabled: yes
+        authorization_services_enabled: no
+        public_client: no
+        frontchannel_logout: no
+        protocol: openid-connect
+        protocol_mappers:
+          - config:
+              access.token.claim: "true"
+              claim.name: "family_name"
+              id.token.claim: "true"
+              jsonType.label: String
+              user.attribute: lastName
+              userinfo.token.claim: "true"
+            consentRequired: false
+            name: family name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+          - config:
+              userinfo.token.claim: "true"
+              user.attribute: email
+              id.token.claim: true
+              access.token.claim: "true"
+              claim.name: email
+              jsonType.label: String
+            name: email
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            consentRequired: false
+          - config:
+              multivalued: "true"
+              user.attribute": foo
+              access.token.claim: "true"
+              claim.name: "resource_access.${client_id}.roles"
+              jsonType.label: String
+            name: client roles
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-client-role-mapper
+            consentRequired: false
+          - config:
+              userinfo.token.claim: "true"
+              user.attribute: firstName
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: given_name
+              jsonType.label: String
+            name: given name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            consentRequired: false
+          - config:
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+            name: full name
+            protocol: openid-connect
+            protocolMapper: oidc-full-name-mapper
+            consentRequired: false
+          - config:
+              userinfo.token.claim: "true"
+              user.attribute: username
+              id.token.claim: "true"
+              access.token.claim: "true"
+              claim.name: preferred_username
+              jsonType.label: String
+            name: username
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            consentRequired: false
+          - config:
+              access.token.claim: "true"
+              claim.name: "group"
+              full.path: "true"
+              id.token.claim: "true"
+              userinfo.token.claim: "true"
+            consentRequired: false
+            name: group
+            protocol: openid-connect
+            protocolMapper: oidc-group-membership-mapper
+          - config:
+              multivalued: 'true'
+              id.token.claim: 'true'
+              access.token.claim: 'true'
+              userinfo.token.claim: 'true'
+              usermodel.clientRoleMapping.clientId: automation-hub
+              claim.name: client_roles
+              jsonType.label: String
+            name: client_roles
+            protocolMapper: oidc-usermodel-client-role-mapper
+            protocol: openid-connect
+          - config:
+              id.token.claim: true
+              access.token.claim: true
+              included.client.audience: automation-hub
+            protocol: openid-connect
+            name: audience mapper
+            protocolMapper: oidc-audience-mapper
+        attributes:
+          user.info.response.signature.alg: RS256
+          request.object.signature.alg: RS256
+
+    - name: Create Token for service Keycloak
+      uri:
+        url: "http://localhost:8080/auth/realms/master/protocol/openid-connect/token"
+        method: POST
+        body_format: form-urlencoded
+        body:
+          username: "admin"
+          password: "admin"
+          grant_type: "password"
+          client_id: "admin-cli"
+      register: keycloak_token
+
+    - name: Define ldap_config
+      set_fact:
+        ldap_config:
+          name: ldap
+          providerId: ldap
+          providerType: org.keycloak.storage.UserStorageProvider
+          parentId: aap
+          config:
+            enabled:
+            - 'true'
+            priority:
+            - '0'
+            fullSyncPeriod:
+            - "-1"
+            changedSyncPeriod:
+            - "-1"
+            cachePolicy:
+            - DEFAULT
+            batchSizeForSync:
+            - '1000'
+            editMode:
+            - READ_ONLY
+            importEnabled:
+            - 'true'
+            syncRegistrations:
+            - 'false'
+            vendor:
+            - other
+            usernameLDAPAttribute:
+            - uid
+            rdnLDAPAttribute:
+            - uid
+            uuidLDAPAttribute:
+            - entryUUID
+            userObjectClasses:
+            - inetOrgPerson, organizationalPerson
+            connectionUrl:
+            - ldap://ldap:10389
+            usersDn:
+            - ou=people,dc=planetexpress,dc=com
+            authType:
+            - simple
+            bindDn:
+            - cn=admin,dc=planetexpress,dc=com
+            bindCredential:
+            - GoodNewsEveryone
+            customUserSearchFilter: []
+            searchScope:
+            - '2'
+            validatePasswordPolicy:
+            - 'false'
+            trustEmail:
+            - 'false'
+            useTruststoreSpi:
+            - ldapsOnly
+            connectionPooling:
+            - 'true'
+            pagination:
+            - 'true'
+            allowKerberosAuthentication:
+            - 'false'
+            debug:
+            - 'false'
+            useKerberosForPasswordAuthentication:
+            - 'false'
+
+    - name: Create LDAP configuration
+      uri:
+        url: "http://localhost:8080/auth/admin/realms/aap/components"
+        method: POST
+        body_format: json
+        body: "{{ ldap_config | to_json }}"
+        status_code:
+        - 201
+        - 409
+        headers:
+          Content-type: "application/json"
+          Accept: "application/json"
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+      register: create_ldap_config
+
+    - name: Get components
+      uri:
+        url: "http://localhost:8080/auth/admin/realms/aap/components?parent=aap&type=org.keycloak.storage.UserStorageProvider"
+        method: GET
+        status_code:
+        - 200
+        headers:
+          Content-type: "application/json"
+          Accept: "application/json"
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+      register: keycloak_components
+
+    - name: Save ldap id
+      set_fact:
+        ldap_id: "{{ keycloak_components['json'][0]['id'] }}"
+
+    - name: Define ldap_group_mapper
+      set_fact:
+        ldap_group_mapper:
+          config:
+            groups.dn:
+            - ou=people,dc=planetexpress,dc=com
+            group.name.ldap.attribute:
+            - cn
+            group.object.classes:
+            - Group
+            preserve.group.inheritance:
+            - 'false'
+            ignore.missing.groups:
+            - 'false'
+            membership.ldap.attribute:
+            - member
+            membership.attribute.type:
+            - DN
+            membership.user.ldap.attribute:
+            - uid
+            mode:
+            - READ_ONLY
+            user.roles.retrieve.strategy:
+            - LOAD_GROUPS_BY_MEMBER_ATTRIBUTE
+            memberof.ldap.attribute:
+            - memberOf
+            drop.non.existing.groups.during.sync:
+            - 'false'
+            groups.path:
+            - "/"
+          name: group
+          providerId: group-ldap-mapper
+          providerType: org.keycloak.storage.ldap.mappers.LDAPStorageMapper
+          parentId: "{{ ldap_id }}"
+
+    - name: Create LDAP group mapping
+      uri:
+        url: "http://localhost:8080/auth/admin/realms/aap/components"
+        method: POST
+        body_format: json
+        body: "{{ ldap_group_mapper | to_json }}"
+        status_code:
+        - 201
+        - 409
+        headers:
+          Content-type: "application/json"
+          Accept: "application/json"
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+      register: create_ldap_group_mapper
+
+    - name: Get group mapper identifier
+      uri:
+        url: "http://localhost:8080/auth/admin/realms/aap/components?parent={{ ldap_id }}&type=org.keycloak.storage.ldap.mappers.LDAPStorageMapper&name=group"
+        method: GET
+        status_code:
+        - 200
+        headers:
+          Content-type: "application/json"
+          Accept: "application/json"
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+      register: keycloak_storage_mapper
+
+    - name: Save group mapper id
+      set_fact:
+        keycloak_ldap_group_mapper_id: "{{ keycloak_storage_mapper['json'][0]['id']  }}"
+
+    - name: Sync LDAP users
+      uri:
+        url: "http://localhost:8080/auth/admin/realms/aap/user-storage/{{ ldap_id }}/sync?action=triggerFullSync"
+        method: POST
+        status_code:
+        - 200
+        headers:
+          Content-type: "application/json"
+          Accept: "application/json"
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+      register: sync_ldap_users
+
+    - name: Sync LDAP groups
+      uri:
+        url: "http://localhost:8080/auth/admin/realms/aap/user-storage/{{ ldap_id }}/mappers/{{ keycloak_ldap_group_mapper_id }}/sync?direction=fedToKeycloak"
+        method: POST
+        status_code:
+        - 200
+        headers:
+          Content-type: "application/json"
+          Accept: "application/json"
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+      register: sync_ldap_groups
+
+    - name: Create a Keycloak client role for Hub Administrator
+      community.general.keycloak_role:
+        name: hubadmin
+        description: An administrator role for Automation Hub
+        realm: aap
+        client_id: automation-hub
+        state: present
+        auth_client_id: admin-cli
+        auth_keycloak_url: http://localhost:8080/auth
+        auth_realm: master
+        auth_username: admin
+        auth_password: admin
+      register: hub_admin_create
+
+    - name: Get realm public key
+      uri:
+        url: "http://localhost:8080/auth/realms/aap"
+        method: GET
+        status_code:
+        - 200
+        headers:
+          Content-type: "application/json"
+          Accept: "application/json"
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+      register: keycloak_realm
+
+    - name: Save public key
+      set_fact:
+        keycloak_realm_public_key: "{{ keycloak_realm['json']['public_key']  }}"
+
+    - debug:
+        var: keycloak_realm_public_key

--- a/dev/compose/keycloak-utils/keycloak-realm.yaml
+++ b/dev/compose/keycloak-utils/keycloak-realm.yaml
@@ -1,0 +1,27 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Get Keycloak Admin Token
+      uri:
+        url: "http://localhost:8080/auth/realms/master/protocol/openid-connect/token"
+        method: POST
+        body_format: form-urlencoded
+        body:
+          username: admin
+          password: admin
+          grant_type: password
+          client_id: admin-cli
+      register: keycloak_token
+
+    - name: Get Realm Public Key
+      uri:
+        url: "http://localhost:8080/auth/realms/aap"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ keycloak_token.json.access_token }}"
+          Content-Type: application/json
+      register: realm_details
+
+    - name: Debug Realm Public Key
+      debug:
+        var: realm_details.json.public_key

--- a/dev/compose/keycloak.yaml
+++ b/dev/compose/keycloak.yaml
@@ -1,0 +1,341 @@
+x-common-env: &common-env
+  GNUPGHOME: /root/.gnupg/
+
+  DJANGO_SUPERUSER_USERNAME: admin
+  DJANGO_SUPERUSER_EMAIL: admin@example.com
+  DJANGO_SUPERUSER_PASSWORD: admin
+
+  POSTGRES_USER: galaxy_ng
+  POSTGRES_PASSWORD: galaxy_ng
+  POSTGRES_DB: galaxy_ng
+
+  PULP_ANALYTICS: 'false'
+
+  PULP_DATABASES__default__ENGINE: django.db.backends.postgresql
+  PULP_DATABASES__default__NAME: galaxy_ng
+  PULP_DATABASES__default__USER: galaxy_ng
+  PULP_DATABASES__default__PASSWORD: galaxy_ng
+  PULP_DATABASES__default__HOST: postgres
+  PULP_DATABASES__default__PORT: 5432
+
+  PULP_DEBUG: 1
+  PULP_GALAXY_DEPLOYMENT_MODE: standalone
+  PULP_DEFAULT_FILE_STORAGE: "pulpcore.app.models.storage.FileSystem"
+  PULP_REDIRECT_TO_OBJECT_STORAGE: 'false'
+
+  PULP_GALAXY_API_PATH_PREFIX: '/api/'
+  PULP_CONTENT_PATH_PREFIX: '/pulp/content/'
+  PULP_ANSIBLE_API_HOSTNAME: 'http://localhost:5001'
+  PULP_ANSIBLE_CONTENT_HOSTNAME: "http://localhost:5001"
+  PULP_CONTENT_ORIGIN: "http://localhost:5001"
+  PULP_CSRF_TRUSTED_ORIGINS: "['https://localhost']"
+
+  PULP_GALAXY_AUTO_SIGN_COLLECTIONS: 'false'
+  PULP_GALAXY_REQUIRE_CONTENT_APPROVAL: 'false'
+  PULP_GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL: 'false'
+  PULP_GALAXY_COLLECTION_SIGNING_SERVICE: 'ansible-default'
+  PULP_GALAXY_CONTAINER_SIGNING_SERVICE: 'container-default'
+
+  PULP_TOKEN_AUTH_DISABLED: false
+  PULP_TOKEN_SERVER: 'http://localhost:5001/token/'
+  PULP_TOKEN_SIGNATURE_ALGORITHM: ES256
+  PULP_PUBLIC_KEY_PATH: '/src/galaxy_ng/dev/common/container_auth_public_key.pem'
+  PULP_PRIVATE_KEY_PATH: '/src/galaxy_ng/dev/common/container_auth_private_key.pem'
+  SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL: 'http://localhost:8080/auth/realms/master/protocol/openid-connect/token'
+
+  PULP_SOCIAL_AUTH_KEYCLOAK_KEY: automation-hub
+  PULP_SOCIAL_AUTH_KEYCLOAK_SECRET: REALLYWELLKEPTSECRET
+  PULP_SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY: "CHANGE-ME"
+  PULP_SOCIAL_AUTH_LOGIN_REDIRECT_URL: 'http://localhost:5001'
+  PULP_KEYCLOAK_PROTOCOL: http
+  PULP_KEYCLOAK_HOST: keycloak
+  PULP_KEYCLOAK_HOST_LOOPBACK: localhost
+  PULP_KEYCLOAK_PORT: 8080
+  PULP_KEYCLOAK_REALM: aap
+  PULP_RH_ENTITLEMENT_REQUIRED: insights
+
+  HUB_API_ROOT: 'http://localhost:5001/api/'
+  HUB_USE_MOVE_ENDPOINT: 'true'
+  CONTAINER_REGISTRY: 'localhost:5001'
+
+  LOCK_REQUIREMENTS: 0
+  DEV_SOURCE_PATH:
+
+  PULP_AUTHENTICATION_BACKEND_PRESET: keycloak
+  PULP_AUTH_LDAP_SERVER_URI: "ldap://ldap:10389"
+  PULP_AUTH_LDAP_BIND_DN: "cn=admin,dc=planetexpress,dc=com"
+  PULP_AUTH_LDAP_BIND_PASSWORD: "GoodNewsEveryone"
+  PULP_AUTH_LDAP_USER_SEARCH_BASE_DN: "ou=people,dc=planetexpress,dc=com"
+  PULP_AUTH_LDAP_USER_SEARCH_SCOPE: SUBTREE
+  PULP_AUTH_LDAP_USER_SEARCH_FILTER: "(uid=%(user)s)"
+  PULP_AUTH_LDAP_GROUP_SEARCH_BASE_DN: "ou=people,dc=planetexpress,dc=com"
+  PULP_AUTH_LDAP_GROUP_SEARCH_SCOPE: SUBTREE
+  PULP_AUTH_LDAP_GROUP_SEARCH_FILTER: "(objectClass=Group)"
+  PULP_AUTH_LDAP_GROUP_TYPE_CLASS: "django_auth_ldap.config:GroupOfNamesType"
+  PULP_AUTH_LDAP_ALWAYS_UPDATE_USER: true
+  PULP_AUTH_LDAP_USER_ATTR_MAP__first_name: givenName
+  PULP_AUTH_LDAP_USER_ATTR_MAP__last_name: sn
+  PULP_AUTH_LDAP_USER_ATTR_MAP__email: mail
+  PULP_AUTH_LDAP_MIRROR_GROUPS: true
+  PULP_AUTH_LDAP_USER_FLAGS_BY_GROUP__is_staff: "cn=ship_crew,ou=people,dc=planetexpress,dc=com"
+  PULP_AUTH_LDAP_USER_FLAGS_BY_GROUP__is_superuser: "cn=admin_staff,ou=people,dc=planetexpress,dc=com"
+  PULP_GALAXY_LDAP_LOGGING: true
+
+  PULP_GALAXY_AUTHENTICATION_CLASSES: "['galaxy_ng.app.auth.keycloak.KeycloakBasicAuth']"
+  KEYCLOAK_REDIRECT_URL: "http://localhost:5001/"
+
+  HUB_TEST_AUTHENTICATION_BACKEND: "keycloak"
+  HUB_TEST_MARKS: "deployment_standalone or all or keycloak"
+
+  PULP_RESOURCE_SERVER_SYNC_ENABLED: false
+
+  API_PROTOCOL: http
+  API_HOST: localhost
+  API_PORT: 5001
+
+  LDAP_LOGLEVEL: 256
+
+x-debugging: &debugging
+  stdin_open: true
+  tty: true
+
+services:
+  base_img:
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+    image: "localhost/galaxy_ng/galaxy_ng:base"
+
+  base_img_dev:
+    depends_on:
+      - base_img
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        <<: *common-env
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+
+  redis:
+    image: "redis:5"
+
+  postgres:
+    image: "postgres:13"
+    ports:
+      - '5433:5432'
+    environment:
+      <<: *common-env
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "galaxy_ng"]
+      interval: 10s
+      retries: 5
+
+  migrations:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        set -e;
+        rm -rf /var/lib/pulp/.migrated;
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+        pulpcore-manager check --database default;
+        pulpcore-manager migrate;
+        pulpcore-manager shell < /src/galaxy_ng/dev/common/setup_test_data.py;
+        pulpcore-manager createsuperuser --noinput || true;
+        touch /var/lib/pulp/.migrated;
+      "
+
+  api:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+      - migrations
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    extra_hosts:
+      localhost: "host-gateway"
+    networks:
+      - default
+      - service-mesh
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+        /src/galaxy_ng/dev/compose/bin/wait /var/lib/pulp/.migrated;
+        /src/galaxy_ng/dev/compose/bin/reloader /src/galaxy_ng/dev/compose/bin/pulpcore-api
+      "
+
+  content:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+      - migrations
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    extra_hosts:
+      localhost: "host-gateway"
+    networks:
+      - default
+      - service-mesh
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+        /src/galaxy_ng/dev/compose/bin/wait /var/lib/pulp/.migrated;
+        /src/galaxy_ng/dev/compose/bin/reloader /src/galaxy_ng/dev/compose/bin/pulpcore-content
+      "
+
+  worker:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+      - migrations
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+        /src/galaxy_ng/dev/compose/bin/wait /var/lib/pulp/.migrated;
+        gpg --list-secret-keys;
+        /src/galaxy_ng/dev/compose/bin/reloader /venv/bin/pulpcore-worker
+      "
+
+  manager:
+    image: "localhost/galaxy_ng/galaxy_ng:dev"
+    depends_on:
+      - base_img_dev
+      - postgres
+      - migrations
+      - worker
+    volumes:
+      - "etc_pulp_certs:/etc/pulp/certs"
+      - "var_lib_pulp_ldap:/var/lib/pulp"
+      - "../../../:/src"
+      - "../../:/app"
+    environment:
+      <<: *common-env
+    user: root
+    <<: *debugging
+    command: |
+      bash -c "
+        /src/galaxy_ng/dev/compose/bin/devinstall;
+        /src/galaxy_ng/dev/compose/bin/wait /var/lib/pulp/.migrated;
+        sleep 5;
+        gpg --list-secret-keys;
+        /src/galaxy_ng/dev/compose/signing/setup_signing_services.sh;
+        echo 'Signing Services';
+        curl -s -u $DJANGO_SUPERUSER_USERNAME:$DJANGO_SUPERUSER_PASSWORD http://api:24817/api/galaxy/pulp/api/v3/signing-services/?fields=name,script,pubkey_fingerprint | python -m json.tool;
+        /src/galaxy_ng/dev/compose/signing/setup_repo_keyring.sh;
+        echo ' ';
+        echo '###################### API ROOT ##############################';
+        curl -s -u $DJANGO_SUPERUSER_USERNAME:$DJANGO_SUPERUSER_PASSWORD http://api:24817/api/galaxy/ | python -m json.tool;
+        echo '################### DEV_SOURCE_PATH ##########################';
+        echo $DEV_SOURCE_PATH;
+        echo ' ';
+        echo '######################## READY ###############################';
+        echo ' ';
+        echo 'Credentials:  ' $DJANGO_SUPERUSER_USERNAME:$DJANGO_SUPERUSER_PASSWORD;
+        echo 'API Spec:      http://localhost:5001/api/galaxy/v3/swagger-ui/';
+        echo 'Django Admin:  docker compose -f dev/compose/ldap.yaml exec manager pulpcore-manager';
+        echo 'Settings list: docker compose -f dev/compose/ldap.yaml exec manager dynaconf list';
+        echo 'Docs:          https://github.com/ansible/galaxy_ng/blob/master/dev/compose/README.md';
+        echo '##############################################################';
+        tail -f /dev/null
+      "
+
+  nginx:
+    image: "nginx:latest"
+    depends_on:
+      - postgres
+      - migrations
+      - api
+      - content
+      - keycloak
+    ports:
+      - '5001:5001'
+    volumes:
+      - '../nginx/nginx.conf:/etc/nginx/nginx.conf:ro'
+
+  ldap:
+    image: "rroemhild/test-openldap"
+    environment:
+      <<: *common-env
+    ports:
+      - "10389:10389"
+      - "10636:10636"
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+
+  keycloak:
+    image: "quay.io/keycloak/keycloak:legacy"
+    environment:
+      <<: *common-env
+      DB_VENDOR: POSTGRES
+      DB_ADDR: kc-postgres
+      DB_DATABASE: keycloak
+      DB_USER: keycloak
+      DB_PASSWORD: keycloak
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+    ports:
+      - "8080:8080"
+    depends_on:
+      - kc-postgres
+    volumes:
+      - "./standalone-keycloak/keycloak.conf:/opt/jboss/keycloak/standalone/configuration/keycloak.conf:ro"
+
+  kc-postgres:
+    image: "postgres:13"
+    volumes:
+      - kc_pg_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
+      POSTGRES_DB: keycloak
+
+volumes:
+  var_lib_pulp_ldap:
+    name: var_lib_pulp_ldap
+  etc_pulp_certs:
+    name: etc_pulp_certs
+  kc_pg_data:
+    name: kc_pg_data
+
+networks:
+  service-mesh:
+    name: service-mesh


### PR DESCRIPTION
What is this PR doing:

This PR introduces a new Docker Compose configuration file, keycloak.yaml (Keycloak Profile), to the galaxy_ng/dev/compose directory. Implement Keycloak authentication with LDAP integration for Ansible Automation Hub, enabling centralized user management and single sign-on capabilities across the platform.


Issue: AAP-32586 - Add docker-compose file for Keycloak profile
Please see: https://issues.redhat.com/browse/AAP-32586

