### PR TITLE
Fix duplicated entry_points

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,8 @@ RUN set -ex; \
                                /etc/pulp/{certs,keys} \
                                /tmp/ansible && \
     install -dm 0700 -o galaxy /etc/pulp/gnupg && \
+    pip3.11 install --config-settings editable_mode=compat --no-deps --editable /app && \
     chown -R galaxy ${VIRTUAL_ENV} && \
-    pip3.11 install --no-deps --editable /app && \
     PULP_CONTENT_ORIGIN=x django-admin collectstatic && \
     install -Dm 0644 -o galaxy /app/ansible.cfg /etc/ansible/ansible.cfg && \
     install -Dm 0644 -o galaxy /app/docker/etc/settings.py /etc/pulp/settings.py && \


### PR DESCRIPTION
ref: https://github.com/pypa/setuptools/issues/3649

now:
```
In [1]: from importlib.metadata import entry_points

In [2]: [e.name for e in entry_points(group="pulpcore.plugin") if "galaxy_ng" in e.name]
Out[2]: ['galaxy_ng']
```

before:
```
In [1]: from importlib.metadata import entry_points

In [2]: [e.name for e in entry_points(group="pulpcore.plugin") if "galaxy_ng" in e.name]
Out[2]: ['galaxy_ng', 'galaxy_ng']
```
