### PR TITLE
fix: remove ALLOW_LOCAL_RESOURCE_MANAGEMENT setting

### DIFF
--- a/dev/compose/aap.yaml
+++ b/dev/compose/aap.yaml
@@ -59,8 +59,6 @@ x-common-env: &common-env
   PULP_ANSIBLE_BASE_JWT_VALIDATE_CERT: 'false'
   PULP_ANSIBLE_BASE_JWT_KEY: 'https://localhost'
 
-  # disable user/group modifications
-  PULP_ALLOW_LOCAL_RESOURCE_MANAGEMENT: 'false'
 
   # role content workaround ..
   PULP_ANSIBLE_BASE_ROLES_REQUIRE_VIEW: 'false'

--- a/dev/compose/certified-sync.yaml
+++ b/dev/compose/certified-sync.yaml
@@ -38,9 +38,6 @@ x-common-env: &common-env
   PULP_GALAXY_REQUIRE_CONTENT_APPROVAL: 'true'
   PULP_GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL: 'false'
 
-  # disable user/group modifications
-  PULP_ALLOW_LOCAL_RESOURCE_MANAGEMENT: 'true'
-
   # role content workaround ..
   PULP_ANSIBLE_BASE_ROLES_REQUIRE_VIEW: 'false'
 

--- a/dev/compose/community.yaml
+++ b/dev/compose/community.yaml
@@ -64,9 +64,6 @@ x-common-env: &common-env
   PULP_GALAXY_REQUIRE_CONTENT_APPROVAL: 'false'
   PULP_GALAXY_AUTO_SIGN_COLLECTIONS: 'false'
 
-  # disable user/group modifications
-  PULP_ALLOW_LOCAL_RESOURCE_MANAGEMENT: 'true'
-
   # role content workaround
   PULP_ANSIBLE_BASE_ROLES_REQUIRE_VIEW: 'false'
 

--- a/dev/compose/standalone.yaml
+++ b/dev/compose/standalone.yaml
@@ -59,9 +59,6 @@ x-common-env: &common-env
   PULP_ANSIBLE_BASE_JWT_VALIDATE_CERT: 'false'
   PULP_ANSIBLE_BASE_JWT_KEY: 'https://localhost'
 
-  # disable user/group modifications
-  PULP_ALLOW_LOCAL_RESOURCE_MANAGEMENT: 'true'
-
   # role content workaround ..
   PULP_ANSIBLE_BASE_ROLES_REQUIRE_VIEW: 'false'
 

--- a/galaxy_ng/app/access_control/access_policy.py
+++ b/galaxy_ng/app/access_control/access_policy.py
@@ -576,8 +576,11 @@ class AccessPolicyBase(AccessPolicyFromDB):
                 })
         return True
 
-    def is_local_resource_management_disabled(self, request, view, action):
-        return not settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT
+    def is_local_resource_management_disabled(self, request, view, action) -> bool:
+        """
+        If the resource server is configured, then local resource management is disabled.
+        """
+        return settings.get("IS_CONNECTED_TO_RESOURCE_SERVER")
 
     def user_is_superuser(self, request, view, action):
         if getattr(self, "swagger_fake_view", False):

--- a/galaxy_ng/app/api/ui/v1/serializers/user.py
+++ b/galaxy_ng/app/api/ui/v1/serializers/user.py
@@ -175,7 +175,7 @@ class CurrentUserSerializer(UserSerializer):
     @extend_schema_field(OpenApiTypes.OBJECT)
     def get_model_permissions(self, obj):
         permissions = {}
-        allow_group_user_edits = settings.get("ALLOW_LOCAL_RESOURCE_MANAGEMENT", True)
+        allow_group_user_edits = not settings.get("IS_CONNECTED_TO_RESOURCE_SERVER")
         for i, j in PERMISSIONS.items():
             permissions[i] = j
             permissions[i]["has_model_permission"] = obj.has_perm(i)

