### PR TITLE
fixes broken mkdocs builds

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,11 @@ plugins:
   - mkdocstrings:
       enable_inventory: true
       default_handler: python
+      import:
+        - url: https://docs.ansible.com/ansible/latest/objects.inv
+          domains: [py, std, "std:doc", "std:label"]
+        - url: https://pip.pypa.io/en/latest/objects.inv
+          domains: [py, std]
       handlers:
         python:
           paths: [src]
@@ -110,11 +115,6 @@ plugins:
             docstring_style: sphinx
             merge_init_into_class: yes
             show_submodules: yes
-          import:
-            - url: https://docs.ansible.com/ansible/latest/objects.inv
-              domains: [py, std, "std:doc", "std:label"]
-            - url: https://pip.pypa.io/en/latest/objects.inv
-              domains: [py, std]
   - minify:
       minify_html: true
 markdown_extensions:


### PR DESCRIPTION
#### What is this PR doing:

Doc builds fail with a type error. The fix is to move the import block from under handlers.python up to the top level of the mkdocstrings plugin config.

Issue: No-Issue

#### Reviewers must know:

Logs for failed build on read the docs: https://app.readthedocs.org/api/v2/build/32447562.txt
