### PR TITLE
Make the Keycloak OIDC path prefix configurable

### DIFF
--- a/galaxy_ng/app/dynaconf_hooks.py
+++ b/galaxy_ng/app/dynaconf_hooks.py
@@ -355,6 +355,7 @@ def configure_keycloak(settings: Dynaconf) -> dict[str, Any]:
     KEYCLOAK_HOST = settings.get("KEYCLOAK_HOST", default=None)
     KEYCLOAK_PORT = settings.get("KEYCLOAK_PORT", default=None)
     KEYCLOAK_REALM = settings.get("KEYCLOAK_REALM", default=None)
+    KEYCLOAK_PATH_PREFIX = settings.get("KEYCLOAK_PATH_PREFIX", default="/auth")
 
     # Add settings if Social Auth values are provided
     if all(
@@ -379,21 +380,30 @@ def configure_keycloak(settings: Dynaconf) -> dict[str, Any]:
         )
         data["KEYCLOAK_HOST_LOOPBACK"] = settings.get("KEYCLOAK_HOST_LOOPBACK", default=None)
         data["KEYCLOAK_URL"] = f"{KEYCLOAK_PROTOCOL}://{KEYCLOAK_HOST}:{KEYCLOAK_PORT}"
-        auth_url_str = "{keycloak}/auth/realms/{realm}/protocol/openid-connect/auth/"
+        # Keycloak < 17 (WildFly) serves the OIDC endpoints under /auth, Keycloak 17+
+        # (Quarkus) serves them at the root unless KC_HTTP_RELATIVE_PATH is set.
+        # Normalize to either "" or "/<segments>" without a trailing slash.
+        data["KEYCLOAK_PATH_PREFIX"] = f"/{(KEYCLOAK_PATH_PREFIX or '').strip('/')}".rstrip("/")
+        auth_url_str = "{keycloak}{prefix}/realms/{realm}/protocol/openid-connect/auth/"
         data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] = auth_url_str.format(
-            keycloak=data["KEYCLOAK_URL"], realm=KEYCLOAK_REALM
+            keycloak=data["KEYCLOAK_URL"],
+            prefix=data["KEYCLOAK_PATH_PREFIX"],
+            realm=KEYCLOAK_REALM,
         )
         if data["KEYCLOAK_HOST_LOOPBACK"]:
             loopback_url = "{protocol}://{host}:{port}".format(
                 protocol=KEYCLOAK_PROTOCOL, host=data["KEYCLOAK_HOST_LOOPBACK"], port=KEYCLOAK_PORT
             )
             data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] = auth_url_str.format(
-                keycloak=loopback_url, realm=KEYCLOAK_REALM
+                keycloak=loopback_url,
+                prefix=data["KEYCLOAK_PATH_PREFIX"],
+                realm=KEYCLOAK_REALM,
             )
 
