### PR TITLE
[backport 4.10] enable middleware to log traceback on timeout (#2254)

### DIFF
--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -99,6 +99,7 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',
     'django_guid.middleware.guid_middleware',
     'pulpcore.middleware.DomainMiddleware',
+    'ansible_base.lib.middleware.logging.log_request.LogTracebackMiddleware',
     # END: Pulp standard middleware
     'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]


### PR DESCRIPTION
Issue: AAP-29982 enable middleware to log traceback on timeout

gunicorn sends a signal 6 when it is about to timeout a request This middleware handles that request and logs a traceback.

this aids in debugging infrastructure issues that may be causing requests to timeout.

(cherry picked from commit 414a532b90fb2e60ff1f28b3b81a382fa0ad9771)

#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAH-####

#### Reviewers must know:
<!-- e.g: Testing steps, dependencies, needed branches etc. -->

**PR Author & Reviewers**: Keep or remove backport labels per [Backporting Guidelines](https://github.com/ansible/galaxy_ng/wiki/Backporting-Guidelines)
**Reviewers**: Look for sound code, no [code smells](https://www.codegrip.tech/productivity/everything-you-need-to-know-about-code-smells/), docs & test coverage
**Merger**: When merging, include the Jira issue link in the squashed commit
