### PR TITLE
chore: Makefile help text reorg + utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,12 @@
 .SILENT:
 
-
-
 .DEFAULT:
 .PHONY: help
 help:             ## Show the help.
 	@echo "Usage: make <target>"
 	@echo ""
 	@echo "Targets:"
-	@fgrep "##" Makefile | fgrep -v fgrep | sed 's/^/\n/' | sed 's/#/\n/'
-
+	@grep -F "##" Makefile | grep -F -v grep -F | sed 's/^/\n/' | sed 's/#/\n/'
 
 # Update python dependencies lock files (i.e. requirements.*.txt)
 
@@ -44,86 +41,150 @@ fmt:              ## Format the code using Darker
 	@echo "Formatting code using darker, just like black, but only on changed regions of files."
 	darker
 
-# Container environment management
-
-.PHONY: docker/test/integration/container
-docker/test/integration/container:      ## Run integration tests.
-	docker build . -f dev/standalone/integration-test-dockerfile -t galaxy-integration-runner
-	docker run -it --rm --add-host=localhost:host-gateway galaxy-integration-runner $(FLAGS)
-
-.PHONY: docker/db_snapshot
-NAME ?= galaxy
-docker/db_snapshot:   ## Snapshot database with optional NAME param. Example: make docker/db_snapshot NAME=my_special_backup
-	docker exec galaxy_ng_postgres_1 pg_dump -U galaxy_ng -F c -b -f "/galaxy.backup" galaxy_ng
-	mkdir -p db_snapshots/
-	docker cp galaxy_ng_postgres_1:/galaxy.backup db_snapshots/$(NAME).backup
-
-.PHONY: docker/db_restore
-NAME ?= galaxy
-docker/db_restore:   ## Restore database from a snapshot with optional NAME param. Example: make docker/db_restore NAME=my_special_backup
-	docker cp db_snapshots/$(NAME).backup galaxy_ng_postgres_1:/galaxy.backup
-	docker exec galaxy_ng_postgres_1 pg_restore --clean -U galaxy_ng -d galaxy_ng "/galaxy.backup"
-
-# Application management and debugging
-
-.PHONY: api/push-test-images
-api/push-test-images:   ## Pushes a set of test container images
-	docker login -u admin -p admin localhost:5001 || echo "!!! docker login failed, check if docker is running"
-	for foo in postgres treafik mongo mariadb redis node mysql busybox alpine docker python hhtpd nginx memcached golang; do  docker pull $$foo; docker image tag $$foo localhost:5001/$$foo:latest; docker push localhost:5001/$$foo:latest; done
-
 # Version / bumpversion management
 
-# 'bumpversion path' to go from 4.1.0 -> 4.1.1
-dev/bumpversion-patch:
+.PHONY: dev/bumpversion-patch
+dev/bumpversion-patch:  ## 'bumpversion path' to go from 4.1.0 -> 4.1.1
 	bump2version --verbose patch
 
-# 'bumpversion minor' to go from 4.1.1 -> 4.2.0
-dev/bumpversion-minor:
+.PHONY: bumpversion-minor
+dev/bumpversion-minor:  ## 'bumpversion minor' to go from 4.1.1 -> 4.2.0
 	bump2version --verbose minor
 
-# 'bumpversion major' to go from 4.2.9 -> 5.0.0
-dev/bumpversion-major:
+.PHONY: bumpversion-major
+dev/bumpversion-major:  ## 'bumpversion major' to go from 4.2.9 -> 5.0.0
 	bump2version --verbose major
 
-# 'bumpversion build' to go from 5.3.7.a1 -> 5.3.7.a2
-dev/bumpversion-build:
+.PHONY: dev/bumpversion-build
+dev/bumpversion-build:  ## 'bumpversion build' to go from 5.3.7.a1 -> 5.3.7.a2
 	bump2version --verbose build
 
-# 'bumpversion release' to from 5.3.7.a1 -> 5.3.7.b1
 # another 'bumpversion release' to from from 5.3.7.b1 -> 5.3.7
-dev/bumpversion-release:
+.PHONY: dev/bumpversion-release
+dev/bumpversion-release:  ## 'bumpversion release' to from 5.3.7.a1 -> 5.3.7.b1
 	bump2version --verbose release
 