-        data[
-            "SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL"
-        ] = f"{data['KEYCLOAK_URL']}/auth/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token/"
+        data["SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL"] = (
+            f"{data['KEYCLOAK_URL']}{data['KEYCLOAK_PATH_PREFIX']}"
+            f"/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token/"
+        )
 
         data["SOCIAL_AUTH_LOGIN_REDIRECT_URL"] = settings.get(
             "SOCIAL_AUTH_LOGIN_REDIRECT_URL", default="/ui/"

--- a/galaxy_ng/tests/unit/app/test_dynaconf_hooks.py
+++ b/galaxy_ng/tests/unit/app/test_dynaconf_hooks.py
@@ -8,6 +8,7 @@ from django.core.exceptions import SuspiciousOperation
 from galaxy_ng.app.dynaconf_hooks import (
     post as post_hook,
     configure_cors,
+    configure_keycloak,
     configure_logging,
     configure_socialauth,
     configure_renderers,
@@ -169,6 +170,14 @@ BASE_SETTINGS = {
             {
                 "GALAXY_AUTH_KEYCLOAK_ENABLED": True,
                 "GALAXY_FEATURE_FLAGS__external_authentication": True,
+                # the legacy wildfly /auth prefix is the default ...
+                "KEYCLOAK_PATH_PREFIX": "/auth",
+                "SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL": (
+                    "http://cloak.com:8080/auth/realms/aap/protocol/openid-connect/auth/"
+                ),
+                "SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL": (
+                    "http://cloak.com:8080/auth/realms/aap/protocol/openid-connect/token/"
+                ),
                 "AUTHENTICATION_BACKENDS": [
                     "social_core.backends.keycloak.KeycloakOAuth2",
                     "dynaconf_merge",
@@ -338,6 +347,59 @@ BASE_SETTINGS = {
                 ],
             },
         ),
+        # 6 >=4.10 keycloak 17+ (quarkus) serves the endpoints at the root ...
+        (
+            True,
+            {
+                "AUTHENTICATION_BACKEND_PRESET": "keycloak",
+                "SOCIAL_AUTH_KEYCLOAK_KEY": "xyz",
+                "SOCIAL_AUTH_KEYCLOAK_SECRET": "abc",
+                "SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY": "1234",
+                "KEYCLOAK_PROTOCOL": "http",
+                "KEYCLOAK_HOST": "cloak.com",
+                "KEYCLOAK_PORT": 8080,
+                "KEYCLOAK_REALM": "aap",
+                "KEYCLOAK_PATH_PREFIX": "",
+            },
+            {
+                "GALAXY_AUTH_KEYCLOAK_ENABLED": True,
+                "KEYCLOAK_PATH_PREFIX": "",
+                "SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL": (
+                    "http://cloak.com:8080/realms/aap/protocol/openid-connect/auth/"
+                ),
+                "SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL": (
+                    "http://cloak.com:8080/realms/aap/protocol/openid-connect/token/"
+                ),
+            },
+        ),
+        # 7 >=4.10 keycloak loopback host with a custom path prefix ...
+        (
+            True,
+            {
+                "AUTHENTICATION_BACKEND_PRESET": "keycloak",
+                "SOCIAL_AUTH_KEYCLOAK_KEY": "xyz",
+                "SOCIAL_AUTH_KEYCLOAK_SECRET": "abc",
+                "SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY": "1234",
+                "KEYCLOAK_PROTOCOL": "http",
+                "KEYCLOAK_HOST": "cloak.com",
+                "KEYCLOAK_HOST_LOOPBACK": "localhost",
+                "KEYCLOAK_PORT": 8080,
+                "KEYCLOAK_REALM": "aap",
+                "KEYCLOAK_PATH_PREFIX": "sso",
+            },
+            {
+                "GALAXY_AUTH_KEYCLOAK_ENABLED": True,
+                "KEYCLOAK_PATH_PREFIX": "/sso",
+                "KEYCLOAK_URL": "http://cloak.com:8080",
+                # only the authorization url swaps in the loopback host ...
+                "SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL": (
+                    "http://localhost:8080/sso/realms/aap/protocol/openid-connect/auth/"
+                ),
+                "SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL": (
+                    "http://cloak.com:8080/sso/realms/aap/protocol/openid-connect/token/"
+                ),
+            },
+        ),
     ],
 )
 def test_dynaconf_hooks_authentication_backends_and_classes(
@@ -391,6 +453,73 @@ def test_dab_dynaconf():
     ]
     for key in expected_keys:
         assert key in new_settings
+
+
+class TestConfigureKeycloak:
+
+    BASE_KEYCLOAK_SETTINGS = {
+        "SOCIAL_AUTH_KEYCLOAK_KEY": "xyz",
+        "SOCIAL_AUTH_KEYCLOAK_SECRET": "abc",
+        "SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY": "1234",
+        "KEYCLOAK_PROTOCOL": "http",
+        "KEYCLOAK_HOST": "cloak.com",
+        "KEYCLOAK_PORT": 8080,
+        "KEYCLOAK_REALM": "aap",
+    }
+
+    def _configure(self, **extra_settings):
+        xsettings = SuperDict()
+        xsettings.update(copy.deepcopy(BASE_SETTINGS))
+        xsettings.update(copy.deepcopy(self.BASE_KEYCLOAK_SETTINGS))
+        xsettings.update(extra_settings)
+        return configure_keycloak(xsettings)
+
+    def test_path_prefix_defaults_to_legacy_auth(self):
+        data = self._configure()
+        assert data["KEYCLOAK_PATH_PREFIX"] == "/auth"
+        assert data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] == (
+            "http://cloak.com:8080/auth/realms/aap/protocol/openid-connect/auth/"
+        )
+        assert data["SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL"] == (
+            "http://cloak.com:8080/auth/realms/aap/protocol/openid-connect/token/"
+        )
+
+    @pytest.mark.parametrize(
+        ("prefix", "expected"),
+        [
+            ("/auth", "/auth"),
+            ("auth", "/auth"),
+            ("/auth/", "/auth"),
+            ("auth/", "/auth"),
+            ("", ""),
+            ("/", ""),
+            (None, ""),
+            ("/sso/auth/", "/sso/auth"),
+        ],
+    )
+    def test_path_prefix_normalization(self, prefix, expected):
+        data = self._configure(KEYCLOAK_PATH_PREFIX=prefix)
+        assert data["KEYCLOAK_PATH_PREFIX"] == expected
+        assert data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] == (
+            f"http://cloak.com:8080{expected}/realms/aap/protocol/openid-connect/auth/"
+        )
+        assert data["SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL"] == (
+            f"http://cloak.com:8080{expected}/realms/aap/protocol/openid-connect/token/"
+        )
+
+    def test_empty_path_prefix_does_not_disable_keycloak(self):
+        data = self._configure(KEYCLOAK_PATH_PREFIX="")
+        assert data["GALAXY_AUTH_KEYCLOAK_ENABLED"] is True
+
+    def test_path_prefix_applies_to_loopback_authorization_url(self):
+        data = self._configure(KEYCLOAK_HOST_LOOPBACK="localhost", KEYCLOAK_PATH_PREFIX="")
+        assert data["SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL"] == (
+            "http://localhost:8080/realms/aap/protocol/openid-connect/auth/"
+        )
+        # the token url keeps the non-loopback host ...
+        assert data["SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL"] == (
+            "http://cloak.com:8080/realms/aap/protocol/openid-connect/token/"
+        )
 
 
 class TestConfigureCors:


