### PR TITLE
fix: Bump lower bound galaxy_importer on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ django_ansible_base_dependency = (
 )
 
 requirements = [
-    "galaxy-importer>=0.4.27,<0.5.0",
+    "galaxy-importer>=0.4.29,<0.5.0",
     "pulpcore>=3.49.0,<3.50.0",
     "pulp_ansible==0.23.1",
     "pulp-container>=2.19.2,<2.20.0",


### PR DESCRIPTION
RPM Builds are made based on what is on setup.py
to enforce 0.4.29 we need lower bound to bump.

For cloud deployments and Dev env the pin comes
from the requirements files.