-docs/install:
+# Documentation Management
+
+.PHONY: docs/clean
+docs/clean:  ## Clean the documentation
+	@rm -rf site
+
+.PHONY: docs/install
+docs/install:   ## Install the documentation dependencies
 	@pip install -r doc_requirements.txt
 	@pip install -U 'Jinja2==3.0.1'
 
-docs/build:
+.PHONY: docs/build
+docs/build:  ## Build the documentation
 	@mkdocs build --clean
 
-docs/serve:
+.PHONY: docs/serve
+docs/serve:  ## Serve the documentation
 	@mkdocs serve
 
-#########################################################
-# Simple stack spinup ... please don't overengineer this
-#########################################################
+
+# Docker Compose Environment Management
 
 .PHONY: compose/standalone
-compose/standalone:
+compose/standalone:  ## Spin up a standalone stack
 	docker compose -f dev/compose/standalone.yaml up
 
+.PHONY: compose/standalone/down
+compose/standalone/down:  ## Stop a standalone stack
+	docker compose -f dev/compose/standalone.yaml down
+
 .PHONY: compose/insights
-compose/insights:
+compose/insights:  ## Spin up a insights stack
 	docker compose -f dev/compose/insights.yaml up
 
+.PHONY: compose/insights/down
+compose/insights/down:  ## Stop a insights stack
+	docker compose -f dev/compose/insights.yaml down
+
 .PHONY: compose/aap
-compose/aap:
+compose/aap:  ## Spin up AAP stack
 	docker compose -f dev/compose/aap.yaml up
 
+.PHONY: compose/aap/down
+compose/aap/down:  ## Stop AAP stack
+	docker compose -f dev/compose/aap.yaml down
+
 .PHONY: compose/community
-compose/community:
+compose/community:  ## Spin up a community stack
 	docker compose -f dev/compose/community.yaml up
 
+.PHONY: compose/community/down
+compose/community/down:  ## Stop a community stack
+	docker compose -f dev/compose/community.yaml down
+
 .PHONY: compose/certified
-compose/certified:
+compose/certified:  ## Spin up a certified stack
 	docker compose -f dev/compose/certified-sync.yaml up
+
+.PHONY: compose/certified/down
+compose/certified/down:  ## Stop a certified stack
+	docker compose -f dev/compose/certified-sync.yaml down
+
+# Dev Environment Utils
+
+.PHONY: compose/db_snapshot
+NAME ?= galaxy
+compose/db_snapshot:   ## Snapshot database with optional NAME param. Example: make docker/db_snapshot NAME=my_special_backup
+	docker exec compose-postgres-1 pg_dump -U galaxy_ng -F c -b -f "/galaxy.backup" galaxy_ng
+	mkdir -p db_snapshots/
+	docker cp compose-postgres-1:/galaxy.backup db_snapshots/$(NAME).backup
+
+.PHONY: compose/db_restore
+NAME ?= galaxy
+compose/db_restore:   ## Restore database from a snapshot with optional NAME param. Example: make docker/db_restore NAME=my_special_backup
+	docker cp db_snapshots/$(NAME).backup compose-postgres-1:/galaxy.backup
+	docker exec compose-postgres-1 pg_restore --clean -U galaxy_ng -d galaxy_ng "/galaxy.backup"
+
+.PHONY: compose/db_shell
+compose/db_shell:   ## Open a shell in the database container
+	docker exec -it compose-postgres-1 psql -U galaxy_ng galaxy_ng
+
+.PHONY: compose/dj_shell
+compose/dj_shell:   ## Open a shell in the django container
+	docker exec -it compose-manager-1 django-admin shell_plus
+
+.PHONY: compose/dj_show_urls
+compose/dj_show_urls:   ## Show the urls registered in Django
+	docker exec compose-manager-1 django-admin show_urls
+
+.PHONY: compose/dynaconf/inspect
+compose/dynaconf/inspect:   ## Inspect the dynaconf configuration
+	docker exec compose-manager-1 dynaconf inspect -m debug -vv --format yaml
+
+# Test data population
+
+.PHONY: push-test-images
+push-test-images:   ## Pushes a set of test container images
+	docker login -u admin -p admin localhost:5001 || echo "!!! docker login failed, check if docker is running"
+	for foo in postgres treafik mongo mariadb redis node mysql busybox alpine docker python hhtpd nginx memcached golang; do  docker pull $$foo; docker image tag $$foo localhost:5001/$$foo:latest; docker push localhost:5001/$$foo:latest; done
+
+# Local execution of tests
+
+.PHONY: test/unit
+test/unit:  ## Run unit tests
+	# if tox is not found raise a warning and install it
+	@which tox || (echo "tox not found, installing it now" && pip install tox)
+	tox -e py311
+
+.PHONY: test/integration/standalone 
+test/integration/standalone:  ## Run integration tests
+	# if pytest is not found raise a warning and install it
+	@which pytest || (echo "pytest not found, installing it now" && pip install -r integration_requirements.txt)
+	@echo "Running integration tests"
+	HUB_ADMIN_PASS=admin \
+	HUB_API_ROOT=http://localhost:5001/api/galaxy/ \
+	GALAXYKIT_SLEEP_SECONDS_POLLING=.5 \
+    GALAXYKIT_SLEEP_SECONDS_ONETIME=.5 \
+    GALAXYKIT_POLLING_MAX_ATTEMPTS=50 \
+    GALAXY_SLEEP_SECONDS_POLLING=.5 \
+    GALAXY_SLEEP_SECONDS_ONETIME=.5 \
+    GALAXY_POLLING_MAX_ATTEMPTS=50 \
+	pytest  galaxy_ng/tests/integration \
+	-p 'no:pulpcore' -p 'no:pulp_ansible' \
+	-v -r sx --color=yes -m 'deployment_standalone or all'