### PR DESCRIPTION
#### What is this PR doing:

 Currently the Keycloak OIDC URLs with `/auth` is hard coded. That path only exists on
  Keycloak 16 and older, which ran on WildFly — Keycloak 17 moved to Quarkus and serves
  everything from the root, so the endpoints sit at `/realms/...` unless you go out of your way
  to set `KC_HTTP_RELATIVE_PATH`. The practical effect is that galaxy_ng can't authenticate
  against any recent Keycloak version unless you reconfigure the Keycloak side
  to look like the old one.

  There's no way around it from the outside, either. Overriding the two
  `SOCIAL_AUTH_KEYCLOAK_*_URL` settings doesn't help, because the dynaconf `post` hook runs
  after `settings.py` and after the environment is read and simply overwrites them, and neither
  key is in `DYNAMIC_SETTINGS_SCHEMA`.

  So this adds a `KEYCLOAK_PATH_PREFIX` setting. It defaults to `"/auth"`, so nothing changes
  for anyone already running this. On a modern Keycloak you set it to `""` and the endpoints
  resolve where they actually live.

  Issue: No-Issue

  #### Reviewers must know:

  The value gets normalized on the way in, so `/auth`, `auth`, `/auth/` and `auth/` all mean the
  same thing, and `""` and `"/"` both mean no prefix. It applies to the authorization URL, the
  `KEYCLOAK_HOST_LOOPBACK` variant of it, and the access token URL.

  One decision worth a second look: I left it out of the `all([...])` check that gates the whole
  Keycloak block. An empty string is a legitimate value here, and including it there would
  silently switch Keycloak off for exactly the people this is meant to help.

  `dump-auth-config` didn't need touching — it reads the finished URLs, so it picks this up for
  free.

  On tests, the existing keycloak case now asserts the old `/auth/...` URLs outright, so if
  anyone breaks the default it fails loudly rather than quietly. On top of that there are cases
  for the empty prefix, for the loopback host with a custom prefix, and for the normalization
  variants.