### PR TITLE
modify dab source to use full commit hash

### DIFF
--- a/requirements/requirements.insights.txt
+++ b/requirements/requirements.insights.txt
@@ -122,7 +122,7 @@ django==4.2.23
     #   insights-analytics-collector
     #   pulpcore
     #   social-auth-app-django
-django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@2025.7.29
+django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@894af11435d5a203255d81fbb15085f8b8feacc2
     # via galaxy-ng (setup.py)
 django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)

--- a/requirements/requirements.standalone.txt
+++ b/requirements/requirements.standalone.txt
@@ -108,7 +108,7 @@ django==4.2.23
     #   insights-analytics-collector
     #   pulpcore
     #   social-auth-app-django
-django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@2025.7.29
+django-ansible-base[feature-flags,jwt-consumer] @ git+https://github.com/ansible/django-ansible-base@894af11435d5a203255d81fbb15085f8b8feacc2
     # via galaxy-ng (setup.py)
 django-auth-ldap==4.0.0
     # via galaxy-ng (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,10 @@ class BuildPyCommand(_BuildPyCommand):
         return super().run()
 
 
-django_ansible_base_branch = os.getenv('DJANGO_ANSIBLE_BASE_BRANCH', '2025.7.29')
+# use full commit hash in place of DAB tag i.e. 2025.7.29 = 894af11435d5a203255d81fbb15085f8b8feacc2
+django_ansible_base_branch = os.getenv(
+    'DJANGO_ANSIBLE_BASE_BRANCH', '894af11435d5a203255d81fbb15085f8b8feacc2'
+)
 django_ansible_base_dependency = (
     'django-ansible-base[jwt-consumer,feature-flags] @ '
     f'git+https://github.com/ansible/django-ansible-base@{django_ansible_base_branch}'


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
Changes the DAB dependency to reference the full commit hash instead of the release tag. 
This is required for the downstream builds to cache the external dependency. For more info see: https://github.com/hermetoproject/hermeto/blob/main/docs/pip.md#external-dependencies

<!-- Add Jira issue link or replace with No-Issue -->
Issue: AAP-49734

