### PR TITLE
tests fix: do not use ephemeral workaround in crc stage

### DIFF
--- a/galaxy_ng/tests/integration/utils/client_ansible_lib.py
+++ b/galaxy_ng/tests/integration/utils/client_ansible_lib.py
@@ -226,7 +226,7 @@ class AnsibeGalaxyHttpClient:
             headers["Content-Type"] = "application/text"
 
         # ephemeral workaround ...
-        if self._auth_url and 'localhost' not in self._auth_url and auth_required:
+        if self._auth_url and 'crc-eph' in self._auth_url and auth_required:
             btoken = self.get_bearer_token(grant_type='password')
             # btoken = self.get_bearer_token(grant_type='refresh_token')
             headers['Authorization'] = f'Bearer {btoken}'


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Modifies integration tests to NOT use password auth in CRC stage.

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAP-42264

