### PR TITLE
Bump pulp_ansible to 0.24.2

### DIFF
--- a/requirements/requirements.common.txt
+++ b/requirements/requirements.common.txt
@@ -336,7 +336,7 @@ psycopg[binary]==3.2.3
     # via pulpcore
 psycopg-binary==3.2.3
     # via psycopg
-pulp-ansible==0.23.1
+pulp-ansible==0.24.2
     # via galaxy-ng (setup.py)
 pulp-container==2.19.5
     # via galaxy-ng (setup.py)

--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -356,7 +356,7 @@ psycopg[binary]==3.2.3
     # via pulpcore
 psycopg-binary==3.2.3
     # via psycopg
-pulp-ansible==0.23.1
+pulp-ansible==0.24.2
     # via galaxy-ng (setup.py)
 pulp-container==2.19.5
     # via galaxy-ng (setup.py)

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -336,7 +336,7 @@ psycopg[binary]==3.2.3
     # via pulpcore
 psycopg-binary==3.2.3
     # via psycopg
-pulp-ansible==0.23.1
+pulp-ansible==0.24.2
     # via galaxy-ng (setup.py)
 pulp-container==2.19.5
     # via galaxy-ng (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ django_ansible_base_dependency = (
 requirements = [
     "galaxy-importer>=0.4.29,<0.5.0",
     "pulpcore>=3.49.0,<3.50.0",
-    "pulp_ansible==0.23.1",
+    "pulp_ansible==0.24.2",
     "pulp-container>=2.19.2,<2.20.0",
     "django-prometheus>=2.0.0",
     "social-auth-core>=4.4.2",


### PR DESCRIPTION
#### What is this PR doing:
Bump pulp_ansible to 0.24.2 to resolve issue installing collections when differing versions of the same collection are synced from rh-certified and then community before trying to install.  See ticket for detailed reproduction steps. 

Issue: AAP-24271
