### PR TITLE
Add list-all-users management command

### DIFF
--- a/galaxy_ng/app/management/commands/list-all-users.py
+++ b/galaxy_ng/app/management/commands/list-all-users.py
@@ -1,0 +1,22 @@
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    Django management command for listing all users
+    """
+
+    help = 'List all users in the system'
+
+    def handle(self, *args, **options):
+        User = get_user_model()
+        users = User.objects.all()
+
+        if not users:
+            self.stdout.write("No users found")
+            return
+
+        self.stdout.write(f"Found {users.count()} user(s):")
+        for user in users:
+            self.stdout.write(f"  - {user.username}")

--- a/galaxy_ng/tests/unit/app/management/commands/test_list_all_users.py
+++ b/galaxy_ng/tests/unit/app/management/commands/test_list_all_users.py
@@ -1,0 +1,40 @@
+from io import StringIO
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class TestListAllUsersCommand(TestCase):
+    def test_no_users(self):
+        """Test output when no users exist"""
+        out = StringIO()
+        call_command('list-all-users', stdout=out)
+        self.assertIn("No users found", out.getvalue())
+
+    def test_list_single_user(self):
+        """Test output with one user"""
+        User = get_user_model()
+        User.objects.create(username='testuser1')
+
+        out = StringIO()
+        call_command('list-all-users', stdout=out)
+        output = out.getvalue()
+
+        self.assertIn("Found 1 user(s):", output)
+        self.assertIn("testuser1", output)
+
+    def test_list_multiple_users(self):
+        """Test output with multiple users"""
+        User = get_user_model()
+        User.objects.create(username='alice')
+        User.objects.create(username='bob')
+        User.objects.create(username='charlie')
+
+        out = StringIO()
+        call_command('list-all-users', stdout=out)
+        output = out.getvalue()
+
+        self.assertIn("Found 3 user(s):", output)
+        self.assertIn("alice", output)
+        self.assertIn("bob", output)
+        self.assertIn("charlie", output)


### PR DESCRIPTION
## Summary
- Adds a `list-all-users` Django management command that lists all users in the system via `django-admin list-all-users`
- Includes unit tests covering: no users, single user, and multiple users

## Test plan
- [ ] Run `django-admin list-all-users` with no users and verify "No users found" output
- [ ] Create users and verify the command lists them all with a correct count
- [ ] Run unit tests: `pytest galaxy_ng/tests/unit/app/management/commands/test_list_all_users.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)