### PR TITLE
Revert "backport stable4.10: Bump galaxy-importer to 0.4.29"

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -163,7 +163,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-galaxy-importer==0.4.29
+galaxy-importer==0.4.25
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -309,7 +309,6 @@ packaging==23.2
     #   ansible-lint
     #   bindep
     #   black
-    #   galaxy-importer
     #   gunicorn
     #   marshmallow
     #   pulp-glue

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -51,6 +51,10 @@ bindep==2.11.0
     # via ansible-builder
 black==24.4.2
     # via ansible-lint
+bleach==3.3.1
+    # via galaxy-importer
+bleach-allowlist==1.0.3
+    # via galaxy-importer
 boto3==1.34.149
     # via
     #   -r requirements/requirements.insights.in
@@ -179,7 +183,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-galaxy-importer==0.4.29
+galaxy-importer==0.4.24
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -258,8 +262,6 @@ multidict==6.0.5
     #   yarl
 mypy-extensions==1.0.0
     # via black
-nh3==0.2.21
-    # via galaxy-importer
 oauthlib==3.2.2
     # via
     #   requests-oauthlib
@@ -329,7 +331,7 @@ packaging==23.2
     #   ansible-lint
     #   bindep
     #   black
-    #   galaxy-importer
+    #   bleach
     #   gunicorn
     #   marshmallow
     #   pulp-glue
@@ -456,6 +458,7 @@ semantic-version==2.10.0
 six==1.16.0
     # via
     #   azure-core
+    #   bleach
     #   isodate
     #   python-dateutil
     #   url-normalize
@@ -499,6 +502,8 @@ watchtower==3.2.0
     # via -r requirements/requirements.insights.in
 wcmatch==8.5.2
     # via ansible-lint
+webencodings==0.5.1
+    # via bleach
 whitenoise==6.6.0
     # via pulpcore
 wrapt==1.16.0

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -163,7 +163,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-galaxy-importer==0.4.29
+galaxy-importer==0.4.25
     # via
     #   galaxy-ng (setup.py)
     #   pulp-ansible
@@ -309,7 +309,6 @@ packaging==23.2
     #   ansible-lint
     #   bindep
     #   black
-    #   galaxy-importer
     #   gunicorn
     #   marshmallow
     #   pulp-glue

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ django_ansible_base_dependency = (
 )
 
 requirements = [
-    "galaxy-importer>=0.4.29,<0.5.0",
+    "galaxy-importer>=0.4.21,<0.5.0",
     "pulpcore>=3.49.0,<3.50.0",
     "pulp_ansible>=0.21.0,<0.22.0",
     "pulp-container>=2.19.2,<2.20.0",


### PR DESCRIPTION
Reverts ansible/galaxy_ng#2482

The PR must be merged only after April 17 to get included on May 7 release.