--- a/galaxy_ng/app/api/ui/v1/views/settings.py
+++ b/galaxy_ng/app/api/ui/v1/views/settings.py
@@ -28,7 +28,6 @@ class SettingsView(api_base.APIView):
             "KEYCLOAK_URL",
             "ANSIBLE_BASE_JWT_VALIDATE_CERT",
             "ANSIBLE_BASE_JWT_KEY",
-            "ALLOW_LOCAL_RESOURCE_MANAGEMENT",
             "ANSIBLE_BASE_ROLES_REQUIRE_VIEW",
             "DYNACONF_AFTER_GET_HOOKS",
             "ANSIBLE_API_HOSTNAME",
@@ -36,6 +35,7 @@ class SettingsView(api_base.APIView):
             "CONTENT_ORIGIN",
             "TOKEN_SERVER",
             "TOKEN_AUTH_DISABLED",
+            "IS_CONNECTED_TO_RESOURCE_SERVER",
         ]
         settings_dict = settings.as_dict()
         data = {key: settings_dict.get(key, None) for key in keyset}

--- a/galaxy_ng/app/api/ui/v2/permissions.py
+++ b/galaxy_ng/app/api/ui/v2/permissions.py
@@ -27,10 +27,9 @@ class ComplexUserPermissions(AnsibleBaseUserPermissions):
     ComplexUserPermissions complies with the "complex" requirements
     of a system where there is a resource server that syncs users
     and a jwt that creates users and a confusing mix of how is_superuser
-    can get populated on galaxy when ALLOW_LOCAL_RESOURCE_MANAGEMENT
-    is False,
+    can get populated on galaxy when the resource server is configured,
 
-    To try to break down the logic when ALLOW_LOCAL_RESOURCE_MANAGEMENT=False:
+    To try to break down the logic when the resource server is configured:
         - users CAN NOT be created/edited/deleted directly in galaxy, except ...
         - if the request is a PATCH or a PUT that is only modifying the value
           of is_superuser, then it can be allowed
@@ -46,13 +45,13 @@ class ComplexUserPermissions(AnsibleBaseUserPermissions):
     def has_permission(self, request, view):
         if (
             request.user.is_superuser
-            and settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is not False
+            and not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER')
         ):
             return True
 
         if (
             request.method not in ('GET', 'HEAD', 'PUT', 'PATCH')
-            and settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False
+            and settings.get('IS_CONNECTED_TO_RESOURCE_SERVER')
         ):
             return False
 
@@ -61,7 +60,7 @@ class ComplexUserPermissions(AnsibleBaseUserPermissions):
     def has_object_permission(self, request, view, obj):
         if (
             request.user.is_superuser
-            and settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is not False
+            and not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER')
         ):
             return True
 

