### PR TITLE
chore: Use a different sonar cloud badge on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img align="left" width="150" src="https://raw.githubusercontent.com/ansible/logos/be211ebccc316652eb725db688e75d932f8fa073/galaxy/galaxy-logo.svg">
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ansible_galaxy_ng&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ansible_galaxy_ng)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible_galaxy_ng&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ansible_galaxy_ng)
 [![Build Status](https://github.com/ansible/galaxy_ng/actions/workflows/ci-docker-compose-integration.yml/badge.svg)](https://github.com/ansible/galaxy_ng/actions/workflows/ci-docker-compose-integration.yml)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ansible_galaxy_ng&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ansible_galaxy_ng)
 


### PR DESCRIPTION
From this
[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ansible_galaxy_ng&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ansible_galaxy_ng)

To this
[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible_galaxy_ng&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ansible_galaxy_ng)

Reason: It will take time for us to add code coverage to reach 80% set in the sonar way, not sure this will ever be an effort, the red alert is already reised on the sonar dashboard.

The Maintanability badge will become yellow (B) or red (C) if we ever introduce higher code complexity or code smells.