### PR TITLE
fix(dev): Set permissions and compat mode for devinstall

### DIFF
--- a/dev/compose/bin/devinstall
+++ b/dev/compose/bin/devinstall
@@ -11,14 +11,26 @@ for item in "${SRC_PATH_LIST[@]}"; do
     if [[ -d "$src_path" ]]; then
         echo "Installing path ${item} in editable mode."
 
+        # NOTE: `--config-settings editable_mode=compat` was added to allow editable install of
+        # projects still using `setup.py`, in the case it was dynaconf 3.2.x, once all relevant deps migrate
+        # to pyproject.toml that parameter can be removed.
         if [[ "${LOCK_REQUIREMENTS}" -eq "1" ]]; then
-            pip3.11 install --no-cache-dir --no-deps --editable "$src_path" >/dev/null
+            pip3.11 install --config-settings editable_mode=compat --no-cache-dir --no-deps --editable "$src_path" >/dev/null
         else
-            pip3.11 install --no-cache-dir --editable "$src_path" >/dev/null
+            pip3.11 install --config-settings editable_mode=compat --no-cache-dir --editable "$src_path" >/dev/null
+        fi
+
+        # if running as root user, set permissions on /src/${item} to be owned by user named galaxy
+        if [[ "$(id -u)" -eq 0 ]]; then
+            if id -u galaxy >/dev/null 2>&1; then
+                echo "Setting ownership of ${src_path} to user galaxy."
+                chown -R galaxy:galaxy "$src_path"
+            else
+                echo "WARNING: User 'galaxy' not found. Skipping permission changes for ${src_path}."
+            fi
         fi
 
     else
         echo "WARNING: Source path ${item} is not a directory."
     fi
 done
-


### PR DESCRIPTION
After installing the editable dep, permissions must be fixed.

Dynaconf is still using `setup.py` on 3.2.x, so be able to install it as editable the new pip requires a parameter.