### PR DESCRIPTION
## Before

```console
❯ make                             
Usage: make <target>

Targets:
fgrep: warning: fgrep is obsolescent; using grep -F
fgrep: warning: fgrep is obsolescent; using grep -F

help:             
# Show the help.

requirements/no-pip-upgrade:     
# Update based on setup.py and *.in files without asking pip for latest version

requirements/pip-upgrade-single-package:     
# Update based on setup.py and *.in files, and parameter via pip, i.e. package=djangorestframework

requirements/pip-upgrade-all:     
# Update based on setup.py and *.in files, and all packages via pip

lint:             
# Lint the code

fmt:              
# Format the code using Darker

docker/test/integration/container:      
# Run integration tests.

docker/db_snapshot:   
# Snapshot database with optional NAME param. Example: make docker/db_snapshot NAME=my_special_backup

docker/db_restore:   
# Restore database from a snapshot with optional NAME param. Example: make docker/db_restore NAME=my_special_backup

api/push-test-images:   
# Pushes a set of test container images


########################################################


########################################################
```

## After

```console
❯ make                            
Usage: make <target>

Targets:

help:             
# Show the help.

requirements/no-pip-upgrade:     
# Update based on setup.py and *.in files without asking pip for latest version

requirements/pip-upgrade-single-package:     
# Update based on setup.py and *.in files, and parameter via pip, i.e. package=djangorestframework

requirements/pip-upgrade-all:     
# Update based on setup.py and *.in files, and all packages via pip

lint:             
# Lint the code

fmt:              
# Format the code using Darker

dev/bumpversion-patch:  
# 'bumpversion path' to go from 4.1.0 -> 4.1.1

dev/bumpversion-minor:  
# 'bumpversion minor' to go from 4.1.1 -> 4.2.0

dev/bumpversion-major:  
# 'bumpversion major' to go from 4.2.9 -> 5.0.0

dev/bumpversion-build:  
# 'bumpversion build' to go from 5.3.7.a1 -> 5.3.7.a2

dev/bumpversion-release:  
# 'bumpversion release' to from 5.3.7.a1 -> 5.3.7.b1

docs/clean:  
# Clean the documentation

docs/install:   
# Install the documentation dependencies

docs/build:  
# Build the documentation

docs/serve:  
# Serve the documentation

compose/standalone:  
# Spin up a standalone stack

compose/insights:  
# Spin up a insights stack

compose/aap:  
# Spin up AAP stack

compose/community:  
# Spin up a community stack

compose/certified:  
# Spin up a certified stack

compose/db_snapshot:   
# Snapshot database with optional NAME param. Example: make docker/db_snapshot NAME=my_special_backup

compose/db_restore:   
# Restore database from a snapshot with optional NAME param. Example: make docker/db_restore NAME=my_special_backup

compose/db_shell:   
# Open a shell in the database container

compose/dj_shell:   
# Open a shell in the django container

compose/dj_show_urls:   
# Show the urls registered in Django

compose/dynaconf/inspect:   
# Inspect the dynaconf configuration

push-test-images:   
# Pushes a set of test container images

test/unit:  
# Run unit tests

test/integration/standalone:  
# Run integration tests

```