--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -87,6 +87,9 @@ def post(settings: Dynaconf, run_dynamic: bool = True, run_validate: bool = True
     data.update(configure_authentication_backends(settings, data))
     data.update(configure_authentication_classes(settings, data))
 
+    # When the resource server is configured, local resource management is disabled.
+    data["IS_CONNECTED_TO_RESOURCE_SERVER"] = settings.get("RESOURCE_SERVER__URL") is not None
+
     # This must go last, so that all the default settings are loaded before dynamic and validation
     if run_dynamic:
         data.update(configure_dynamic_settings(settings))

--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -450,9 +450,6 @@ ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
 # WARNING: This setting is used in database migrations to create a default organization.
 DEFAULT_ORGANIZATION_NAME = "Default"
 
-# If False it disables editing and managing users and groups.
-ALLOW_LOCAL_RESOURCE_MANAGEMENT = True
-
 # https://github.com/ansible/django-ansible-base/pull/611
 RENAMED_USERNAME_PREFIX = "galaxy_"
 

--- a/galaxy_ng/tests/integration/aap/test_aap_user_management.py
+++ b/galaxy_ng/tests/integration/aap/test_aap_user_management.py
@@ -104,8 +104,8 @@ def test_aap_galaxy_normal_user_can_not_demote_superuser(
     gateway_admin_client,
     gateway_user_factory,
 ):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is not False:
-        pytest.skip("ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
+    if not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip("This test relies on being connected to a resource server")
 
     u1 = gateway_user_factory()
     u2 = gateway_user_factory()
@@ -145,8 +145,8 @@ def test_aap_galaxy_local_resource_management_setting_gates_user_creation(
     gateway_admin_client,
     random_username
 ):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is not False:
-        pytest.skip("ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
+    if not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip("This test relies on being connected to a resource server")
 
     # make sure the user can't be created directly in galaxy ...
     resp = gateway_admin_client.post(
@@ -180,8 +180,8 @@ def test_aap_galaxy_local_resource_management_setting_gates_field_modification(
     gateway_admin_client,
     random_gateway_user,
 ):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is not False:
-        pytest.skip("ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
+    if not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip("This test relies on being connected to a resource server")
 
     uid = random_gateway_user.galaxy_v2_me['id']
     user_url = f'{users_endpoint}/{uid}/'
@@ -210,8 +210,8 @@ def test_aap_galaxy_local_resource_management_setting_gates_deletion(
     gateway_admin_client,
     random_gateway_user,
 ):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is not False:
-        pytest.skip("ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
+    if not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip("This test relies on being connected to a resource server")
 
     uid = random_gateway_user.galaxy_v2_me['id']
     user_url = f'{users_endpoint}/{uid}/'
@@ -230,8 +230,8 @@ def test_aap_galaxy_superuser_management(
     gateway_admin_client,
     random_gateway_user
 ):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is not False:
-        pytest.skip("ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
+    if not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip("This test relies on being connected to a resource server")
 
     ga = gateway_admin_client
     uc = random_gateway_user.user_client

--- a/galaxy_ng/tests/integration/api/test_groups.py
+++ b/galaxy_ng/tests/integration/api/test_groups.py
@@ -42,7 +42,7 @@ API_PREFIX = CLIENT_CONFIG.get("api_prefix").rstrip("/")
 def test_gw_group_role_listing(galaxy_client, settings, test_data):
     """Tests ability to list roles assigned to a namespace."""
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("this test relies on local resource creation")
 
     gc = galaxy_client("admin", ignore_cache=True)

--- a/galaxy_ng/tests/integration/api/test_load_data.py
+++ b/galaxy_ng/tests/integration/api/test_load_data.py
@@ -32,7 +32,7 @@ class TestLoadData:
     @pytest.mark.min_hub_version("4.6dev")
     @pytest.mark.load_data
     def test_load_users_and_groups(self, galaxy_client, settings, data):
-        if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
+        if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
             pytest.skip("this test relies on local resource creation")
 
         gc = galaxy_client("admin")

--- a/galaxy_ng/tests/integration/api/test_ui_paths.py
+++ b/galaxy_ng/tests/integration/api/test_ui_paths.py
@@ -781,7 +781,7 @@ def test_api_ui_v1_settings(ansible_config):
         assert ds['GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD'] is False
         assert ds['GALAXY_REQUIRE_CONTENT_APPROVAL'] is True
 
-        assert ds["ALLOW_LOCAL_RESOURCE_MANAGEMENT"] in [True, False]
+        assert ds["IS_CONNECTED_TO_RESOURCE_SERVER"] in [True, False]
         assert ds["ANSIBLE_BASE_ROLES_REQUIRE_VIEW"] in [True, False]
         assert ds["TOKEN_AUTH_DISABLED"] in [True, False]
         assert "ANSIBLE_API_HOSTNAME" in ds

--- a/galaxy_ng/tests/integration/conftest.py
+++ b/galaxy_ng/tests/integration/conftest.py
@@ -409,7 +409,7 @@ def autohubtest2(galaxy_client):
 def random_namespace(galaxy_client, settings):
     """Make a randomized namespace."""
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("this test relies on local resource creation")
 
     gc = galaxy_client("admin")

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac.py
@@ -64,7 +64,7 @@ def test_dab_rbac_repository_owner_by_user_or_team(
     random_username
 ):
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("this test relies on local resource creation")
 
     gc = galaxy_client("admin", ignore_cache=True)
@@ -179,7 +179,7 @@ def test_dab_rbac_namespace_owner_by_user_or_team(
       to view a private repository that includes their collection.
     """
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("this test relies on local resource creation")
 
     gc = galaxy_client("admin", ignore_cache=True)
@@ -319,7 +319,7 @@ def test_dab_user_platform_auditor_bidirectional_sync(
     * when revoking the "Platform Auditor" roledef the galaxy.auditor role
       should also be revoked automatically,
     """
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("this test relies on local resource creation")
 
     gc = galaxy_client("admin", ignore_cache=True)
@@ -408,7 +408,7 @@ def test_dab_team_platform_auditor_bidirectional_sync(
     * when revoking the "Platform Auditor" roledef the galaxy.auditor role
       should also be revoked automatically,
     """
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("this test relies on local resource creation")
 
     gc = galaxy_client("admin", ignore_cache=True)
@@ -505,7 +505,7 @@ def test_dab_user_assignment_filtering_as_user(
     * The role_user_assignments endpoint behaves differently for
       evaluating a superuser vs a user for access.
     """
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("this test relies on local resource creation")
 
     gc = galaxy_client("admin", ignore_cache=True)
@@ -571,7 +571,7 @@ def test_dab_rbac_ee_ownership_with_user_or_team(
     * This does not check for functionality of the roledef.
     * This only validates the assignments.
     """
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("this test relies on local resource creation")
 
     ROLE_NAME = 'galaxy.execution_environment_namespace_owner'

--- a/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
+++ b/galaxy_ng/tests/integration/dab/test_dab_rbac_contract.py
@@ -229,7 +229,7 @@ def test_create_custom_namespace_system_admin_role(custom_role_factory, galaxy_c
 @pytest.mark.min_hub_version("4.10dev")
 def test_give_user_custom_role_system(settings, galaxy_client, custom_role_factory, namespace):
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT', True) is not True:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("this test relies on local resource creation")
 
     # TODO(cutwater): verify that assignment is seen in pulp API (HOW?)
@@ -303,7 +303,7 @@ def test_give_team_custom_role_system(
     team,
     namespace,
 ):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT', True) is not True:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("galaxykit uses drf tokens, which bypass JWT auth and claims processing")
 
     # Step 0: Setup test.
@@ -466,7 +466,7 @@ def test_give_team_custom_role_object(
     namespace,
     team,
 ):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT', True) is not True:
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
         pytest.skip("galaxykit uses drf tokens, which bypass JWT auth and claims processing")
 
     # Step 0: Setup test.

--- a/galaxy_ng/tests/integration/dab/test_disable_shared_resources.py
+++ b/galaxy_ng/tests/integration/dab/test_disable_shared_resources.py
@@ -5,8 +5,8 @@ import uuid
 
 @pytest.fixture
 def test_group(settings, galaxy_client):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
-        pytest.skip(reason="ALLOW_LOCAL_RESOURCE_MANAGEMENT=false")
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="This test relies on local resource management")
 
     gc = galaxy_client("admin")
 
@@ -15,8 +15,8 @@ def test_group(settings, galaxy_client):
 
 @pytest.fixture
 def test_user(settings, galaxy_client):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
-        pytest.skip(reason="ALLOW_LOCAL_RESOURCE_MANAGEMENT=false")
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="This test relies on local resource management")
 
     gc = galaxy_client("admin")
 
@@ -33,8 +33,8 @@ def test_user(settings, galaxy_client):
 @pytest.mark.deployment_standalone
 @pytest.mark.skip(reason="FIXME - skip until resource management is decided")
 def test_dab_groups_are_read_only(settings, galaxy_client, url, test_group):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') in [None, True]:
-        pytest.skip(reason="ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
+    if not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="This test relies on being connected to a resource server")
 
     gc = galaxy_client("admin")
 
@@ -75,8 +75,8 @@ def test_dab_groups_are_read_only(settings, galaxy_client, url, test_group):
 )
 @pytest.mark.deployment_standalone
 def test_dab_users_are_read_only(settings, galaxy_client, url, test_user):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') in [None, True]:
-        pytest.skip(reason="ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
+    if not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="This test relies on being connected to a resource server")
 
     gc = galaxy_client("admin")
 
@@ -109,8 +109,8 @@ def test_dab_users_are_read_only(settings, galaxy_client, url, test_user):
 @pytest.mark.deployment_standalone
 @pytest.mark.skip(reason="FIXME - skip until resource management is decided")
 def test_dab_cant_modify_group_memberships(settings, galaxy_client, test_user, test_group):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') in [None, True]:
-        pytest.skip(reason="ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
+    if not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="This test relies on being connected to a resource server")
 
     gc = galaxy_client("admin")
 
@@ -136,8 +136,8 @@ def test_dab_cant_modify_group_memberships(settings, galaxy_client, test_user, t
 @pytest.mark.deployment_standalone
 @pytest.mark.skip(reason="FIXME - skip until resource management is decided")
 def test_dab_can_modify_roles(settings, galaxy_client, test_user, test_group):
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') in [None, True]:
-        pytest.skip(reason="ALLOW_LOCAL_RESOURCE_MANAGEMENT=true")
+    if not settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="This test relies on being connected to a resource server")
 
     gc = galaxy_client("admin")
 

--- a/galaxy_ng/tests/integration/dab/test_ui_v2.py
+++ b/galaxy_ng/tests/integration/dab/test_ui_v2.py
@@ -28,8 +28,8 @@ def test_ui_v2_user_create(
 ):
     """Test user creation in ui/v2/users/."""
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
-        pytest.skip(reason="this only works local resource management enabled")
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="this test relies on local resource management")
 
     gc = galaxy_client("admin", ignore_cache=True)
 
@@ -81,8 +81,8 @@ def test_ui_v2_user_create_invalid_data(
 ):
     """Test user edits in ui/v2/users/ with invalid data."""
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
-        pytest.skip(reason="this only works local resource management enabled")
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="this test relies on local resource management")
 
     gc = galaxy_client("admin", ignore_cache=True)
 
@@ -115,8 +115,8 @@ def test_ui_v2_user_edit(
 ):
     """Test user edit in ui/v2/users/."""
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
-        pytest.skip(reason="this only works local resource management enabled")
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="this test relies on local resource management")
 
     gc = galaxy_client("admin", ignore_cache=True)
 
@@ -169,8 +169,8 @@ def test_ui_v2_user_edit_invalid_data(
 ):
     """Test user edits in ui/v2/users/ with invalid data."""
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
-        pytest.skip(reason="this only works local resource management enabled")
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="this test relies on local resource management")
 
     gc = galaxy_client("admin", ignore_cache=True)
 
@@ -213,8 +213,8 @@ def test_ui_v2_teams(
 ):
     """Test teams creation and deletion."""
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
-        pytest.skip(reason="this only works local resource management enabled")
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="this test relies on local resource management")
 
     client = galaxy_client("admin", ignore_cache=True)
 
@@ -256,8 +256,8 @@ def test_ui_v2_teams_membership_local_and_nonlocal(
 ):
     """Test teams creation and deletion."""
 
-    if settings.get('ALLOW_LOCAL_RESOURCE_MANAGEMENT') is False:
-        pytest.skip(reason="this only works local resource management enabled")
+    if settings.get('IS_CONNECTED_TO_RESOURCE_SERVER'):
+        pytest.skip(reason="this test relies on local resource management")
 
     org_name = random_username.replace('user_', 'org_')
     team1_name = random_username.replace('user_', 'team1_')


### PR DESCRIPTION
Issue: AAP-48071

This PR Replaces the usage of `ALLOW_LOCAL_RESOURCE_MANAGEMENT` flag with the condition based on `RESOURCE_SERVER__URL` being configured.

It adds a new transient setting resolved at the hooking level `IS_CONNECTED_TO_RESOURCE_SERVER` that will resolve to `True` if `RESOURCE_SERVER__URL` is configured, otherwise `False`.

When `IS_CONNECTED_TO_RESOURCE_SERVER` is True, then local resource management is considered disabled.