### PR TITLE
Set `retain_repo_versions: 1` to `validated` repository

### DIFF
--- a/galaxy_ng/app/migrations/0056_set_retain_repo_versions_to_validated_repo.py
+++ b/galaxy_ng/app/migrations/0056_set_retain_repo_versions_to_validated_repo.py
@@ -6,7 +6,7 @@ def set_retain_repo_versions_to_validated_repo(apps, schema_editor):
 
     db_alias = schema_editor.connection.alias
 
-    validated_repo = AnsibleRepository.objects.using(db_alias).filter(name="validateds").first()
+    validated_repo = AnsibleRepository.objects.using(db_alias).filter(name="validated").first()
     if validated_repo and validated_repo.retain_repo_versions is None:
         validated_repo.retain_repo_versions = 1
         validated_repo.save()

--- a/galaxy_ng/app/migrations/0056_set_retain_repo_versions_to_validated_repo.py
+++ b/galaxy_ng/app/migrations/0056_set_retain_repo_versions_to_validated_repo.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+def set_retain_repo_versions_to_validated_repo(apps, schema_editor):
+    AnsibleRepository = apps.get_model('ansible', 'AnsibleRepository')
+
+    db_alias = schema_editor.connection.alias
+
+    validated_repo = AnsibleRepository.objects.using(db_alias).filter(name="validateds").first()
+    if validated_repo and validated_repo.retain_repo_versions is None:
+        validated_repo.retain_repo_versions = 1
+        validated_repo.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("galaxy", "0055_remove_organization_users_remove_team_users"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=set_retain_repo_versions_to_validated_repo,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]


### PR DESCRIPTION
Issue: [AAP-41840](https://issues.redhat.com/browse/AAP-41840)

The migration file [0032_add_validated_repo.py](https://github.com/jerabekjiri/galaxy_ng/blob/master/galaxy_ng/app/migrations/0032_add_validated_repo.py), which creates the `validated` repository, runs after [0022_enforce_retain_repo_versions.py](https://github.com/jerabekjiri/galaxy_ng/blob/master/galaxy_ng/app/migrations/0022_enforce_retain_repo_versions.py), causing `validated` repo to have a default value `None`. 
