### PR TITLE
[stable-4.9] Backport skopeo to `Dockerfile.rhel8`

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -22,7 +22,7 @@ COPY requirements/requirements.insights.txt /tmp/requirements.txt
 # NOTE: en_US.UTF-8 locale is provided by glibc-langpack-en
 RUN set -ex; \
     DNF="dnf -y --disableplugin=subscription-manager" && \
-    INSTALL_PKGS="glibc-langpack-en git-core libpq python3.11 python3.11-pip" && \
+    INSTALL_PKGS="glibc-langpack-en git-core libpq python3.11 python3.11-pip skopeo" && \
     INSTALL_PKGS_BUILD="gcc libpq-devel python3.11-devel openldap-devel" && \
     LANG=C ${DNF} install ${INSTALL_PKGS} ${INSTALL_PKGS_BUILD} && \
     python3.11 -m venv "${VIRTUAL_ENV}" && \


### PR DESCRIPTION
Error: `skopeo: command not found`
```
manager-1       | Traceback (most recent call last):
manager-1       |   File "/venv/bin/pulpcore-manager", line 8, in <module>
manager-1       |     sys.exit(manage())
manager-1       |              ^^^^^^^^
manager-1       |   File "/venv/lib64/python3.11/site-packages/pulpcore/app/manage.py", line 11, in manage
manager-1       |     execute_from_command_line(sys.argv)
manager-1       |   File "/venv/lib64/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
manager-1       |     utility.execute()
manager-1       |   File "/venv/lib64/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
manager-1       |     self.fetch_command(subcommand).run_from_argv(self.argv)
manager-1       |   File "/venv/lib64/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
manager-1       |     self.execute(*args, **cmd_options)
manager-1       |   File "/venv/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
manager-1       |     output = self.handle(*args, **options)
manager-1       |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
manager-1       |   File "/venv/lib64/python3.11/site-packages/pulpcore/app/management/commands/add-signing-service.py", line 89, in handle
manager-1       |     SigningService.objects.create(
manager-1       |   File "/venv/lib64/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
manager-1       |     return getattr(self.get_queryset(), name)(*args, **kwargs)
manager-1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
manager-1       |   File "/venv/lib64/python3.11/site-packages/django/db/models/query.py", line 658, in create
manager-1       |     obj.save(force_insert=True, using=self.db)
manager-1       |   File "/venv/lib64/python3.11/site-packages/pulpcore/app/models/content.py", line 869, in save
manager-1       |     self.validate()
manager-1       |   File "/venv/lib64/python3.11/site-packages/pulp_container/app/models.py", line 457, in validate
manager-1       |     signed = self.sign(
manager-1       |              ^^^^^^^^^^
manager-1       |   File "/venv/lib64/python3.11/site-packages/pulpcore/app/models/content.py", line 812, in sign
manager-1       |     raise RuntimeError(str(completed_process.stderr))
manager-1       | RuntimeError: b'/var/lib/pulp/scripts/container_sign.sh: line 6: skopeo: command not found\n'
```