### PR TITLE
Enable the organization roles for JWT claims hashing

### DIFF
--- a/galaxy_ng/app/settings.py
+++ b/galaxy_ng/app/settings.py
@@ -440,9 +440,8 @@ ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {
     'sys_auditor': {'shortname': 'sys_auditor'},
     'team_member': {},
     'team_admin': {},
-    # TODO(jctanner): add organization to the registry later
-    # 'org_admin': {},
-    # 'org_member': {},
+    'org_admin': {},
+    'org_member': {},
 }
 
 # WARNING: This setting is used in database migrations to create a default organization.


### PR DESCRIPTION
#### What is this PR doing:
Several items in DAB have been going in assuming that we can generate a hash representing the user claims (user permissions), which for now are permissions limited to a certain set of roles --> audititor, org admin/member, team admin/member

We already have all those roles enabled here in galaxy_ng as managed roles... except for the organization admin/member. So for the claims hash comparison to work, we need to enable those roles.

#### Reviewers must know:
Related to https://github.com/ansible/django-ansible-base/pull/809 and its predecessor patches.
